### PR TITLE
feat(gateway): group affected sessions for verified recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1373,13 +1373,28 @@ else, and its context links must keep classifying across restarts).
   user's requested catalogue choice for later restarts, while `agentLaunchModel` and
   `agentLaunchContextWindow` record the exact model id and discovered window during initial command
   assembly and after an accepted relaunch. Context meters use that record for the label and
-  denominator while keeping the
-  transcript's token count; this avoids showing a replayed pre-switch model or window until the next
+  denominator while keeping the transcript's token count; this avoids showing a replayed pre-switch
+  model or window until the next
   assistant row arrives. Hand-launched and older sessions fall back to transcript metadata, with
   `core/model-window.ts` consulting `PtyManager`'s current scope-checked catalogue for discovered
   windows. Exact ids, optional `[1m]` spelling, and the final provider path segment match; a known
   family window remains the floor, and a settings or credential change immediately removes the old
   catalogue from consideration.
+  **Grouped gateway recovery.** A current non-empty catalogue can raise one dialog for idle,
+  resumable local sessions whose launched model disappeared, whose reported window changed, or
+  whose exact launch id would now assemble with different context settings. Candidate gates run for
+  both the active canvas and other open projects; legacy nodes retain a per-session first-observation
+  window ledger. Settings and boot discovery stay in the debounced prime effect. Window focus starts
+  exactly one refresh with the then-current settings, and only the current request's monotonic
+  `discoveryAt` completion triggers evaluation. Ready-empty, loading, and error catalogues cannot
+  judge and never start a recursive request. The dialog dismisses on confirmation and a persistent
+  strip shows each serialized restart as pending, running, successful, or failed. Failed rows keep
+  their refusal or verification reason, navigate to the session, and remain retryable until the user
+  retries or spends the ask. A `restarted` lifecycle result is successful only when the actual
+  `agentLaunchModel` and `agentLaunchContextWindow` written by TerminalNode satisfy the current
+  trigger and current ready catalogue. An uncured restart remains failed and unspent; Canvas never
+  overwrites that launch record with an expected value. Only a non-empty all-success batch
+  auto-dismisses, and its timer is scoped to that batch generation.
 - **Grok** (`@xai-official/grok` 1.0.0, builtin since 2026-08) — in `AGENT_HOOK_TARGETS`,
   `RESUMABLE_AGENTS`, `RENAME_CAPABLE`, `PERMISSION_MODE_CAPABLE`, `CANVAS_CONTROL_CAPABLE`,
   `CONTEXT_LINK_CAPABLE`, `CHAT_CAPABLE`, `TRANSFER_SOURCE_CAPABLE`, `USAGE_CAPABLE` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -687,20 +687,29 @@ Lifecycle, by intent:
   agent-restart.ts` restarts the agent CLI *inside* the pane and leaves the PTY, the tmux session
   and its scrollback untouched. It exists for **new-model pickup** — a freshly released model only
   shows up in a CLI's model list on a fresh launch, and doing that by hand means closing and
-  re-resuming every agent node on the canvas. Choreography: write the CLI's own exit line (`/exit`
-  for claude, `/quit` for codex — that table is also the gate, an agent not in it can never be
-  restarted in place), poll `pty:pane-command` (`#{pane_current_command}`, local tmux socket or the
-  project's SSH ControlMaster; any failure reads as "not a shell yet") every `RESTART_POLL_MS`
-  (250 ms) until a SHELL owns the pane, then echo-deliver `resumeCommand(...)` — the same
-  `claude --resume` / `codex resume` the cold restore uses. **Nothing is ever killed**: if the CLI
-  has not quit within `RESTART_EXIT_TIMEOUT_MS` (6 s) the run reports `exit-timeout` and leaves the
-  session running. A `working` **or `blocked`** session is refused — `/exit` typed into a
-  permission prompt would ANSWER it, not quit — and a node is held one-restart-at-a-time until the
-  resume line has actually LEFT the pane (an un-submitted line is where a second `/exit` would be
-  spliced in). The bulk action runs the same per-node closure sequentially over every idle agent
+  re-resuming every agent node on the canvas. Choreography: preflight `pty:pane-command`, then call
+  the ONE core stop mechanism, `pty.terminateForeground(nodeId, sourceAgentId)`: `paneOwner` proves
+  the expected harness from full argv, `agentPidIn` retains the exact PID that verdict rested on,
+  and the local/SSH kill leg re-proves that PID is still live in the foreground group immediately
+  before SIGTERM. **Nothing is typed into the pane.** The two PIDs are distinct facts: `PaneOwner.panePid` is the
+  long-lived login shell tmux spawned, while `agentPidIn(PaneOwner)` is the current harness PID;
+  the latter is re-read at the action boundary rather than persisted, because an exited process's
+  PID can be reused. If a successful kernel probe finds the expected agent absent, core returns
+  `already-exited`: local restart force-recycles the whole session without misidentifying its
+  current foreground owner as the agent, then cold restore resumes the conversation. An unreadable/unknown probe still
+  refuses (`lost-foreground`). Poll every `RESTART_POLL_MS` (250 ms) until a shell owns the
+  pane, then echo-deliver `resumeCommand(...)` — the same `claude --resume` / `codex resume` cold
+  restore uses. If the group does not release within `RESTART_EXIT_TIMEOUT_MS` (6 s), report
+  `exit-timeout` and do not resume. A `working` **or `blocked`** session is still refused by policy:
+  ordinary restart must not discard active work or a pending decision merely because the PID stop
+  is safe. The node is held one-restart-at-a-time until the resume line has actually LEFT the pane,
+  so a second restart cannot terminate the replacement or splice another launch line into it. The
+  bulk action runs the same per-node closure sequentially over every idle agent
   node in canvas order and reports one summary line. `performRestartResume` is now a COMPOSITION of
   `performExitPhase` + `performResumePhase` (2026-08-12, behavior-pinned split) — hibernation
-  drives the halves separately; each half refuses independently.
+  drives the halves separately; each half refuses independently. As of 2026-09-01 every production
+  caller, including Eco, supplies that same identity-gated terminator; `performExitPhase` has no
+  in-band exit-write path.
 - **Agent hibernation ("Eco", 2026-08-12, OPT-IN default off)** → `settings.agentHibernationEnabled`
   (+ `agentHibernationIdleMinutes`, default 30; Settings → Agents): a 60 s renderer sweep
   (`Canvas`) exits the CLI of up to **2** agent nodes per pass that are hook-idle in state `done`,
@@ -713,7 +722,7 @@ Lifecycle, by intent:
   share ONE `guardConcurrentRestart` set. Load-bearing rules a refactor must not undo:
   (1) **recurring fact is durable** — both loop-card dismiss surfaces route through
   `lib/loopCard.ts`, which HIDES a cron/schedule card but retains `agentStatus.loop`
-  (`dismissed: true`); clearing it would let Eco `/exit` a CLI whose cron wakeup lives in that
+  (`dismissed: true`); clearing it would let Eco terminate a CLI whose cron wakeup lives in that
   process. (2) **Fire-time re-asks**: still-offscreen, remote, eligibility — a plan-time verdict
   is stale by seconds. (3) `hibernated` **self-heals** on live hook states + SessionStart (never
   on `done` — a late Stop POST must not undo a just-performed hibernate); cold restore (`fresh`)
@@ -1330,10 +1339,12 @@ else, and its context links must keep classifying across restarts).
   capability (`MODEL_SWITCH_CAPABLE = claude/codex/copilot`) resolved through `capabilityAgentId`, so a
   custom agent with a supported `baseAgent` inherits it automatically — the settings UI and canvas
   menu carry no agent allowlist. A model switch SIGTERMs the pane's foreground non-shell process
-  group (never types `/exit`) and RECYCLES the tmux session before cold-resume: an existing shell may
+  group (never types `/exit`) and RECYCLES the tmux session before cold-resume. If the expected
+  agent is no longer in a successfully read foreground group, skip signalling and force this same
+  recycle path; unknown owner probes still refuse. An existing shell may
   predate the gateway setting, and tmux env changes do not retroactively change that shell's
   environment. Recreating it guarantees the current URL/key applies without typing a secret into
-  the pane. Ordinary Restart stays in-place. Custom-agent env is still merged last and may override
+  the pane. Ordinary Restart uses the same exact-PID stop but stays in-place. Custom-agent env is still merged last and may override
   the shared mapping. Desktop and Server Edition use the same core handler; relay tabs deliberately
   do not apply this machine's gateway to another core. Mobile needs a settings/model-picker surface
   before it can expose the feature.
@@ -1400,9 +1411,9 @@ else, and its context links must keep classifying across restarts).
     the read and write legs split. Its read path is the transcript the context tail already tracks
     (injected as `AgentSessionNameDeps.geminiPathFor`, held in a `let` in `src/main/index.ts` to avoid a
     TDZ throw that would kill a node's whole poll chain).
-  - **In-place restart** works for gemini: `EXIT_SEQUENCES.gemini = '/quit'` — and it must stay **bare**,
-    because `/quit --delete` exits *and permanently deletes* the session history, i.e. exactly what the
-    restart exists to resume (pinned by its own test).
+  - **In-place restart** works for gemini: `EXIT_SEQUENCES.gemini = '/quit'` remains the reviewed
+    support-table entry, but production restart never types it (or the history-destroying
+    `/quit --delete`); the shared exact-PID terminator stops Gemini out-of-band before resume.
   Full picture, measurements, gaps and a device checklist: **`docs/gemini-agent.md`**.
 - **Permission mode** (agents in `PERMISSION_MODE_CAPABLE` — claude, grok, **gemini**, **codex**) —
   the mode a session **starts** in (`claude --permission-mode <mode>`; Shift+Tab still cycles it at
@@ -2567,11 +2578,15 @@ principle. Per-agent write-ups: `docs/grok-agent.md`, `docs/gemini-agent.md`.
     returns `null` (the node keeps its own name); an unknown notification type is a no-op; a failed
     probe means the bare command, never a blocked launch. Say in the code which facts are *composed*
     rather than captured (gemini's resumed-transcript shape is) and what the wrong-guess cost is.
-15. **Kill the "in place" actions carefully.** An exit sequence must be the CLI's documented primary
-    and **bare**: gemini's `/quit` also takes `--delete`, which exits *and permanently deletes the
-    session history* — the very conversation the restart exists to resume. It has its own test.
-    Refuse the restart while the node is `working` **or** `blocked`: an exit line typed into a
-    permission prompt **answers** it.
+15. **Kill the "in place" actions carefully.** Never type a CLI exit sequence into a pane: a stale
+    node may now be a raw shell/editor, and Gemini's `/quit --delete` permanently deletes the very
+    history a restart exists to resume. Route every restart/Eco stop through
+    `performExitPhase` → identity-gated `terminateForeground`; re-prove the exact argv-verified PID
+    is live in the foreground group at the kill boundary. Track the pane login-shell PID separately
+    from the dynamically discovered agent PID. A successful probe with no expected agent takes the
+    force-respawn path without PID-targeting the replacement owner; an unknown probe refuses. Still
+    refuse ordinary restart while the
+    node is `working` or `blocked` — safe signalling is not permission to discard active work.
 16. **Write the device checklist for what you could not run.** Every unverified claim becomes a
     numbered item; group the ones that fall out of a single capture run. `docs/grok-agent.md` §9 and
     `docs/gemini-agent.md` §9 are the format.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1348,6 +1348,22 @@ else, and its context links must keep classifying across restarts).
   the shared mapping. Desktop and Server Edition use the same core handler; relay tabs deliberately
   do not apply this machine's gateway to another core. Mobile needs a settings/model-picker surface
   before it can expose the feature.
+  **Large-context Claude launches.** Model discovery retains a positive integer context window
+  from `context_length`, `max_context_length`, or `context_window`. For a claude-base agent,
+  `claudeAutocompactFor` appends `[1m]` to a discovered model above 200k and emits
+  `CLAUDE_CODE_AUTO_COMPACT_WINDOW` plus `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=80`; at or below the
+  threshold it strips a stale suffix and emits neither variable. The suffix and variables are one
+  result and must stay paired: the command assembler applies the model id, while `PtyManager`
+  injects the variables into the same local or staged remote spawn environment as the gateway
+  credentials. An unknown catalogue fails open to the unchanged id and no guessed window.
+  Successful core discovery publishes a single `{scope, models}` snapshot for spawning. The scope
+  is an opaque process-local digest of the normalized discovery route, public credential selector,
+  and exact resolved credential. `PtyManager` consumes it only while it still matches the current
+  settings and secret, so changing a discovery path, environment value, or stored key immediately
+  makes old context metadata ineligible. Renderer settings changes likewise clear the visible
+  catalogue before the debounced replacement request; replacing the stored key explicitly clears
+  it because the persisted secret sentinel itself does not change. Core accepts a discovery result
+  into launch state only when it is the latest request and still matches the saved configuration.
 - **Grok** (`@xai-official/grok` 1.0.0, builtin since 2026-08) — in `AGENT_HOOK_TARGETS`,
   `RESUMABLE_AGENTS`, `RENAME_CAPABLE`, `PERMISSION_MODE_CAPABLE`, `CANVAS_CONTROL_CAPABLE`,
   `CONTEXT_LINK_CAPABLE`, `CHAT_CAPABLE`, `TRANSFER_SOURCE_CAPABLE`, `USAGE_CAPABLE` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1369,6 +1369,17 @@ else, and its context links must keep classifying across restarts).
   first sorted discovered id. An empty catalogue emits nothing rather than guessing an id the key
   may not serve. This route is independent of the parent model's context window, and travels through
   the same local/tmux or staged remote environment path as the other gateway variables.
+  **Launch records keep context meters truthful across model switches.** `agentModel` persists the
+  user's requested catalogue choice for later restarts, while `agentLaunchModel` and
+  `agentLaunchContextWindow` record the exact model id and discovered window during initial command
+  assembly and after an accepted relaunch. Context meters use that record for the label and
+  denominator while keeping the
+  transcript's token count; this avoids showing a replayed pre-switch model or window until the next
+  assistant row arrives. Hand-launched and older sessions fall back to transcript metadata, with
+  `core/model-window.ts` consulting `PtyManager`'s current scope-checked catalogue for discovered
+  windows. Exact ids, optional `[1m]` spelling, and the final provider path segment match; a known
+  family window remains the floor, and a settings or credential change immediately removes the old
+  catalogue from consideration.
 - **Grok** (`@xai-official/grok` 1.0.0, builtin since 2026-08) — in `AGENT_HOOK_TARGETS`,
   `RESUMABLE_AGENTS`, `RENAME_CAPABLE`, `PERMISSION_MODE_CAPABLE`, `CANVAS_CONTROL_CAPABLE`,
   `CONTEXT_LINK_CAPABLE`, `CHAT_CAPABLE`, `TRANSFER_SOURCE_CAPABLE`, `USAGE_CAPABLE` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1364,6 +1364,11 @@ else, and its context links must keep classifying across restarts).
   catalogue before the debounced replacement request; replacing the stored key explicitly clears
   it because the persisted secret sentinel itself does not change. Core accepts a discovery result
   into launch state only when it is the latest request and still matches the saved configuration.
+  **Claude subagents use the same gateway catalogue.** A gateway-backed claude-base session sets
+  `CLAUDE_CODE_SUBAGENT_MODEL` to the configured default when that id is listed, otherwise to the
+  first sorted discovered id. An empty catalogue emits nothing rather than guessing an id the key
+  may not serve. This route is independent of the parent model's context window, and travels through
+  the same local/tmux or staged remote environment path as the other gateway variables.
 - **Grok** (`@xai-official/grok` 1.0.0, builtin since 2026-08) — in `AGENT_HOOK_TARGETS`,
   `RESUMABLE_AGENTS`, `RENAME_CAPABLE`, `PERMISSION_MODE_CAPABLE`, `CANVAS_CONTROL_CAPABLE`,
   `CONTEXT_LINK_CAPABLE`, `CHAT_CAPABLE`, `TRANSFER_SOURCE_CAPABLE`, `USAGE_CAPABLE` and

--- a/src/core/agent-env-ipc.test.ts
+++ b/src/core/agent-env-ipc.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { IPC } from '../shared/ipc'
 import {
+  type GatewayModel,
   MODEL_GATEWAY_SECRET_REF,
   type ModelGatewaySettings
 } from '../shared/agents/model-gateway'
 import { registerAgentEnvIpc } from './agent-env-ipc'
 import { ModelGatewayCredentialService } from './model-gateway-credentials'
+import type { ModelGatewayDiscoveryScope } from './model-gateway-scope'
 import { fakePlatform, type FakePlatform } from './platform-fake'
 import { initPlatform, resetPlatformForTests } from './platform'
 
@@ -16,6 +18,11 @@ describe('model gateway discovery API-key expansion', () => {
   let credentials: ModelGatewayCredentialService
   let storedKey: string | null
   let savedGateway: ModelGatewaySettings | undefined
+  let onDiscovered: ReturnType<
+    typeof vi.fn<
+      (scope: ModelGatewayDiscoveryScope, models: GatewayModel[]) => void
+    >
+  >
 
   beforeEach(async () => {
     inheritedKey = process.env.NODETERM_TEST_GATEWAY_KEY
@@ -41,7 +48,10 @@ describe('model gateway discovery API-key expansion', () => {
     })
     await credentials.init()
     savedGateway = undefined
-    registerAgentEnvIpc(() => savedGateway, credentials)
+    onDiscovered = vi.fn<
+      (scope: ModelGatewayDiscoveryScope, models: GatewayModel[]) => void
+    >()
+    registerAgentEnvIpc(() => savedGateway, credentials, onDiscovered)
   })
 
   afterEach(() => {
@@ -192,5 +202,90 @@ describe('model gateway discovery API-key expansion', () => {
         headers: expect.objectContaining({ Authorization: 'Bearer vk-typed-into-the-form' })
       })
     )
+    expect(onDiscovered).not.toHaveBeenCalled()
+  })
+
+  it('publishes a successful catalogue only for the still-current saved configuration', async () => {
+    savedGateway = { baseUrl: 'https://gateway.example.test', apiKey: 'key' }
+
+    await fake.handlers[IPC.agentDiscoverModels]({ ...savedGateway })
+
+    expect(onDiscovered).toHaveBeenCalledTimes(1)
+    expect(onDiscovered.mock.calls[0][1]).toEqual([
+      { id: 'openai/gpt-5.5', provider: 'openai' }
+    ])
+  })
+
+  it('drops a response when the effective discovery path changes while it is in flight', async () => {
+    let resolve!: (response: Response) => void
+    fetchMock.mockReturnValue(new Promise((done) => { resolve = done }))
+    savedGateway = { baseUrl: 'https://gateway.example.test', apiKey: 'key' }
+    const pending = fake.handlers[IPC.agentDiscoverModels]({ ...savedGateway })
+
+    savedGateway = { ...savedGateway, discoveryPath: '/openai/v1/models' }
+    resolve(new Response(JSON.stringify({ data: [{ id: 'old' }] }), { status: 200 }))
+    await pending
+
+    expect(onDiscovered).not.toHaveBeenCalled()
+  })
+
+  it('drops a response when an environment credential rotates while it is in flight', async () => {
+    let resolve!: (response: Response) => void
+    fetchMock.mockReturnValue(new Promise((done) => { resolve = done }))
+    process.env.NODETERM_TEST_GATEWAY_KEY = 'old'
+    savedGateway = {
+      baseUrl: 'https://gateway.example.test',
+      apiKey: '${env:NODETERM_TEST_GATEWAY_KEY}'
+    }
+    const pending = fake.handlers[IPC.agentDiscoverModels]({ ...savedGateway })
+
+    process.env.NODETERM_TEST_GATEWAY_KEY = 'new'
+    resolve(new Response(JSON.stringify({ data: [{ id: 'old' }] }), { status: 200 }))
+    await pending
+
+    expect(onDiscovered).not.toHaveBeenCalled()
+  })
+
+  it('drops a response when the stored credential rotates behind the sentinel', async () => {
+    await fake.handlers[IPC.agentGatewayCredentialSave]('old')
+    let resolve!: (response: Response) => void
+    fetchMock.mockReturnValue(new Promise((done) => { resolve = done }))
+    savedGateway = {
+      baseUrl: 'https://gateway.example.test',
+      apiKey: MODEL_GATEWAY_SECRET_REF
+    }
+    const pending = fake.handlers[IPC.agentDiscoverModels]({ ...savedGateway })
+
+    await fake.handlers[IPC.agentGatewayCredentialSave]('new')
+    resolve(new Response(JSON.stringify({ data: [{ id: 'old' }] }), { status: 200 }))
+    await pending
+
+    expect(onDiscovered).not.toHaveBeenCalled()
+  })
+
+  it('lets only the newest same-scope request publish when responses arrive out of order', async () => {
+    const resolves: Array<(response: Response) => void> = []
+    fetchMock.mockImplementation(() => new Promise<Response>((done) => resolves.push(done)))
+    savedGateway = { baseUrl: 'https://gateway.example.test', apiKey: 'key' }
+    const older = fake.handlers[IPC.agentDiscoverModels]({ ...savedGateway })
+    const newer = fake.handlers[IPC.agentDiscoverModels]({ ...savedGateway })
+
+    resolves[1](new Response(JSON.stringify({ data: [{ id: 'new' }] }), { status: 200 }))
+    await newer
+    resolves[0](new Response(JSON.stringify({ data: [{ id: 'old' }] }), { status: 200 }))
+    await older
+
+    expect(onDiscovered).toHaveBeenCalledTimes(1)
+    expect(onDiscovered.mock.calls[0][1]).toEqual([{ id: 'new' }])
+  })
+
+  it('publishes an empty successful catalogue to clear the matching snapshot', async () => {
+    savedGateway = { baseUrl: 'https://gateway.example.test', apiKey: 'key' }
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ data: [] }), { status: 200 }))
+
+    await fake.handlers[IPC.agentDiscoverModels]({ ...savedGateway })
+
+    expect(onDiscovered).toHaveBeenCalledTimes(1)
+    expect(onDiscovered.mock.calls[0][1]).toEqual([])
   })
 })

--- a/src/core/agent-env-ipc.ts
+++ b/src/core/agent-env-ipc.ts
@@ -28,7 +28,7 @@ async function discoverModels(
   saved: ModelGatewaySettings | undefined,
   storedSecret: string | null
 ): Promise<ModelDiscoveryResult> {
-  const routes = modelGatewayRoutes(settings?.baseUrl ?? '')
+  const routes = modelGatewayRoutes(settings?.baseUrl ?? '', settings?.discoveryPath)
   const apiKeyField = settings?.apiKey ?? ''
   // SECURITY GATE — this handler is reachable by relay peers and Server Edition WS clients, and
   // `settings` (URL included) is caller-supplied. `${secret:…}` / `${env:…}` references resolve
@@ -37,6 +37,11 @@ async function discoverModels(
   // your own host. References therefore resolve ONLY when the requested baseUrl is byte-identical
   // to the persisted gateway URL; a literal key pasted into the form is the caller's own and may
   // be tested against any URL (the pre-save "does this key work?" flow in Settings).
+  //
+  // The discovery PATH needs no such byte-identity gate: `modelGatewayRoutes` reduces it to a
+  // validated path SUFFIX on the same baseUrl, so a forged one cannot aim the request — or the
+  // resolved key — at a different host; worst case is a 404 on the saved gateway, surfaced as an
+  // ordinary discovery error.
   const isReference = apiKeyField.includes('${')
   const trusted = !!settings?.baseUrl && settings.baseUrl === saved?.baseUrl
   if (isReference && !trusted) {

--- a/src/core/agent-env-ipc.ts
+++ b/src/core/agent-env-ipc.ts
@@ -11,10 +11,16 @@ import {
   modelGatewayRoutes,
   parseGatewayModels,
   resolveModelGatewayApiKey,
+  type GatewayModel,
   type ModelDiscoveryResult,
   type ModelGatewaySettings
 } from '../shared/agents/model-gateway'
 import type { ModelGatewayCredentialService } from './model-gateway-credentials'
+import {
+  currentModelGatewayDiscoveryScope,
+  modelGatewayDiscoveryScope,
+  type ModelGatewayDiscoveryScope
+} from './model-gateway-scope'
 
 const DISCOVERY_TIMEOUT_MS = 10_000
 
@@ -26,7 +32,8 @@ const DISCOVERY_TIMEOUT_MS = 10_000
 async function discoverModels(
   settings: ModelGatewaySettings,
   saved: ModelGatewaySettings | undefined,
-  storedSecret: string | null
+  storedSecret: string | null,
+  onSuccessfulDiscovery?: (resolvedCredential: string, models: GatewayModel[]) => void
 ): Promise<ModelDiscoveryResult> {
   const routes = modelGatewayRoutes(settings?.baseUrl ?? '', settings?.discoveryPath)
   const apiKeyField = settings?.apiKey ?? ''
@@ -87,6 +94,7 @@ async function discoverModels(
       return { models: [], error: `Model discovery failed (HTTP ${response.status}).` }
     }
     const models = parseGatewayModels(await response.json())
+    onSuccessfulDiscovery?.(apiKey, models)
     return models.length
       ? { models }
       : { models: [], error: 'The gateway returned no usable models.' }
@@ -108,11 +116,34 @@ async function discoverModels(
  *  env key references for a caller-chosen URL (see the gate in `discoverModels`). */
 export function registerAgentEnvIpc(
   getSavedGateway: () => ModelGatewaySettings | undefined,
-  credentials?: ModelGatewayCredentialService
+  credentials?: ModelGatewayCredentialService,
+  onDiscovered?: (scope: ModelGatewayDiscoveryScope, models: GatewayModel[]) => void
 ): void {
-  platform().handle(IPC.agentDiscoverModels, (settings: ModelGatewaySettings) =>
-    discoverModels(settings, getSavedGateway(), credentials?.readForHost() ?? null)
-  )
+  // Latest invocation wins even when two requests for the same configuration resolve out of order.
+  // Increment before validation so a later invalid attempt also prevents an older fetch from
+  // repopulating launch state after the user has moved on.
+  let requestSeq = 0
+  platform().handle(IPC.agentDiscoverModels, (settings: ModelGatewaySettings) => {
+    const seq = ++requestSeq
+    return discoverModels(
+      settings,
+      getSavedGateway(),
+      credentials?.readForHost() ?? null,
+      (resolvedCredential, models) => {
+        if (!onDiscovered || seq !== requestSeq) return
+        const requestScope = modelGatewayDiscoveryScope(settings, resolvedCredential)
+        const current = getSavedGateway()
+        const currentScope = current
+          ? currentModelGatewayDiscoveryScope(
+              current,
+              credentials?.readForHost() ?? null,
+              process.env
+            )
+          : null
+        if (requestScope && requestScope === currentScope) onDiscovered(requestScope, models)
+      }
+    )
+  })
   platform().handle(IPC.agentGatewayCredentialStatus, () =>
     credentials?.status() ?? { hasStoredKey: false, storage: 'unavailable' as const }
   )

--- a/src/core/model-gateway-scope.test.ts
+++ b/src/core/model-gateway-scope.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  currentModelGatewayDiscoveryScope,
+  modelGatewayDiscoveryScope
+} from './model-gateway-scope'
+import { MODEL_GATEWAY_SECRET_REF } from '../shared/agents/model-gateway'
+
+describe('model gateway discovery scope', () => {
+  it('normalizes equivalent base URLs and conventional discovery paths', () => {
+    const a = modelGatewayDiscoveryScope(
+      { baseUrl: 'https://gateway.test/', apiKey: '${env:KEY}' },
+      'secret'
+    )
+    const b = modelGatewayDiscoveryScope(
+      {
+        baseUrl: 'https://gateway.test',
+        apiKey: '${env:KEY}',
+        discoveryPath: '/v1/models/'
+      },
+      'secret'
+    )
+    expect(a).not.toBeNull()
+    expect(a).toBe(b)
+  })
+
+  it('changes with the effective discovery path or resolved environment value', () => {
+    const settings = { baseUrl: 'https://gateway.test', apiKey: '${env:KEY}' }
+    const base = currentModelGatewayDiscoveryScope(settings, null, { KEY: 'one' })
+    expect(base).not.toBe(
+      currentModelGatewayDiscoveryScope(
+        { ...settings, discoveryPath: '/openai/v1/models' },
+        null,
+        { KEY: 'one' }
+      )
+    )
+    expect(base).not.toBe(currentModelGatewayDiscoveryScope(settings, null, { KEY: 'two' }))
+  })
+
+  it('changes when a stored secret rotates behind the unchanged sentinel', () => {
+    const settings = { baseUrl: 'https://gateway.test', apiKey: MODEL_GATEWAY_SECRET_REF }
+    expect(currentModelGatewayDiscoveryScope(settings, 'one')).not.toBe(
+      currentModelGatewayDiscoveryScope(settings, 'two')
+    )
+  })
+
+  it('distinguishes a literal probe from the saved sentinel even when values match', () => {
+    expect(
+      modelGatewayDiscoveryScope(
+        { baseUrl: 'https://gateway.test', apiKey: 'same-secret' },
+        'same-secret'
+      )
+    ).not.toBe(
+      modelGatewayDiscoveryScope(
+        { baseUrl: 'https://gateway.test', apiKey: MODEL_GATEWAY_SECRET_REF },
+        'same-secret'
+      )
+    )
+  })
+
+  it('returns null for invalid routes and unresolved credentials', () => {
+    expect(
+      currentModelGatewayDiscoveryScope(
+        { baseUrl: 'file:///tmp/gateway', apiKey: 'key' },
+        null
+      )
+    ).toBeNull()
+    expect(
+      currentModelGatewayDiscoveryScope(
+        { baseUrl: 'https://gateway.test', apiKey: '${env:MISSING}' },
+        null,
+        {}
+      )
+    ).toBeNull()
+    expect(
+      currentModelGatewayDiscoveryScope(
+        { baseUrl: 'https://gateway.test', apiKey: MODEL_GATEWAY_SECRET_REF },
+        null
+      )
+    ).toBeNull()
+  })
+})

--- a/src/core/model-gateway-scope.ts
+++ b/src/core/model-gateway-scope.ts
@@ -1,0 +1,46 @@
+import { createHmac, randomBytes } from 'node:crypto'
+import {
+  modelGatewayRoutes,
+  resolveModelGatewayApiKey,
+  type ModelGatewaySettings
+} from '../shared/agents/model-gateway'
+
+/**
+ * Process-local identity for the exact gateway catalogue that supplied launch metadata.
+ * The keyed digest is deliberately opaque: callers can compare scopes, but cannot recover or
+ * persist the credential material that made them distinct.
+ */
+export type ModelGatewayDiscoveryScope = string & {
+  readonly __modelGatewayDiscoveryScope: unique symbol
+}
+
+const scopeKey = randomBytes(32)
+
+/** Scope the exact resolved credential used for one request. */
+export function modelGatewayDiscoveryScope(
+  settings: ModelGatewaySettings,
+  resolvedCredential: string
+): ModelGatewayDiscoveryScope | null {
+  const routes = modelGatewayRoutes(settings?.baseUrl ?? '', settings?.discoveryPath)
+  const selector = settings?.apiKey?.trim() ?? ''
+  const credential = resolvedCredential.trim()
+  if (!routes || !selector || !credential) return null
+
+  // JSON supplies unambiguous tuple boundaries. The HMAC covers both the public selector and its
+  // resolved value: a literal pre-save probe cannot impersonate the saved secret sentinel, while a
+  // stored-key or environment-value rotation still invalidates an otherwise unchanged setting.
+  return createHmac('sha256', scopeKey)
+    .update(JSON.stringify([routes.discovery, selector, credential]))
+    .digest('base64url') as ModelGatewayDiscoveryScope
+}
+
+/** Scope the gateway configuration that is current in core at the instant this is called. */
+export function currentModelGatewayDiscoveryScope(
+  settings: ModelGatewaySettings,
+  storedSecret: string | null,
+  env: Record<string, string | undefined> = process.env
+): ModelGatewayDiscoveryScope | null {
+  const resolved = resolveModelGatewayApiKey(settings?.apiKey ?? '', env, storedSecret)
+  if (resolved.missing.length || resolved.storedSecretMissing) return null
+  return modelGatewayDiscoveryScope(settings, resolved.value)
+}

--- a/src/core/model-window.test.ts
+++ b/src/core/model-window.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  cachedWindowFor,
+  setGatewayModelWindowSource,
+  staticWindowFor
+} from './model-window'
+
+describe('model-window — current discovered-window authority', () => {
+  let models: Array<{ id: string; contextWindow?: number }>
+
+  beforeEach(() => {
+    models = []
+    setGatewayModelWindowSource(() => models)
+  })
+
+  afterEach(() => setGatewayModelWindowSource(null))
+
+  it('prefers a current discovered window over the unknown-family guess', () => {
+    models = [{ id: 'vllm/GLM-5.3-Flash-NVFP4', contextWindow: 400_000 }]
+    expect(cachedWindowFor('vllm/GLM-5.3-Flash-NVFP4')).toBe(400_000)
+  })
+
+  it('matches an omitted provider prefix and normalizes [1m] on both sides', () => {
+    models = [{ id: 'vllm/GLM-5.2-NVFP4-MTP[1m]', contextWindow: 400_000 }]
+    expect(cachedWindowFor('GLM-5.2-NVFP4-MTP')).toBe(400_000)
+    expect(cachedWindowFor('vllm/GLM-5.2-NVFP4-MTP[1m]')).toBe(400_000)
+  })
+
+  it('never shrinks a family-inferred window', () => {
+    models = [{ id: 'claude-sonnet-5', contextWindow: 200_000 }]
+    expect(cachedWindowFor('claude-sonnet-5')).toBe(1_000_000)
+  })
+
+  it('falls back immediately when the live provider changes scope or delists the id', () => {
+    models = [{ id: 'vllm/custom', contextWindow: 333_000 }]
+    expect(cachedWindowFor('vllm/custom')).toBe(333_000)
+    models = []
+    expect(cachedWindowFor('vllm/custom')).toBe(200_000)
+  })
+
+  it('treats a missing or throwing provider as an empty catalogue', () => {
+    setGatewayModelWindowSource(null)
+    expect(cachedWindowFor('vllm/custom')).toBe(200_000)
+    setGatewayModelWindowSource(() => {
+      throw new Error('scope unavailable')
+    })
+    expect(cachedWindowFor('vllm/custom')).toBe(200_000)
+  })
+
+  it('ignores invalid reported windows and leaves static family rules unchanged', () => {
+    models = [{ id: 'vllm/custom', contextWindow: Number.NaN }]
+    expect(cachedWindowFor('vllm/custom')).toBe(200_000)
+    expect(staticWindowFor('claude-haiku-4-5')).toBe(200_000)
+    expect(staticWindowFor('claude-opus-5')).toBe(1_000_000)
+    expect(staticWindowFor('unknown-thing')).toBe(200_000)
+  })
+})

--- a/src/core/model-window.ts
+++ b/src/core/model-window.ts
@@ -17,6 +17,55 @@ const STATIC: Array<[RegExp, number]> = [
   [/opus|sonnet|fable|mythos|(^|[^a-z0-9])1m([^a-z0-9]|$)/i, LARGE_WINDOW]
 ]
 
+export type GatewayModelWindowSource = () => readonly {
+  id: string
+  contextWindow?: number
+}[]
+
+/** Live source for the current gateway scope. PtyManager registers its already scope-checked
+ *  catalogue; keeping the source as a function makes a settings or credential change take effect
+ *  on the next lookup without a second cache or duplicated scope logic. */
+let gatewayModelWindowSource: GatewayModelWindowSource | null = null
+
+export function setGatewayModelWindowSource(source: GatewayModelWindowSource | null): void {
+  gatewayModelWindowSource = source
+}
+
+function gatewayModels(): ReturnType<GatewayModelWindowSource> {
+  try {
+    return gatewayModelWindowSource?.() ?? []
+  } catch {
+    return []
+  }
+}
+
+function gatewayWindowFor(model: string | null): number | undefined {
+  if (!model) return undefined
+  const base = model.trim().replace(/\[1m\]$/, '')
+  if (!base) return undefined
+  const models = gatewayModels()
+  // Exact ids first (the model argument is trimmed, so keep the raw compare too). Then the
+  // LAST `/` SEGMENT as a fallback — measured: transcripts written on a gateway session name
+  // `GLM-5.3-Flash-NVFP4` while the catalogue carries `vllm/GLM-5.3-Flash-NVFP4`, so an
+  // exact-only lookup missed exactly the models a gateway serves. Segment equality is still
+  // equality, not a guess.
+  for (const entry of models) {
+    const gid = entry.id.trim().replace(/\[1m\]$/, '')
+    const win = entry.contextWindow
+    if ((gid === base || entry.id === model) && validWindow(win)) return win
+  }
+  for (const entry of models) {
+    const gid = entry.id.trim().replace(/\[1m\]$/, '')
+    const win = entry.contextWindow
+    if (gid.split('/').pop() === base.split('/').pop() && validWindow(win)) return win
+  }
+  return undefined
+}
+
+function validWindow(value: number | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
 /** Context window for a model id: 1M for opus/sonnet/fable/[1m], 200k for haiku/unknown. */
 export function staticWindowFor(model: string | null): number {
   if (model) {
@@ -25,9 +74,28 @@ export function staticWindowFor(model: string | null): number {
   return DEFAULT_WINDOW
 }
 
-/** Synchronous best guess for the model's window (no cache/network needed). */
+/**
+ * Synchronous best guess for the model's window — the LARGER of the discovered window (when
+ * this core has been told one) and the family inference. MAX, not "discovered wins": a proxy
+ * cataloguing an Anthropic model through the OpenAI convention often reports the
+ * capability-API 200k for a 1M-eligible model, and the family rule exists precisely because
+ * the id alone cannot witness that. The meter's job is the true denominator; taking the
+ * larger never SHRINKS a number either source asserts, and a truth below the guess only
+ * under-reports fill (conservative), never over-reports it. The autocompact env does not
+ * flow through here — it reads the catalogue directly (`gatewayModelsForCurrent`), so this
+ * rule never widens what the CLI compacts against.
+ */
 export function cachedWindowFor(model: string | null): number {
-  return staticWindowFor(model)
+  const discovered = gatewayWindowFor(model)
+  // When discovery MATCHES the id, compute the family floor on the SUFFIX-STRIPPED base: the
+  // `[1m]` marker is how a launcher advertises a large window, and the discovered record is a
+  // better witness than that marker — escalation from it would disagree with the
+  // CLAUDE_CODE_AUTO_COMPACT_WINDOW the CLI actually compacts against. Stripping only under a
+  // known record preserves the never-shrink rule (an Anthropic id catalogued at 200k still
+  // floors at its family 1M) while dropping the marker's escalation. WITHOUT a matching
+  // record the raw id feeds the family table unchanged.
+  const family = staticWindowFor(discovered !== undefined && model ? model.replace(/\[1m\]$/, '') : model)
+  return discovered !== undefined ? Math.max(discovered, family) : family
 }
 
 // ---------------------------------------------------------------------------------------------

--- a/src/core/pty-manager-platform.test.ts
+++ b/src/core/pty-manager-platform.test.ts
@@ -22,7 +22,8 @@ describe('PtyManager platform registration', () => {
       IPC.ptyKill,
       IPC.ptyDestroy,
       IPC.ptySendText,
-      IPC.ptyReadScrollback
+      IPC.ptyReadScrollback,
+      IPC.ptyAgentProcess
     ]) {
       // ptyKill is sender-aware (co-attach: unsubscribe ONE client) → senderListeners.
       expect(fake.handlers[ch] ?? fake.listeners[ch] ?? fake.senderListeners[ch], ch).toBeDefined()

--- a/src/core/pty-manager.pane-owner.test.ts
+++ b/src/core/pty-manager.pane-owner.test.ts
@@ -11,6 +11,7 @@ import { fakePlatform } from './platform-fake'
 import { TMUX_SOCKET, sessionName } from './tmux-naming'
 import { PANE_OWNER_FMT } from './agents/pane-owner'
 import { RMT_TMUX_SOCKET } from './remote-ssh/control-master'
+import type { AgentProcessProof, TerminateForegroundOutcome } from '../shared/types'
 
 /** Every `runAsync` in pty-manager lands here. `answer` decides what each call resolves to. */
 const calls: Array<{ file: string; args: string[] }> = []
@@ -252,7 +253,8 @@ async function killManager(opts: { customAgents?: unknown[] } = {}) {
     tmuxPath: string | null
     sessions: Map<string, unknown>
     getSettings: () => unknown
-    terminateForeground(k: string, expected?: string): Promise<boolean>
+    terminateForeground(k: string, expected?: string): Promise<TerminateForegroundOutcome>
+    agentProcess(k: string, expected: string): Promise<AgentProcessProof>
   }
   mgr.tmuxPath = '/usr/bin/tmux'
   mgr.sessions.set('sess-1', { persistKey: NODE, sshRemote: undefined })
@@ -297,11 +299,72 @@ describe('PtyManager.terminateForeground — identity gate', () => {
   it('KILLS the foreground group when the expected agent owns it', async () => {
     script.answer = claudeForeground
     const mgr = await killManager()
-    expect(await mgr.terminateForeground(NODE, 'claude')).toBe(true)
+    expect(await mgr.terminateForeground(NODE, 'claude')).toBe('terminated')
     expect(killed).toEqual([-2503294]) // SIGTERM to the negative process group
   })
 
-  it('REFUSES (no kill) when the pane belongs to a different program than expected', async () => {
+  it('reports already-exited when the original pane shell owns the foreground', async () => {
+    script.answer = (file, args) => {
+      if (args.includes(PANE_OWNER_FMT)) return { stdout: `2485382|${TTY}|-zsh|%3\n` }
+      if (file === 'ps') return { stdout: '2485382 2485382 Ss+  -zsh' }
+      return { stdout: '' }
+    }
+    const mgr = await killManager()
+    expect(await mgr.terminateForeground(NODE, 'claude')).toBe('already-exited')
+    expect(killed).toEqual([])
+  })
+
+  it('forces respawn when a nested shell replaced the expected agent', async () => {
+    script.answer = (file, args) => {
+      if (args.includes(PANE_OWNER_FMT)) return { stdout: `2485382|${TTY}|bash|%3\n` }
+      if (file === 'ps') return { stdout: '2503294 2503294 S+   bash ./long-running-script.sh' }
+      return { stdout: '' }
+    }
+    const mgr = await killManager()
+    expect(await mgr.terminateForeground(NODE, 'claude')).toBe('already-exited')
+    expect(killed).toEqual([])
+  })
+
+  it('REFUSES when the argv-verified agent PID exited before the kill boundary', async () => {
+    script.answer = (file, args) => {
+      // paneOwner identified PID 2503294 as Claude, but its liveness/tpgid re-check is now empty:
+      // the agent exited and whatever owns the pane next must not inherit its kill authorization.
+      if (args.includes('tpgid=') && args.at(-1) === '2503294') return { stdout: '' }
+      return claudeForeground(file, args)
+    }
+    const mgr = await killManager()
+    expect(await mgr.terminateForeground(NODE, 'claude')).toBe('refused')
+    expect(killed).toEqual([])
+  })
+
+  it('recovers when the verified agent exits at the kill boundary and the login shell takes over', async () => {
+    let ownerReads = 0
+    script.answer = (file, args) => {
+      if (args.includes(PANE_OWNER_FMT)) {
+        ownerReads++
+        return {
+          stdout:
+            ownerReads === 1
+              ? `2485382|${TTY}|node|%3\n`
+              : `2485382|${TTY}|-zsh|%3\n`
+        }
+      }
+      if (args.includes('tpgid=')) {
+        return { stdout: args.at(-1) === '2503294' ? '' : '2503294' }
+      }
+      if (file === 'ps') {
+        return {
+          stdout: ownerReads === 1 ? PS_OUT : '2485382 2485382 Ss+  -zsh'
+        }
+      }
+      return { stdout: '' }
+    }
+    const mgr = await killManager()
+    expect(await mgr.terminateForeground(NODE, 'claude')).toBe('already-exited')
+    expect(killed).toEqual([])
+  })
+
+  it('forces respawn without signalling when a different program replaced the expected agent', async () => {
     // Foreground group is vim, not the agent.
     script.answer = (file, args) => {
       if (args.includes(PANE_OWNER_FMT)) return { stdout: `2485382|${TTY}|vim|%3\n` }
@@ -312,7 +375,7 @@ describe('PtyManager.terminateForeground — identity gate', () => {
       return { stdout: '' }
     }
     const mgr = await killManager()
-    expect(await mgr.terminateForeground(NODE, 'claude')).toBe(false)
+    expect(await mgr.terminateForeground(NODE, 'claude')).toBe('already-exited')
     expect(killed).toEqual([])
   })
 
@@ -320,7 +383,7 @@ describe('PtyManager.terminateForeground — identity gate', () => {
     script.answer = (file, args) =>
       args.includes(PANE_OWNER_FMT) ? { stdout: `2485382|${TTY}|node\n` } : { stdout: '' } // ps empty ⇒ null owner
     const mgr = await killManager()
-    expect(await mgr.terminateForeground(NODE, 'claude')).toBe(false)
+    expect(await mgr.terminateForeground(NODE, 'claude')).toBe('refused')
     expect(killed).toEqual([])
   })
 
@@ -336,15 +399,57 @@ describe('PtyManager.terminateForeground — identity gate', () => {
     const mgr = await killManager({
       customAgents: [{ id: 'custom:x', label: 'Aider', launchCmd: 'aider' }]
     })
-    expect(await mgr.terminateForeground(NODE, 'custom:x')).toBe(true)
+    expect(await mgr.terminateForeground(NODE, 'custom:x')).toBe('terminated')
     expect(killed).toEqual([-2503294])
+  })
+
+  it('proves the exact expected agent is running without signalling it', async () => {
+    script.answer = claudeForeground
+    const mgr = await killManager()
+
+    expect(await mgr.agentProcess(NODE, 'claude')).toEqual({
+      verdict: 'agent',
+      shellPid: 2485382,
+      agentPid: 2503294
+    })
+    expect(killed).toEqual([])
+    expect(calls).toHaveLength(2)
+  })
+
+  it('reports a successful owner mismatch when the launched agent already exited', async () => {
+    script.answer = (file, args) => {
+      if (args.includes(PANE_OWNER_FMT)) return { stdout: `2485382|${TTY}|-zsh|%3\n` }
+      if (file === 'ps') return { stdout: '2485382 2485382 Ss+  -zsh' }
+      return { stdout: '' }
+    }
+    const mgr = await killManager()
+
+    expect(await mgr.agentProcess(NODE, 'claude')).toEqual({
+      verdict: 'not-agent',
+      shellPid: 2485382,
+      agentPid: undefined
+    })
+    expect(killed).toEqual([])
+  })
+
+  it('reports unknown when the post-launch owner cannot be read', async () => {
+    script.answer = (file, args) =>
+      args.includes(PANE_OWNER_FMT) ? { stdout: `2485382|${TTY}|node\n` } : { stdout: '' }
+    const mgr = await killManager()
+
+    expect(await mgr.agentProcess(NODE, 'claude')).toEqual({
+      verdict: 'unknown',
+      shellPid: undefined,
+      agentPid: undefined
+    })
+    expect(killed).toEqual([])
   })
 
   it('with no expected id, keeps the legacy shell-only guard (kills a non-shell foreground)', async () => {
     script.answer = claudeForeground
     const mgr = await killManager()
     // No identity read happens (no PANE_OWNER_FMT call) — only the tpgid path.
-    expect(await mgr.terminateForeground(NODE)).toBe(true)
+    expect(await mgr.terminateForeground(NODE)).toBe('terminated')
     expect(killed).toEqual([-2503294])
     expect(calls.some((c) => c.args.includes(PANE_OWNER_FMT))).toBe(false)
   })

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -2768,14 +2768,20 @@ export class PtyManager {
     // historical Claude fallback does not apply here: gateway access is an explicit agent
     // capability, not a terminal default.
     //
-    // "Restart on subscription" / `vanillaLaunchDefault`: strip the gateway + inherited provider env
+    // "Restart on subscription" / launch mode: strip the gateway + inherited provider env
     // so the agent runs against its OWN default provider (Claude's subscription, Copilot's GitHub
-    // routing). `vanillaEnvStripPattern` resolves through the base harness; null ⇒ the agent has no
-    // strip set ⇒ no-op (gemini/grok/opencode are left alone). `buildPtyEnv` runs only in `spawnNew`
-    // (a fresh session), never on a warm reattach, so toggling the setting never strips an
-    // already-running session — only the next fresh launch.
+    // routing). `vanillaEnvStripPattern` resolves through the base harness (`capabilityAgentId` of
+    // the agent id, so a custom agent inheriting a builtin gets the builtin's strip set); null ⇒ the
+    // agent has no strip set ⇒ no-op (gemini/grok/opencode are left alone). `buildPtyEnv` runs only
+    // in `spawnNew` (a fresh session), never on a warm reattach, so toggling the setting never strips
+    // an already-running session — only the next fresh launch.
+    // The launch mode is a tri-state (`agentLaunchMode`); a per-node one-shot `clearEnv` (the
+    // "Restart on subscription" action) forces the subscription/vanilla path for THIS spawn. The
+    // old boolean `vanillaLaunchDefault` is now a migration mirror kept in lockstep with the mode
+    // by the settings read/write paths, so reading the mode here is sufficient.
+    const launchMode = options.clearEnv ? 'subscription' : this.getSettings().agentLaunchMode
     const stripRe =
-      options.clearEnv || this.getSettings().vanillaLaunchDefault
+      launchMode === 'subscription'
         ? options.agentId
           ? vanillaEnvStripPattern(options.agentId)
           : null

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -139,6 +139,7 @@ import {
 import { foregroundProcessGroup, parsePaneProcess } from './pane-process'
 import { isShellCommand } from '../shared/agents/pane'
 import { modelRespawnErrorKind, modelRespawnTrace } from '../shared/model-respawn-trace'
+import { setGatewayModelWindowSource } from './model-window'
 // Third persistence backend, selected when no local tmux was found (primarily Windows, where
 // tmux does not exist at all) — see docs/windows-session-host.md. Deliberately a thin, separate
 // module rather than inline here: this is the one narrow seam this file needed to grow for a
@@ -1503,6 +1504,7 @@ export class PtyManager {
   ): void {
     this.getSettings = getSettings
     this.getModelGatewaySecret = getModelGatewaySecret
+    setGatewayModelWindowSource(() => this.gatewayModelsForCurrent())
     // Register the custom-id → baseAgent resolver so the capability predicates in
     // shared/agents/config (hasHooks, canResume, mintsSessionId, hasPermissionMode,
     // canControlCanvas, …) resolve a custom agent's INHERITED harness. config.ts takes only an id

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -2776,7 +2776,9 @@ export class PtyManager {
     // already-running session — only the next fresh launch.
     const stripRe =
       options.clearEnv || this.getSettings().vanillaLaunchDefault
-        ? vanillaEnvStripPattern((options.agentId ?? 'claude') as AgentId)
+        ? options.agentId
+          ? vanillaEnvStripPattern(options.agentId)
+          : null
         : null
     const gatewayEnv =
       options.agentId && !stripRe

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -99,7 +99,7 @@ import {
 } from './codex-identity-proxy'
 import { ensureNodeToken, ensureRemoteNodeToken, sweepNodeToken } from './agents/node-token-service'
 import { clearNode as clearNodeAgentStatus } from './agent-status-mirror'
-import { hasSharedIdentity, setCustomAgentBaseResolver, type AgentId } from '../shared/agents/config'
+import { hasSharedIdentity, setCustomAgentBaseResolver, vanillaEnvStripPattern, type AgentId } from '../shared/agents/config'
 import { findCustomAgent } from '../shared/agents/custom-agent'
 import { applyCustomAgentEnv, customAgentEnvArgs } from './custom-agent-env'
 import {
@@ -2767,17 +2767,34 @@ export class PtyManager {
     // A plain terminal has no agentId and must never receive provider credentials. The hook env's
     // historical Claude fallback does not apply here: gateway access is an explicit agent
     // capability, not a terminal default.
-    const gatewayEnv = options.agentId
-      ? modelGatewayEnv(
-          this.getSettings().modelGateway,
-          options.agentId,
-          options.agentModel,
-          process.env as Record<string, string | undefined>,
-          this.getModelGatewaySecret()
-        )
-      : {}
+    //
+    // "Restart on subscription" / `vanillaLaunchDefault`: strip the gateway + inherited provider env
+    // so the agent runs against its OWN default provider (Claude's subscription, Copilot's GitHub
+    // routing). `vanillaEnvStripPattern` resolves through the base harness; null ⇒ the agent has no
+    // strip set ⇒ no-op (gemini/grok/opencode are left alone). `buildPtyEnv` runs only in `spawnNew`
+    // (a fresh session), never on a warm reattach, so toggling the setting never strips an
+    // already-running session — only the next fresh launch.
+    const stripRe =
+      options.clearEnv || this.getSettings().vanillaLaunchDefault
+        ? vanillaEnvStripPattern((options.agentId ?? 'claude') as AgentId)
+        : null
+    const gatewayEnv =
+      options.agentId && !stripRe
+        ? modelGatewayEnv(
+            this.getSettings().modelGateway,
+            options.agentId,
+            options.agentModel,
+            process.env as Record<string, string | undefined>,
+            this.getModelGatewaySecret()
+          )
+        : {}
     if (!options.sshRemote) {
       for (const [k, v] of Object.entries(gatewayEnv)) env[k] = v
+      // Strip inherited provider vars so a vanilla session does not fall back to a LaunchAgent-set
+      // ANTHROPIC_BASE_URL instead of the subscription. Local only — see the note above.
+      if (stripRe) {
+        for (const k of Object.keys(env)) if (stripRe.test(k)) delete env[k]
+      }
     }
 
     // The OWNING project's env (`.nodeterm/settings.json`, local overlay + TRUSTED shared half —

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -106,14 +106,27 @@ import {
 } from './codex-identity-proxy'
 import { ensureNodeToken, ensureRemoteNodeToken, sweepNodeToken } from './agents/node-token-service'
 import { clearNode as clearNodeAgentStatus } from './agent-status-mirror'
-import { hasSharedIdentity, setCustomAgentBaseResolver, vanillaEnvStripPattern, type AgentId } from '../shared/agents/config'
+import {
+  capabilityAgentId,
+  hasSharedIdentity,
+  setCustomAgentBaseResolver,
+  vanillaEnvStripPattern,
+  type AgentId
+} from '../shared/agents/config'
 import { findCustomAgent } from '../shared/agents/custom-agent'
 import { applyCustomAgentEnv, customAgentEnvArgs } from './custom-agent-env'
 import {
+  AUTOCOMPACT_ENV_KEYS,
   MODEL_GATEWAY_ENV_KEYS,
+  claudeAutocompactFor,
   modelGatewayEnv,
-  tmuxUpdateEnvironmentLine
+  tmuxUpdateEnvironmentLine,
+  type GatewayModel
 } from '../shared/agents/model-gateway'
+import {
+  currentModelGatewayDiscoveryScope,
+  type ModelGatewayDiscoveryScope
+} from './model-gateway-scope'
 import { leadPaneHookLines } from '../shared/tmux-lead-pane'
 import {
   remoteSessionEnvAvailable,
@@ -928,6 +941,11 @@ export class PtyManager {
   private readProjectSpawnOverrides: ProjectSpawnOverridesReader | null = null
   /** "Which SSH host owns this node?", from the persisted index — see `setRemoteNodeOwner`. */
   private remoteNodeOwner: RemoteNodeOwnerResolver | null = null
+  /** Latest successfully discovered catalogue and the exact route/credential scope that produced it. */
+  private gatewayModelSnapshot: {
+    scope: ModelGatewayDiscoveryScope
+    models: GatewayModel[]
+  } | null = null
   /** ONE shared snapshot interval for all persisted sessions — a per-session interval spawned
    *  one tmux/ssh capture subprocess per session per tick, forever, even for idle terminals. */
   private snapshotTimer: ReturnType<typeof setInterval> | null = null
@@ -1602,6 +1620,24 @@ export class PtyManager {
    *  conf-baked set), so a custom agent's spawn costs at most one `set-option` per NEW key. */
   private updateEnvKeys: Set<string> | null = null
 
+  /** Replace the discovered catalogue snapshot. Empty success deliberately clears old models. */
+  setGatewayModels(scope: ModelGatewayDiscoveryScope, models: GatewayModel[]): void {
+    this.gatewayModelSnapshot = { scope, models: [...models] }
+  }
+
+  /** Models from the exact gateway configuration and resolved credential that are current now. */
+  private gatewayModelsForCurrent(): GatewayModel[] {
+    const settings = this.getSettings().modelGateway
+    const scope = currentModelGatewayDiscoveryScope(
+      settings,
+      this.getModelGatewaySecret(),
+      process.env
+    )
+    return scope && this.gatewayModelSnapshot?.scope === scope
+      ? this.gatewayModelSnapshot.models
+      : []
+  }
+
   /** Make the shared tmux server copy these client-env names into new sessions. The conf bakes
    *  the fixed gateway list; a CUSTOM agent's env keys are user-defined and can only be appended
    *  at runtime. Names ride the `set-option` argv — names only, values never (values reach tmux
@@ -1616,7 +1652,7 @@ export class PtyManager {
     )
     if (!wanted.length) return
     if (!this.updateEnvKeys) {
-      this.updateEnvKeys = new Set(MODEL_GATEWAY_ENV_KEYS)
+      this.updateEnvKeys = new Set([...MODEL_GATEWAY_ENV_KEYS, ...AUTOCOMPACT_ENV_KEYS])
       try {
         const out = execFileSync(
           this.tmuxPath,
@@ -2820,8 +2856,19 @@ export class PtyManager {
             this.getModelGatewaySecret()
           )
         : {}
+    const gatewayModels = this.gatewayModelsForCurrent()
+    const autocompact =
+      !stripRe && options.agentId
+        ? claudeAutocompactFor(
+            capabilityAgentId(options.agentId as AgentId),
+            options.agentModel,
+            gatewayModels
+          )
+        : { modelId: undefined, env: {} }
+    const autocompactEnv = autocompact.env
     if (!options.sshRemote) {
       for (const [k, v] of Object.entries(gatewayEnv)) env[k] = v
+      for (const [k, v] of Object.entries(autocompactEnv)) env[k] = v
       // Strip inherited provider vars so a vanilla session does not fall back to a LaunchAgent-set
       // ANTHROPIC_BASE_URL instead of the subscription. Local only — see the note above.
       if (stripRe) {
@@ -2864,6 +2911,23 @@ export class PtyManager {
       for (const [k, v] of Object.entries(merged.env)) env[k] = v
       for (const w of merged.warnings) console.warn(w)
       customEnvMerged = merged.env
+    }
+
+    // The model marker and the compaction window are one mechanism. A known catalogue must never
+    // produce only one half; an empty cache at cold boot remains fail-open so persisted suffixed
+    // sessions can mount while the first discovery request is still in flight.
+    const envHasWindow = 'CLAUDE_CODE_AUTO_COMPACT_WINDOW' in autocompactEnv
+    if (autocompact.modelId?.endsWith('[1m]') && !envHasWindow && gatewayModels.length) {
+      throw new Error(
+        `Session ${options.persistKey} refuses to spawn: model '${options.agentModel}' assembled to ` +
+          `${autocompact.modelId} without CLAUDE_CODE_AUTO_COMPACT_WINDOW.`
+      )
+    }
+    if (envHasWindow && autocompact.modelId && !autocompact.modelId.endsWith('[1m]')) {
+      throw new Error(
+        `Session ${options.persistKey} refuses to spawn: CLAUDE_CODE_AUTO_COMPACT_WINDOW was set ` +
+          `for an unsuffixed model '${autocompact.modelId}'.`
+      )
     }
 
     const settings = this.getSettings()
@@ -2983,7 +3047,11 @@ export class PtyManager {
       // not delivered and the agent fails loudly in its pane (fail-open, never a fallback to argv).
       // The project's env joins that same 0600 file — same reason, same ordering as the local leg
       // (gateway, then project, then the custom agent's own values on top).
-      const remoteEnvPairs: Record<string, string> = { ...gatewayEnv, ...(projectEnv ?? {}) }
+      const remoteEnvPairs: Record<string, string> = {
+        ...gatewayEnv,
+        ...autocompactEnv,
+        ...(projectEnv ?? {})
+      }
       for (const kv of remoteCustomEnv.args) {
         const eq = kv.indexOf('=')
         if (eq > 0) remoteEnvPairs[kv.slice(0, eq)] = kv.slice(eq + 1)
@@ -3003,7 +3071,7 @@ export class PtyManager {
           envFile,
           sessionEnvFileContent(remoteEnvPairs)
         )
-        const baked = new Set<string>(MODEL_GATEWAY_ENV_KEYS)
+        const baked = new Set<string>([...MODEL_GATEWAY_ENV_KEYS, ...AUTOCOMPACT_ENV_KEYS])
         remoteSessionEnv = {
           file: envFile,
           extraKeys: Object.keys(remoteEnvPairs).filter((k) => !baked.has(k))

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -10,11 +10,13 @@ import { safeSessionProgram } from '../shared/node-exec'
 import { REF_MAX_LEN } from '../shared/presence'
 import {
   DEFAULT_SETTINGS,
+  type AgentProcessProof,
   type PaneCursor,
   type PtyCreateOptions,
   type PtyCreateResult,
   type PtyRecycleTarget,
   type Settings,
+  type TerminateForegroundOutcome,
   type TmuxStatus
 } from '../shared/types'
 import { bundledTmuxPath, findCommand, findFixedTmux, tmuxInstall } from './tmux-hint'
@@ -51,7 +53,12 @@ import {
   shouldRecordOwnership
 } from './agents/pane-ownership'
 import { PANE_OWNER_FMT, foregroundArgvArgs, paneOwnerFrom, parseCombinedPaneOwner, parsePaneOwner } from './agents/pane-owner'
-import { binariesFor, isAgentPane, type PaneOwner } from '../shared/agents/pane-owner-predicate'
+import {
+  agentPidIn,
+  binariesFor,
+  isAgentPane,
+  type PaneOwner
+} from '../shared/agents/pane-owner-predicate'
 import { readSpawnResources, spawnResourceNote } from './spawn-resources'
 import {
   primePtyCeiling,
@@ -116,6 +123,7 @@ import {
 } from './remote-ssh/session-env'
 import { foregroundProcessGroup, parsePaneProcess } from './pane-process'
 import { isShellCommand } from '../shared/agents/pane'
+import { modelRespawnErrorKind, modelRespawnTrace } from '../shared/model-respawn-trace'
 // Third persistence backend, selected when no local tmux was found (primarily Windows, where
 // tmux does not exist at all) — see docs/windows-session-host.md. Deliberately a thin, separate
 // module rather than inline here: this is the one narrow seam this file needed to grow for a
@@ -1753,6 +1761,9 @@ export class PtyManager {
     platform().handle(IPC.ptyTerminateForeground, (persistKey: string, expectedAgentId?: string) =>
       this.terminateForeground(persistKey, expectedAgentId)
     )
+    platform().handle(IPC.ptyAgentProcess, (persistKey: string, expectedAgentId: string) =>
+      this.agentProcess(persistKey, expectedAgentId)
+    )
   }
 
   /** Feeds the renderer's "tmux not found" banner. Without tmux the app silently degrades to a
@@ -1832,10 +1843,23 @@ export class PtyManager {
     everySocket = false,
     acknowledged = true
   ): Promise<void> {
-    if (typeof persistKey !== 'string' || !persistKey || persistKey.length > REF_MAX_LEN)
+    modelRespawnTrace('pty.end-requested', {
+      nodeId: typeof persistKey === 'string' ? persistKey : 'invalid',
+      intent,
+      acknowledged
+    })
+    if (typeof persistKey !== 'string' || !persistKey || persistKey.length > REF_MAX_LEN) {
+      modelRespawnTrace('pty.end-refused', { intent, reason: 'invalid-node-id' })
       return this.refuseClientEnd(channel, acknowledged, 'invalid node id')
-    if (!this.allowEnd(clientId, channel))
+    }
+    if (!this.allowEnd(clientId, channel)) {
+      modelRespawnTrace('pty.end-refused', {
+        nodeId: persistKey,
+        intent,
+        reason: 'rate-limited'
+      })
       return this.refuseClientEnd(channel, acknowledged, 'rate limit exceeded; retry later')
+    }
     return this.endSession(clientId, persistKey, intent, everySocket)
   }
 
@@ -4090,6 +4114,73 @@ export class PtyManager {
   }
 
   /**
+   * Read-only proof that the expected agent owns the pane after a replacement launch. Unlike the
+   * restart acknowledgement in the renderer, this does not infer success from bytes written to a
+   * terminal: it re-reads the pane owner and its foreground process group from the kernel. The
+   * exact PID is intentionally not cached — an exited PID can be reused, so each poll must prove
+   * the current process identity afresh.
+   */
+  async agentProcess(persistKey: string, expectedAgentId: string): Promise<AgentProcessProof> {
+    const finish = (
+      proof: AgentProcessProof,
+      reason: string,
+      fields: Record<string, string | number | boolean | null | undefined> = {}
+    ): AgentProcessProof => {
+      modelRespawnTrace('pty.agent-process', {
+        nodeId: typeof persistKey === 'string' ? persistKey : 'invalid',
+        expectedAgentId:
+          typeof expectedAgentId === 'string' && expectedAgentId.length <= REF_MAX_LEN
+            ? expectedAgentId
+            : 'invalid',
+        verdict: proof.verdict,
+        reason,
+        shellPid: proof.shellPid,
+        agentPid: proof.agentPid,
+        ...fields
+      })
+      return proof
+    }
+
+    if (typeof persistKey !== 'string' || !persistKey || persistKey.length > REF_MAX_LEN)
+      return finish({ verdict: 'unknown' }, 'invalid-node-id')
+    if (
+      typeof expectedAgentId !== 'string' ||
+      !expectedAgentId ||
+      expectedAgentId.length > REF_MAX_LEN
+    )
+      return finish({ verdict: 'unknown' }, 'invalid-agent-id')
+
+    try {
+      const owner = await this.paneOwner(persistKey)
+      const expectedBinaries = binariesFor(expectedAgentId, this.getSettings().customAgents)
+      const verdict = isAgentPane(owner, expectedAgentId, expectedBinaries)
+      const agentPid =
+        verdict === 'agent'
+          ? (agentPidIn(owner, expectedAgentId, expectedBinaries) ?? undefined)
+          : undefined
+      // `isAgentPane` can name an agent from argv without a PID on a legacy/partial PaneOwner. That
+      // is sufficient for display, but cannot prove the SAME replacement survived stabilization.
+      if (verdict === 'agent' && !agentPid)
+        return finish({ verdict: 'unknown', shellPid: owner?.panePid }, 'agent-pid-missing', {
+          paneCommand: owner?.command ?? 'unavailable',
+          processCount: owner?.argv.length ?? 0
+        })
+      return finish(
+        { verdict, shellPid: owner?.panePid, agentPid },
+        verdict === 'agent' ? 'expected-agent-running' : 'owner-verdict',
+        {
+          paneCommand: owner?.command ?? 'unavailable',
+          processCount: owner?.argv.length ?? 0
+        }
+      )
+    } catch (error) {
+      return finish({ verdict: 'unknown' }, 'probe-threw', {
+        errorKind: modelRespawnErrorKind(error)
+      })
+    }
+  }
+
+  /**
    * Terminate the foreground agent process group in a node's tmux pane without writing anything
    * into the terminal. This is intentionally narrower than recycling the session: model switching
    * first stops the harness by PID, then uses the existing recycle path to rebuild the shell with
@@ -4099,12 +4190,55 @@ export class PtyManager {
    * model switch fires from a possibly-stale menu, and hours after the agent exited the pane may
    * belong to vim, a build, or an ssh the user started — none of which should be SIGTERM'd. When an
    * expected id is given, the foreground group's full argv is read (`paneOwner`) and the kill
-   * happens ONLY when `isAgentPane` confirms the expected harness owns the group; `not-agent` and
-   * `unknown` both refuse (fail-closed — we are about to send a signal). Omitting the id preserves
-   * the legacy shell-only guard for any caller that has no agent to assert.
+   * happens ONLY when `isAgentPane` confirms the expected harness owns the group. The one
+   * non-agent state distinguished from refusal is a successful kernel probe that shows the
+   * expected harness is no longer in the foreground group. Callers use that state to force a full
+   * session respawn, regardless of whether the pane currently holds the login shell, an editor, or
+   * another command. An unreadable/unknown probe still fails closed. Omitting the id preserves the
+   * legacy shell-only guard for any caller that has no agent to assert.
    */
-  async terminateForeground(persistKey: string, expectedAgentId?: string): Promise<boolean> {
-    if (typeof persistKey !== 'string' || !persistKey || persistKey.length > REF_MAX_LEN) return false
+  async terminateForeground(
+    persistKey: string,
+    expectedAgentId?: string
+  ): Promise<TerminateForegroundOutcome> {
+    const finish = (
+      outcome: TerminateForegroundOutcome,
+      reason: string,
+      fields: Record<string, string | number | boolean | null | undefined> = {}
+    ): TerminateForegroundOutcome => {
+      modelRespawnTrace('pty.terminate-complete', {
+        nodeId: typeof persistKey === 'string' ? persistKey : 'invalid',
+        expectedAgentId,
+        outcome,
+        reason,
+        ...fields
+      })
+      return outcome
+    }
+    modelRespawnTrace('pty.terminate-begin', {
+      nodeId: typeof persistKey === 'string' ? persistKey : 'invalid',
+      expectedAgentId,
+      hasExpectedAgent: !!expectedAgentId
+    })
+    if (typeof persistKey !== 'string' || !persistKey || persistKey.length > REF_MAX_LEN)
+      return finish('refused', 'invalid-node-id')
+    let expectedAgentPid: number | undefined
+    let verifiedPane: PaneOwner | undefined
+    let expectedBinaries: readonly string[] | null | undefined
+    const classifyLostAgent = async (): Promise<TerminateForegroundOutcome> => {
+      if (!expectedAgentId) return finish('refused', 'no-expected-agent')
+      try {
+        const owner = await this.paneOwner(persistKey)
+        const verdict = isAgentPane(owner, expectedAgentId, expectedBinaries)
+        return verdict === 'not-agent'
+          ? finish('already-exited', 'agent-absent-on-recheck')
+          : finish('refused', 'owner-recheck-uncertain', { verdict })
+      } catch (error) {
+        return finish('refused', 'owner-recheck-threw', {
+          errorKind: modelRespawnErrorKind(error)
+        })
+      }
+    }
     // Identity gate: prove the expected harness owns the foreground group before signalling it.
     // `paneOwner` reads the full argv (local or over the project's ControlMaster) and is null on
     // any uncertainty, which `isAgentPane` maps to `unknown` → refuse.
@@ -4112,43 +4246,124 @@ export class PtyManager {
       const owner = await this.paneOwner(persistKey)
       // Pass the custom-agent list so a `custom:<uuid>` harness is verifiable by its launchCmd
       // binary instead of collapsing to `unknown` (which would fail-closed on every model switch).
-      const binaries = binariesFor(expectedAgentId, this.getSettings().customAgents)
-      if (isAgentPane(owner, expectedAgentId, binaries) !== 'agent') return false
+      expectedBinaries = binariesFor(expectedAgentId, this.getSettings().customAgents)
+      const verdict = isAgentPane(owner, expectedAgentId, expectedBinaries)
+      modelRespawnTrace('pty.terminate-owner-verdict', {
+        nodeId: persistKey,
+        expectedAgentId,
+        verdict,
+        shellPid: owner?.panePid,
+        paneCommand: owner?.command ?? 'unavailable',
+        processCount: owner?.argv.length ?? 0
+      })
+      if (verdict !== 'agent') {
+        // `not-agent` is positive kernel evidence, not a failed probe. The expected harness no
+        // longer owns this session, so the restart caller must skip signalling and force the full
+        // respawn path. `unknown` remains a refusal because it proves nothing.
+        return verdict === 'not-agent'
+          ? finish('already-exited', 'expected-agent-absent')
+          : finish('refused', 'owner-unknown')
+      }
+      // Keep the exact PID the verdict rested on. A name-only verdict followed by a second pane
+      // read has a TOCTOU hole: the agent can exit between them and a raw shell program can become
+      // foreground before the kill. The kill legs below prove THIS PID is still live in the group
+      // they are about to signal; a changed owner refuses instead of terminating the newcomer.
+      expectedAgentPid = agentPidIn(owner, expectedAgentId, expectedBinaries) ?? undefined
+      if (!expectedAgentPid) return finish('refused', 'agent-pid-not-found')
+      verifiedPane = owner ?? undefined
+      modelRespawnTrace('pty.terminate-agent-pid', {
+        nodeId: persistKey,
+        expectedAgentId,
+        agentPid: expectedAgentPid,
+        shellPid: verifiedPane?.panePid
+      })
     }
     const target = sessionName(persistKey)
     const sshRemote = this.sessionByPersistKey(persistKey)?.sshRemote
     try {
       if (sshRemote) {
         const ssh = findSsh()
-        if (!ssh) return false
-        const { stdout } = await runAsync(
-          ssh,
-          remotePaneProcessArgs(sshRemote.conn, sshRemote.controlPath, target)
-        )
-        const pane = parsePaneProcess(stdout)
-        if (!pane || isShellCommand(pane.command)) return false
+        if (!ssh) return finish('refused', 'ssh-unavailable', { remote: true })
+        // The identity read already returned the pane root + command. Reuse it instead of opening
+        // a second SSH round-trip whose newer-but-unverified result could drift from the PID we
+        // authorized. The remote kill command revalidates both live tpgids atomically below.
+        let pane = verifiedPane
+          ? { panePid: verifiedPane.panePid, command: verifiedPane.command }
+          : null
+        if (!pane) {
+          const { stdout } = await runAsync(
+            ssh,
+            remotePaneProcessArgs(sshRemote.conn, sshRemote.controlPath, target)
+          )
+          pane = parsePaneProcess(stdout)
+        }
+        if (!pane || isShellCommand(pane.command))
+          return finish('refused', 'remote-pane-not-signalable', {
+            remote: true,
+            paneCommand: pane?.command ?? 'unavailable'
+          })
+        modelRespawnTrace('pty.terminate-signal', {
+          nodeId: persistKey,
+          expectedAgentId,
+          remote: true,
+          shellPid: pane.panePid,
+          agentPid: expectedAgentPid
+        })
         await runAsync(
           ssh,
-          remoteTerminateForegroundArgs(sshRemote.conn, sshRemote.controlPath, pane.panePid)
+          remoteTerminateForegroundArgs(
+            sshRemote.conn,
+            sshRemote.controlPath,
+            pane.panePid,
+            expectedAgentPid
+          )
         )
-        return true
+        return finish('terminated', 'remote-sigterm-sent', { remote: true })
       }
-      if (!this.tmuxPath) return false
-      const { stdout } = await runAsync(this.tmuxPath, [
-        '-L',
-        TMUX_SOCKET,
-        'display-message',
-        '-p',
-        '-t',
-        target,
-        '#{pane_pid}|#{pane_current_command}'
-      ])
-      const pane = parsePaneProcess(stdout)
-      if (!pane) return false
+      if (!this.tmuxPath) return finish('refused', 'tmux-unavailable', { remote: false })
+      let pane = verifiedPane
+        ? { panePid: verifiedPane.panePid, command: verifiedPane.command }
+        : null
+      if (!pane) {
+        const { stdout } = await runAsync(this.tmuxPath, [
+          '-L',
+          TMUX_SOCKET,
+          'display-message',
+          '-p',
+          '-t',
+          target,
+          '#{pane_pid}|#{pane_current_command}'
+        ])
+        pane = parsePaneProcess(stdout)
+      }
+      if (!pane) return finish('refused', 'pane-unavailable', { remote: false })
       const processTable = await runAsync('ps', ['-o', 'tpgid=', '-p', String(pane.panePid)])
       const processGroup = foregroundProcessGroup(pane, processTable.stdout)
-      if (!processGroup) return false
+      if (!processGroup)
+        return expectedAgentId
+          ? await classifyLostAgent()
+          : finish('refused', 'foreground-group-unavailable', { remote: false })
+      if (expectedAgentPid) {
+        // A successful `ps` row is the liveness proof; matching tpgid ties the exact argv-verified
+        // agent PID to the group below. If the agent exited or another program took foreground,
+        // the row is empty/different and nothing is signalled.
+        const expected = await runAsync('ps', [
+          '-o',
+          'tpgid=',
+          '-p',
+          String(expectedAgentPid)
+        ])
+        if (Number(expected.stdout.trim()) !== processGroup) return classifyLostAgent()
+      }
       process.kill(-processGroup, 'SIGTERM')
+      modelRespawnTrace('pty.terminate-signal', {
+        nodeId: persistKey,
+        expectedAgentId,
+        remote: false,
+        shellPid: pane.panePid,
+        agentPid: expectedAgentPid,
+        processGroup
+      })
       // Grace: give the harness a window to flush session state (transcript, --resume id) before
       // the caller recycles the session (tmux kill-session). Poll the group with signal 0 —
       // ESRCH means it is gone — up to ~1.5s, then return regardless (the recycle is a kill either
@@ -4161,9 +4376,14 @@ export class PtyManager {
         }
         await new Promise((r) => setTimeout(r, 50))
       }
-      return true
-    } catch {
-      return false
+      return finish('terminated', 'local-process-group-exited', { remote: false, processGroup })
+    } catch (error) {
+      modelRespawnTrace('pty.terminate-threw', {
+        nodeId: persistKey,
+        expectedAgentId,
+        errorKind: modelRespawnErrorKind(error)
+      })
+      return classifyLostAgent()
     }
   }
 
@@ -4672,8 +4892,19 @@ export class PtyManager {
     /** Trusted replacement identity; present only after confirmed profile preflight. */
     replacementTarget?: PtyRecycleTarget
   ): Promise<void> {
+    modelRespawnTrace('pty.end-begin', {
+      nodeId: persistKey,
+      intent,
+      backendAlreadyEnded,
+      hasReplacementTarget: !!replacementTarget
+    })
     const current = this.ending.get(persistKey)
     if (current) {
+      modelRespawnTrace('pty.end-coalesced', {
+        nodeId: persistKey,
+        intent,
+        currentIntent: current.intent
+      })
       // Identical repeats share one acknowledgement only when the in-flight target scope covers
       // this caller. An every-socket request, a pre-confirmed backend outcome, and an exact profile
       // reservation are each stronger than their generic counterpart, so a stronger request waits
@@ -4816,6 +5047,13 @@ export class PtyManager {
       live: dying?.sshRemote,
       owner: this.remoteNodeOwner?.(persistKey) ?? null,
       ssh: findSsh()
+    })
+    modelRespawnTrace('pty.end-session-state', {
+      nodeId: persistKey,
+      intent,
+      hadLiveSession: !!dying,
+      remote: remoteEnd.kind !== 'none',
+      backendAlreadyEnded
     })
     // SessionHostClient has a real request/response acknowledgement. Await it BEFORE any local
     // deletion claim: on transport failure the node, tombstone, subscribers and transcript tails
@@ -4990,6 +5228,12 @@ export class PtyManager {
         )
       }
     }
+    modelRespawnTrace('pty.end-complete', {
+      nodeId: persistKey,
+      intent,
+      hadLiveSession: !!dying,
+      remote: remoteEnd.kind !== 'none'
+    })
   }
 
   /**

--- a/src/core/pty-manager.ts
+++ b/src/core/pty-manager.ts
@@ -117,8 +117,10 @@ import { findCustomAgent } from '../shared/agents/custom-agent'
 import { applyCustomAgentEnv, customAgentEnvArgs } from './custom-agent-env'
 import {
   AUTOCOMPACT_ENV_KEYS,
+  CLAUDE_SUBAGENT_ENV_KEYS,
   MODEL_GATEWAY_ENV_KEYS,
   claudeAutocompactFor,
+  claudeSubagentEnvFor,
   modelGatewayEnv,
   tmuxUpdateEnvironmentLine,
   type GatewayModel
@@ -1652,7 +1654,11 @@ export class PtyManager {
     )
     if (!wanted.length) return
     if (!this.updateEnvKeys) {
-      this.updateEnvKeys = new Set([...MODEL_GATEWAY_ENV_KEYS, ...AUTOCOMPACT_ENV_KEYS])
+      this.updateEnvKeys = new Set([
+        ...MODEL_GATEWAY_ENV_KEYS,
+        ...AUTOCOMPACT_ENV_KEYS,
+        ...CLAUDE_SUBAGENT_ENV_KEYS
+      ])
       try {
         const out = execFileSync(
           this.tmuxPath,
@@ -2866,9 +2872,18 @@ export class PtyManager {
           )
         : { modelId: undefined, env: {} }
     const autocompactEnv = autocompact.env
+    const subagentEnv =
+      !stripRe && options.agentId
+        ? claudeSubagentEnvFor(
+            options.agentId as AgentId,
+            gatewayModels,
+            this.getSettings().modelGatewayDefaultModel
+          )
+        : {}
     if (!options.sshRemote) {
       for (const [k, v] of Object.entries(gatewayEnv)) env[k] = v
       for (const [k, v] of Object.entries(autocompactEnv)) env[k] = v
+      for (const [k, v] of Object.entries(subagentEnv)) env[k] = v
       // Strip inherited provider vars so a vanilla session does not fall back to a LaunchAgent-set
       // ANTHROPIC_BASE_URL instead of the subscription. Local only — see the note above.
       if (stripRe) {
@@ -3050,6 +3065,7 @@ export class PtyManager {
       const remoteEnvPairs: Record<string, string> = {
         ...gatewayEnv,
         ...autocompactEnv,
+        ...subagentEnv,
         ...(projectEnv ?? {})
       }
       for (const kv of remoteCustomEnv.args) {
@@ -3071,7 +3087,11 @@ export class PtyManager {
           envFile,
           sessionEnvFileContent(remoteEnvPairs)
         )
-        const baked = new Set<string>([...MODEL_GATEWAY_ENV_KEYS, ...AUTOCOMPACT_ENV_KEYS])
+        const baked = new Set<string>([
+          ...MODEL_GATEWAY_ENV_KEYS,
+          ...AUTOCOMPACT_ENV_KEYS,
+          ...CLAUDE_SUBAGENT_ENV_KEYS
+        ])
         remoteSessionEnv = {
           file: envFile,
           extraKeys: Object.keys(remoteEnvPairs).filter((k) => !baked.has(k))

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -407,6 +407,7 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
       const m = new PtyManager()
       m.init(() => ({
         ...DEFAULT_SETTINGS,
+        agentLaunchMode: mode.vanillaLaunchDefault ? 'subscription' : 'gateway',
         vanillaLaunchDefault: mode.vanillaLaunchDefault,
         modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
       }))
@@ -528,7 +529,7 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
   // recycle: read LIVE at spawn, so a fresh launch strips the gateway + inherited provider env
   // WITHOUT a per-node flag (and survives a reboot, since the setting is the source of truth, not
   // a one-shot data field that is cleared after its single use).
-  it('vanillaLaunchDefault strips the gateway + inherited env on a fresh spawn (no per-node clearEnv)', async () => {
+  it('subscription launch mode strips the gateway + inherited env on a fresh spawn', async () => {
     const inheritedBase = process.env.ANTHROPIC_BASE_URL
     const inheritedDir = process.env.CLAUDE_CONFIG_DIR
     process.env.ANTHROPIC_BASE_URL = 'https://launchagent-gateway.example.test'
@@ -538,6 +539,9 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
       const m = new PtyManager()
       m.init(() => ({
         ...DEFAULT_SETTINGS,
+        // The three-way successor to the boolean. (`vanillaLaunchDefault` is now a mirror kept in
+        // lockstep by the settings read path; tests that build settings inline must set the mode.)
+        agentLaunchMode: 'subscription',
         vanillaLaunchDefault: true,
         modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
       }))
@@ -565,11 +569,12 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     }
   })
 
-  it('vanillaLaunchDefault is a no-op for an agent with no strip pattern, and off keeps the gateway', async () => {
+  it('subscription is a no-op without a strip pattern, while both gateway modes keep the gateway', async () => {
     const { PtyManager } = await import('./pty-manager')
     const m = new PtyManager()
     m.init(() => ({
       ...DEFAULT_SETTINGS,
+      agentLaunchMode: 'subscription',
       vanillaLaunchDefault: true,
       modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
     }))
@@ -587,6 +592,7 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     const m2 = new PtyManager()
     m2.init(() => ({
       ...DEFAULT_SETTINGS,
+      agentLaunchMode: 'gateway',
       vanillaLaunchDefault: false,
       modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
     }))
@@ -594,6 +600,18 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     await create(80, 24, 'gateway-claude-default-off', { agentId: 'claude' })
     expect(spawnArgs[1].env.ANTHROPIC_BASE_URL).toBe('https://bifrost.example.test/anthropic')
     expect(spawnArgs[1].env.ANTHROPIC_AUTH_TOKEN).toBe('vk-gateway')
+
+    // Gateway (default model) changes the renderer's launch command, not PTY credential injection.
+    const m3 = new PtyManager()
+    m3.init(() => ({
+      ...DEFAULT_SETTINGS,
+      agentLaunchMode: 'gateway-model',
+      modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+    }))
+    m3.registerIpc()
+    await create(80, 24, 'gateway-claude-default-model', { agentId: 'claude' })
+    expect(spawnArgs[2].env.ANTHROPIC_BASE_URL).toBe('https://bifrost.example.test/anthropic')
+    expect(spawnArgs[2].env.ANTHROPIC_AUTH_TOKEN).toBe('vk-gateway')
   })
 
   // ── `fresh` drives scrollback replay + agent resume: it must still be computed from tmux ──

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -6,8 +6,22 @@ import { initPlatform, resetPlatformForTests } from './platform'
 import { fakePlatform, type FakePlatform } from './platform-fake'
 import { IPC } from '../shared/ipc'
 import { DEFAULT_SETTINGS } from '../shared/types'
-import { MODEL_GATEWAY_SECRET_REF } from '../shared/agents/model-gateway'
+import {
+  MODEL_GATEWAY_SECRET_REF,
+  type ModelGatewaySettings
+} from '../shared/agents/model-gateway'
 import { TMUX_SOCKET, sessionName } from './tmux-naming'
+import { currentModelGatewayDiscoveryScope } from './model-gateway-scope'
+
+const gatewayScope = (
+  settings: { baseUrl: string; apiKey: string; discoveryPath?: string },
+  storedSecret: string | null = null,
+  env: Record<string, string | undefined> = process.env
+) => {
+  const scope = currentModelGatewayDiscoveryScope(settings, storedSecret, env)
+  if (!scope) throw new Error('test gateway scope did not resolve')
+  return scope
+}
 
 /**
  * SINGLE-USER REGRESSION.
@@ -155,6 +169,29 @@ vi.mock('./pty-devices', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./pty-devices')>()),
   readPtyDevices: () => ({ ceiling: 511, inUse: 8 })
 }))
+
+/**
+ * The autocompact env vars may be present in THIS process's environment when the suite runs under
+ * a nodeterm-spawned Claude shell (the dev machine exports them). Tests that assert "not injected"
+ * scrub the inherited values so undefined reads as undefined, not as the host's leak. Each test
+ * saves + restores around itself rather than mutating the shared beforeEach, so tests that DO want
+ * to observe an inherited value are unaffected.
+ */
+function saveAndScrubAutocompactEnv(): Record<string, string | undefined> {
+  const saved: Record<string, string | undefined> = {
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW: process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW,
+    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+  }
+  delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW
+  delete process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+  return saved
+}
+function restoreAutocompactEnv(saved: Record<string, string | undefined>): void {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+}
 
 describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () => {
   let fake: FakePlatform
@@ -612,6 +649,176 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     await create(80, 24, 'gateway-claude-default-model', { agentId: 'claude' })
     expect(spawnArgs[2].env.ANTHROPIC_BASE_URL).toBe('https://bifrost.example.test/anthropic')
     expect(spawnArgs[2].env.ANTHROPIC_AUTH_TOKEN).toBe('vk-gateway')
+  })
+
+  // ── Claude Code autocompact: a claude-base agent whose gateway model reports a context window
+  //    above the threshold gets the autocompact env vars so the CLI compacts against the REAL
+  //    window (not its 200k default). The matching [1m] suffix on --model is applied at command
+  //    assembly (launch.ts); these tests cover the ENV half that pty-manager injects. ──
+  it('injects autocompact env for a claude model whose discovered window is large', async () => {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager()
+    m.init(() => ({
+      ...DEFAULT_SETTINGS,
+      modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+    }))
+    m.registerIpc()
+    // Seed the discovery cache the spawn site reads (`gatewayModelsForCurrent`).
+    m.setGatewayModels(gatewayScope({ baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }), [
+      { id: 'anthropic/claude-opus-5', contextWindow: 1_000_000 }
+    ])
+
+    await create(80, 24, 'autocompact-claude-large', { agentId: 'claude', agentModel: 'anthropic/claude-opus-5' })
+    const env = spawnArgs[0].env
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://bifrost.example.test/anthropic')
+    expect(env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1000000')
+    expect(env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE).toBe('80')
+  })
+
+  it('never reuses launch metadata after path, environment, or stored-key scope changes', async () => {
+    const savedEnv = process.env.NODETERM_TEST_GATEWAY_KEY
+    const scrubbed = saveAndScrubAutocompactEnv()
+    try {
+      const { PtyManager } = await import('./pty-manager')
+      let storedSecret = 'stored-old'
+      let gateway: ModelGatewaySettings = {
+        baseUrl: 'https://bifrost.example.test',
+        apiKey: MODEL_GATEWAY_SECRET_REF
+      }
+      const m = new PtyManager()
+      m.init(
+        () => ({ ...DEFAULT_SETTINGS, modelGateway: gateway }),
+        () => storedSecret
+      )
+      m.registerIpc()
+      const models = [{ id: 'anthropic/claude-opus-5', contextWindow: 1_000_000 }]
+
+      m.setGatewayModels(gatewayScope(gateway, storedSecret), models)
+      await create(80, 24, 'scope-stored-old', {
+        agentId: 'claude', agentModel: 'anthropic/claude-opus-5'
+      })
+      expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1000000')
+      storedSecret = 'stored-new'
+      await create(80, 24, 'scope-stored-new', {
+        agentId: 'claude', agentModel: 'anthropic/claude-opus-5'
+      })
+      expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+
+      process.env.NODETERM_TEST_GATEWAY_KEY = 'env-old'
+      gateway = {
+        baseUrl: 'https://bifrost.example.test',
+        apiKey: '${env:NODETERM_TEST_GATEWAY_KEY}'
+      }
+      m.setGatewayModels(gatewayScope(gateway, null, process.env), models)
+      await create(80, 24, 'scope-env-old', {
+        agentId: 'claude', agentModel: 'anthropic/claude-opus-5'
+      })
+      expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1000000')
+      process.env.NODETERM_TEST_GATEWAY_KEY = 'env-new'
+      await create(80, 24, 'scope-env-new', {
+        agentId: 'claude', agentModel: 'anthropic/claude-opus-5'
+      })
+      expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+
+      gateway = {
+        baseUrl: 'https://bifrost.example.test',
+        apiKey: 'literal',
+        discoveryPath: '/v1/models'
+      }
+      m.setGatewayModels(gatewayScope(gateway), models)
+      gateway = { ...gateway, discoveryPath: '/openai/v1/models' }
+      await create(80, 24, 'scope-path-new', {
+        agentId: 'claude', agentModel: 'anthropic/claude-opus-5'
+      })
+      expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+    } finally {
+      if (savedEnv === undefined) delete process.env.NODETERM_TEST_GATEWAY_KEY
+      else process.env.NODETERM_TEST_GATEWAY_KEY = savedEnv
+      restoreAutocompactEnv(scrubbed)
+    }
+  })
+
+  it('sets no autocompact env for a claude model at or below the threshold, or unknown to discovery', async () => {
+    // The host this suite runs on may itself export the autocompact vars (a nodeterm-under-Claude
+    // dev shell). Scrub them so "not injected" reads as undefined, not as the inherited value.
+    const saved = saveAndScrubAutocompactEnv()
+    try {
+      const { PtyManager } = await import('./pty-manager')
+      const m = new PtyManager()
+      m.init(() => ({
+        ...DEFAULT_SETTINGS,
+        modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+      }))
+      m.registerIpc()
+      m.setGatewayModels(gatewayScope({ baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }), [
+        { id: 'anthropic/claude-sonnet-5', contextWindow: 200_000 },
+        { id: 'anthropic/claude-haiku-5', contextWindow: 100_000 }
+      ])
+
+      // At the threshold (200k) — not above it.
+      await create(80, 24, 'autocompact-claude-200k', { agentId: 'claude', agentModel: 'anthropic/claude-sonnet-5' })
+      expect(spawnArgs[0].env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+      expect(spawnArgs[0].env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE).toBeUndefined()
+      // Below the threshold.
+      await create(80, 24, 'autocompact-claude-100k', { agentId: 'claude', agentModel: 'anthropic/claude-haiku-5' })
+      expect(spawnArgs[1].env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+      // Unknown to discovery — never guessed.
+      await create(80, 24, 'autocompact-claude-unknown', { agentId: 'claude', agentModel: 'anthropic/claude-future' })
+      expect(spawnArgs[2].env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+      // The gateway env is still injected in all three (autocompact is orthogonal to the gateway).
+      expect(spawnArgs[2].env.ANTHROPIC_BASE_URL).toBe('https://bifrost.example.test/anthropic')
+    } finally {
+      restoreAutocompactEnv(saved)
+    }
+  })
+
+  it('sets no autocompact env for a non-claude agent even with a large-context model', async () => {
+    const saved = saveAndScrubAutocompactEnv()
+    try {
+      const { PtyManager } = await import('./pty-manager')
+      const m = new PtyManager()
+      m.init(() => ({
+        ...DEFAULT_SETTINGS,
+        modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+      }))
+      m.registerIpc()
+      m.setGatewayModels(gatewayScope({ baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }), [
+        { id: 'openai/gpt-5.5-codex', contextWindow: 1_000_000 }
+      ])
+
+      await create(80, 24, 'autocompact-codex', { agentId: 'codex', agentModel: 'openai/gpt-5.5-codex' })
+      expect(spawnArgs[0].env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+      expect(spawnArgs[0].env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE).toBeUndefined()
+      // Codex gateway env is unaffected.
+      expect(spawnArgs[0].env.OPENAI_BASE_URL).toBe('https://bifrost.example.test/openai/v1')
+    } finally {
+      restoreAutocompactEnv(saved)
+    }
+  })
+
+  it('subscription launch mode strips the autocompact env too (no gateway model to read a window from)', async () => {
+    const saved = saveAndScrubAutocompactEnv()
+    try {
+      const { PtyManager } = await import('./pty-manager')
+      const m = new PtyManager()
+      m.init(() => ({
+        ...DEFAULT_SETTINGS,
+        agentLaunchMode: 'subscription',
+        modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+      }))
+      m.registerIpc()
+      m.setGatewayModels(gatewayScope({ baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }), [
+        { id: 'anthropic/claude-opus-5', contextWindow: 1_000_000 }
+      ])
+
+      await create(80, 24, 'autocompact-subscription', { agentId: 'claude', agentModel: 'anthropic/claude-opus-5' })
+      const env = spawnArgs[0].env
+      // No gateway, no autocompact — the subscription CLI's own window applies.
+      expect(env.ANTHROPIC_BASE_URL).toBeUndefined()
+      expect(env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+    } finally {
+      restoreAutocompactEnv(saved)
+    }
   })
 
   // ── `fresh` drives scrollback replay + agent resume: it must still be computed from tmux ──

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -392,6 +392,41 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     }
   })
 
+  it.each([
+    { vanillaLaunchDefault: true, clearEnv: undefined },
+    { vanillaLaunchDefault: false, clearEnv: true }
+  ])('preserves a plain terminal environment in subscription mode: %j', async (mode) => {
+    const inherited = {
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+      ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL
+    }
+    process.env.ANTHROPIC_API_KEY = 'plain-terminal-key'
+    process.env.ANTHROPIC_BASE_URL = 'https://plain-terminal-provider.example.test'
+    try {
+      const { PtyManager } = await import('./pty-manager')
+      const m = new PtyManager()
+      m.init(() => ({
+        ...DEFAULT_SETTINGS,
+        vanillaLaunchDefault: mode.vanillaLaunchDefault,
+        modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+      }))
+      m.registerIpc()
+
+      await create(80, 24, 'subscription-plain-terminal', { clearEnv: mode.clearEnv })
+
+      expect(spawnArgs[0].env.ANTHROPIC_API_KEY).toBe('plain-terminal-key')
+      expect(spawnArgs[0].env.ANTHROPIC_BASE_URL).toBe(
+        'https://plain-terminal-provider.example.test'
+      )
+      expect(spawnArgs[0].args.join(' ')).not.toContain('vk-gateway')
+    } finally {
+      for (const [key, value] of Object.entries(inherited)) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
+    }
+  })
+
   // "Restart on subscription": clearEnv spawns the session VANILLA — skip the gateway AND strip
   // inherited provider vars (a LaunchAgent/zshrc export a GUI launch still inherits) so the agent
   // falls back to its OWN default provider. Both moves are gated on the agent's vanillaEnvPattern

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -180,10 +180,12 @@ vi.mock('./pty-devices', async (importOriginal) => ({
 function saveAndScrubAutocompactEnv(): Record<string, string | undefined> {
   const saved: Record<string, string | undefined> = {
     CLAUDE_CODE_AUTO_COMPACT_WINDOW: process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW,
-    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+    CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE,
+    CLAUDE_CODE_SUBAGENT_MODEL: process.env.CLAUDE_CODE_SUBAGENT_MODEL
   }
   delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW
   delete process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+  delete process.env.CLAUDE_CODE_SUBAGENT_MODEL
   return saved
 }
 function restoreAutocompactEnv(saved: Record<string, string | undefined>): void {
@@ -816,6 +818,54 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
       // No gateway, no autocompact — the subscription CLI's own window applies.
       expect(env.ANTHROPIC_BASE_URL).toBeUndefined()
       expect(env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+    } finally {
+      restoreAutocompactEnv(saved)
+    }
+  })
+
+  it('routes Claude subagents through a served model regardless of the parent window size', async () => {
+    const saved = saveAndScrubAutocompactEnv()
+    try {
+      const { PtyManager } = await import('./pty-manager')
+      let settings = {
+        ...DEFAULT_SETTINGS,
+        modelGatewayDefaultModel: 'vllm/zeta',
+        modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+      }
+      const m = new PtyManager()
+      m.init(() => settings)
+      m.registerIpc()
+      m.setGatewayModels(gatewayScope(settings.modelGateway), [
+        { id: 'vllm/zeta', contextWindow: 200_000 },
+        { id: 'anthropic/alpha' }
+      ])
+
+      await create(80, 24, 'subagent-default', {
+        agentId: 'claude',
+        agentModel: 'vllm/zeta'
+      })
+      expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_SUBAGENT_MODEL).toBe('vllm/zeta')
+      expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+
+      settings = { ...settings, modelGatewayDefaultModel: 'missing' }
+      await create(80, 24, 'subagent-fallback', {
+        agentId: 'claude',
+        agentModel: 'vllm/zeta'
+      })
+      expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_SUBAGENT_MODEL).toBe('anthropic/alpha')
+
+      await create(80, 24, 'subagent-non-claude', {
+        agentId: 'codex',
+        agentModel: 'vllm/zeta'
+      })
+      expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_SUBAGENT_MODEL).toBeUndefined()
+
+      settings = { ...settings, agentLaunchMode: 'subscription' }
+      await create(80, 24, 'subagent-subscription', {
+        agentId: 'claude',
+        agentModel: 'vllm/zeta'
+      })
+      expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_SUBAGENT_MODEL).toBeUndefined()
     } finally {
       restoreAutocompactEnv(saved)
     }

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -755,7 +755,7 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
 
     // No expectedAgentId here — the legacy shell-only guard path (an SSH/codex node's own
     // model switch passes its id; this asserts the base kill mechanism stays intact).
-    await expect(fake.handlers[IPC.ptyTerminateForeground]('solo-1')).resolves.toBe(true)
+    await expect(fake.handlers[IPC.ptyTerminateForeground]('solo-1')).resolves.toBe('terminated')
 
     expect(signal).toHaveBeenCalledWith(-33319, 'SIGTERM')
     expect(tmuxCalls('send-keys')).toEqual([])
@@ -769,7 +769,7 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     processGroupReply = '33293\n'
     const signal = vi.spyOn(process, 'kill').mockImplementation(() => true)
 
-    await expect(fake.handlers[IPC.ptyTerminateForeground]('solo-1')).resolves.toBe(false)
+    await expect(fake.handlers[IPC.ptyTerminateForeground]('solo-1')).resolves.toBe('refused')
 
     expect(signal).not.toHaveBeenCalled()
   })

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../shared/agents/model-gateway'
 import { TMUX_SOCKET, sessionName } from './tmux-naming'
 import { currentModelGatewayDiscoveryScope } from './model-gateway-scope'
+import { cachedWindowFor } from './model-window'
 
 const gatewayScope = (
   settings: { baseUrl: string; apiKey: string; discoveryPath?: string },
@@ -693,9 +694,13 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
         () => storedSecret
       )
       m.registerIpc()
-      const models = [{ id: 'anthropic/claude-opus-5', contextWindow: 1_000_000 }]
+      const models = [
+        { id: 'anthropic/claude-opus-5', contextWindow: 1_000_000 },
+        { id: 'vllm/custom-model', contextWindow: 333_000 }
+      ]
 
       m.setGatewayModels(gatewayScope(gateway, storedSecret), models)
+      expect(cachedWindowFor('vllm/custom-model')).toBe(333_000)
       await create(80, 24, 'scope-stored-old', {
         agentId: 'claude', agentModel: 'anthropic/claude-opus-5'
       })
@@ -705,6 +710,7 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
         agentId: 'claude', agentModel: 'anthropic/claude-opus-5'
       })
       expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+      expect(cachedWindowFor('vllm/custom-model')).toBe(200_000)
 
       process.env.NODETERM_TEST_GATEWAY_KEY = 'env-old'
       gateway = {
@@ -712,6 +718,7 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
         apiKey: '${env:NODETERM_TEST_GATEWAY_KEY}'
       }
       m.setGatewayModels(gatewayScope(gateway, null, process.env), models)
+      expect(cachedWindowFor('vllm/custom-model')).toBe(333_000)
       await create(80, 24, 'scope-env-old', {
         agentId: 'claude', agentModel: 'anthropic/claude-opus-5'
       })
@@ -721,6 +728,7 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
         agentId: 'claude', agentModel: 'anthropic/claude-opus-5'
       })
       expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+      expect(cachedWindowFor('vllm/custom-model')).toBe(200_000)
 
       gateway = {
         baseUrl: 'https://bifrost.example.test',
@@ -728,11 +736,13 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
         discoveryPath: '/v1/models'
       }
       m.setGatewayModels(gatewayScope(gateway), models)
+      expect(cachedWindowFor('vllm/custom-model')).toBe(333_000)
       gateway = { ...gateway, discoveryPath: '/openai/v1/models' }
       await create(80, 24, 'scope-path-new', {
         agentId: 'claude', agentModel: 'anthropic/claude-opus-5'
       })
       expect(spawnArgs.at(-1)?.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeUndefined()
+      expect(cachedWindowFor('vllm/custom-model')).toBe(200_000)
     } finally {
       if (savedEnv === undefined) delete process.env.NODETERM_TEST_GATEWAY_KEY
       else process.env.NODETERM_TEST_GATEWAY_KEY = savedEnv

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -392,6 +392,175 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     }
   })
 
+  // "Restart on subscription": clearEnv spawns the session VANILLA — skip the gateway AND strip
+  // inherited provider vars (a LaunchAgent/zshrc export a GUI launch still inherits) so the agent
+  // falls back to its OWN default provider. Both moves are gated on the agent's vanillaEnvPattern
+  // (resolved through its base harness). The strip runs BEFORE custom-agent env, so a user who
+  // explicitly declares a provider var on a custom agent still wins.
+  it('clearEnv skips the gateway and strips inherited provider env for claude', async () => {
+    const inheritedBase = process.env.ANTHROPIC_BASE_URL
+    const inheritedKey = process.env.ANTHROPIC_API_KEY
+    const inheritedDir = process.env.CLAUDE_CONFIG_DIR
+    process.env.ANTHROPIC_BASE_URL = 'https://launchagent-gateway.example.test'
+    process.env.ANTHROPIC_API_KEY = 'sk-inherited'
+    process.env.CLAUDE_CONFIG_DIR = '/home/me/.nodeterm/claude-accounts/abc'
+    try {
+      const { PtyManager } = await import('./pty-manager')
+      const m = new PtyManager()
+      m.init(() => ({
+        ...DEFAULT_SETTINGS,
+        modelGateway: {
+          baseUrl: 'https://bifrost.example.test',
+          apiKey: 'vk-gateway'
+        }
+      }))
+      m.registerIpc()
+
+      await create(80, 24, 'vanilla-claude', { agentId: 'claude', clearEnv: true })
+
+      const env = spawnArgs[0].env
+      // (1) the gateway is NOT injected …
+      expect(env.ANTHROPIC_BASE_URL).toBeUndefined()
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+      // … and (2) the INHERITED provider vars are stripped too, so the session does not fall back
+      // to the LaunchAgent-set base URL instead of the subscription.
+      expect(env.ANTHROPIC_BASE_URL).toBeUndefined()
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined()
+      // CLAUDE_CONFIG_DIR is the managed-account dir, NOT a provider credential — stripping it
+      // would break account isolation, so it survives a vanilla relaunch.
+      expect(env.CLAUDE_CONFIG_DIR).toBe('/home/me/.nodeterm/claude-accounts/abc')
+    } finally {
+      for (const [k, v] of [
+        ['ANTHROPIC_BASE_URL', inheritedBase],
+        ['ANTHROPIC_API_KEY', inheritedKey],
+        ['CLAUDE_CONFIG_DIR', inheritedDir]
+      ] as const) {
+        if (v === undefined) delete process.env[k]
+        else process.env[k] = v
+      }
+    }
+  })
+
+  it('clearEnv is one-directional: unset, the gateway is injected as usual', async () => {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager()
+    m.init(() => ({
+      ...DEFAULT_SETTINGS,
+      modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+    }))
+    m.registerIpc()
+
+    await create(80, 24, 'gateway-claude', { agentId: 'claude' })
+
+    expect(spawnArgs[0].env.ANTHROPIC_BASE_URL).toBe('https://bifrost.example.test/anthropic')
+    expect(spawnArgs[0].env.ANTHROPIC_AUTH_TOKEN).toBe('vk-gateway')
+  })
+
+  it('clearEnv strips COPILOT_PROVIDER_* for copilot but keeps the home dir', async () => {
+    const inheritedHome = process.env.COPILOT_HOME
+    const inheritedProviderKey = process.env.COPILOT_PROVIDER_API_KEY
+    process.env.COPILOT_HOME = '/home/me/.copilot'
+    process.env.COPILOT_PROVIDER_API_KEY = 'sk-inherited'
+    try {
+      const { PtyManager } = await import('./pty-manager')
+      const m = new PtyManager()
+      m.init(() => ({
+        ...DEFAULT_SETTINGS,
+        modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+      }))
+      m.registerIpc()
+
+      await create(80, 24, 'vanilla-copilot', { agentId: 'copilot', clearEnv: true })
+
+      const env = spawnArgs[0].env
+      // Gateway + inherited provider vars both gone.
+      expect(env.COPILOT_PROVIDER_API_KEY).toBeUndefined()
+      expect(env.COPILOT_PROVIDER_BASE_URL).toBeUndefined()
+      // Home dir is a config dir, not a credential — survives.
+      expect(env.COPILOT_HOME).toBe('/home/me/.copilot')
+    } finally {
+      for (const [k, v] of [
+        ['COPILOT_HOME', inheritedHome],
+        ['COPILOT_PROVIDER_API_KEY', inheritedProviderKey]
+      ] as const) {
+        if (v === undefined) delete process.env[k]
+        else process.env[k] = v
+      }
+    }
+  })
+
+  // The global "Launch on subscription" default is the counterpart to the per-node `clearEnv`
+  // recycle: read LIVE at spawn, so a fresh launch strips the gateway + inherited provider env
+  // WITHOUT a per-node flag (and survives a reboot, since the setting is the source of truth, not
+  // a one-shot data field that is cleared after its single use).
+  it('vanillaLaunchDefault strips the gateway + inherited env on a fresh spawn (no per-node clearEnv)', async () => {
+    const inheritedBase = process.env.ANTHROPIC_BASE_URL
+    const inheritedDir = process.env.CLAUDE_CONFIG_DIR
+    process.env.ANTHROPIC_BASE_URL = 'https://launchagent-gateway.example.test'
+    process.env.CLAUDE_CONFIG_DIR = '/home/me/.nodeterm/claude-accounts/abc'
+    try {
+      const { PtyManager } = await import('./pty-manager')
+      const m = new PtyManager()
+      m.init(() => ({
+        ...DEFAULT_SETTINGS,
+        vanillaLaunchDefault: true,
+        modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+      }))
+      m.registerIpc()
+
+      // No `clearEnv` on the node — the SETTING is what strips. This is the new-session case the
+      // per-node action could not serve (it recycles, which needs a session with turns to resume).
+      await create(80, 24, 'vanilla-default-claude', { agentId: 'claude' })
+
+      const env = spawnArgs[0].env
+      expect(env.ANTHROPIC_BASE_URL).toBeUndefined()
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+      // Inherited provider var stripped too — no fall-back to the LaunchAgent gateway.
+      expect(env.ANTHROPIC_BASE_URL).toBeUndefined()
+      // Account isolation survives (config dir is not a provider credential).
+      expect(env.CLAUDE_CONFIG_DIR).toBe('/home/me/.nodeterm/claude-accounts/abc')
+    } finally {
+      for (const [k, v] of [
+        ['ANTHROPIC_BASE_URL', inheritedBase],
+        ['CLAUDE_CONFIG_DIR', inheritedDir]
+      ] as const) {
+        if (v === undefined) delete process.env[k]
+        else process.env[k] = v
+      }
+    }
+  })
+
+  it('vanillaLaunchDefault is a no-op for an agent with no strip pattern, and off keeps the gateway', async () => {
+    const { PtyManager } = await import('./pty-manager')
+    const m = new PtyManager()
+    m.init(() => ({
+      ...DEFAULT_SETTINGS,
+      vanillaLaunchDefault: true,
+      modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+    }))
+    m.registerIpc()
+
+    // gemini has no vanillaEnvPattern (and no gateway route at all) → the setting strips nothing
+    // and the spawn proceeds normally. A global toggle must not change an agent it does not cover:
+    // a non-provider env var (PATH) survives the strip pass untouched. (A provider var inherited
+    // from the host env is NOT stripped either — gemini has no pattern — which is the no-op.)
+    await create(80, 24, 'vanilla-default-gemini', { agentId: 'gemini' })
+    expect(typeof spawnArgs[0].env.PATH).toBe('string')
+
+    // And with the setting OFF (the default), a claude spawn keeps the gateway — the non-disruptive
+    // upgrade guarantee for existing users. (spawnArgs accumulates within a test: this is [1].)
+    const m2 = new PtyManager()
+    m2.init(() => ({
+      ...DEFAULT_SETTINGS,
+      vanillaLaunchDefault: false,
+      modelGateway: { baseUrl: 'https://bifrost.example.test', apiKey: 'vk-gateway' }
+    }))
+    m2.registerIpc()
+    await create(80, 24, 'gateway-claude-default-off', { agentId: 'claude' })
+    expect(spawnArgs[1].env.ANTHROPIC_BASE_URL).toBe('https://bifrost.example.test/anthropic')
+    expect(spawnArgs[1].env.ANTHROPIC_AUTH_TOKEN).toBe('vk-gateway')
+  })
+
   // ── `fresh` drives scrollback replay + agent resume: it must still be computed from tmux ──
   it('fresh:false on a WARM reattach (tmux session already exists) — no cold restore', async () => {
     await tmuxManager()

--- a/src/core/remote-ssh/control-master.test.ts
+++ b/src/core/remote-ssh/control-master.test.ts
@@ -287,15 +287,20 @@ describe('remote foreground process termination', () => {
   })
 
   it('revalidates the foreground group and never targets the pane shell group', () => {
-    const args = remoteTerminateForegroundArgs(conn, '/s.sock', 33293)
+    const args = remoteTerminateForegroundArgs(conn, '/s.sock', 33293, 44102)
     const command = args[args.length - 1]
     expect(command).toContain('ps -o tpgid= -p 33293')
     expect(command).toContain('[ "$tpgid" -ne 33293 ]')
+    expect(command).toContain('ps -o tpgid= -p 44102')
+    expect(command).toContain('[ "$agent_tpgid" = "$tpgid" ]')
     expect(command).toContain('kill -TERM -- "-$tpgid"')
   })
 
   it('refuses an invalid pane pid before building a remote shell command', () => {
     expect(() => remoteTerminateForegroundArgs(conn, '/s.sock', -1)).toThrow('invalid-pane-pid')
+    expect(() => remoteTerminateForegroundArgs(conn, '/s.sock', 33293, -1)).toThrow(
+      'invalid-agent-pid'
+    )
   })
 })
 

--- a/src/core/remote-ssh/control-master.ts
+++ b/src/core/remote-ssh/control-master.ts
@@ -506,24 +506,38 @@ export function remotePaneProcessArgs(
 }
 
 /**
- * SIGTERM the remote pane's foreground process group, after core has already confirmed tmux is
- * reporting an agent rather than a shell. The shell re-reads tpgid here to close the process-race
- * window and refuses its own group (`panePid`) before invoking kill.
+ * SIGTERM the remote pane's foreground process group, after core has identified the exact expected
+ * agent PID from full argv. The remote shell re-reads both the pane's tpgid and that exact PID's
+ * tpgid in one command, requires them to match, and refuses the pane shell's own group before kill.
  */
 export function remoteTerminateForegroundArgs(
   conn: SshConnection,
   controlPath: string,
-  panePid: number
+  panePid: number,
+  expectedAgentPid?: number
 ): string[] {
   if (!Number.isSafeInteger(panePid) || panePid <= 0) {
     throw new Error('invalid-pane-pid')
   }
+  if (
+    expectedAgentPid !== undefined &&
+    (!Number.isSafeInteger(expectedAgentPid) || expectedAgentPid <= 0)
+  ) {
+    throw new Error('invalid-agent-pid')
+  }
+  const expectedAgentCheck = expectedAgentPid
+    ? `agent_tpgid=$(ps -o tpgid= -p ${expectedAgentPid} | tr -d '[:space:]') && ` +
+      `case "$agent_tpgid" in ''|*[!0-9]*) exit 1;; esac && ` +
+      `[ "$agent_tpgid" = "$tpgid" ] && `
+    : ''
   return childArgs(
     conn,
     controlPath,
     `tpgid=$(ps -o tpgid= -p ${panePid} | tr -d '[:space:]') && ` +
       `case "$tpgid" in ''|*[!0-9]*) exit 1;; esac && ` +
-      `[ "$tpgid" -gt 0 ] && [ "$tpgid" -ne ${panePid} ] && kill -TERM -- "-$tpgid"`
+      `[ "$tpgid" -gt 0 ] && [ "$tpgid" -ne ${panePid} ] && ` +
+      expectedAgentCheck +
+      `kill -TERM -- "-$tpgid"`
   )
 }
 /**

--- a/src/core/settings-store.test.ts
+++ b/src/core/settings-store.test.ts
@@ -182,6 +182,43 @@ describe('SettingsStore nested-default merge', () => {
     })
   })
 
+  describe('agent launch mode migration', () => {
+    const loadWith = (saved: Record<string, unknown>): Settings => {
+      writeFileSync(path.join(dir, 'settings.json'), JSON.stringify(saved), 'utf-8')
+      const store = new SettingsStore()
+      store.init()
+      return store.get()
+    }
+
+    it('migrates the legacy vanilla boolean and keeps its downgrade mirror synchronized', () => {
+      expect(loadWith({ vanillaLaunchDefault: true })).toMatchObject({
+        agentLaunchMode: 'subscription',
+        vanillaLaunchDefault: true
+      })
+      expect(loadWith({ vanillaLaunchDefault: false })).toMatchObject({
+        agentLaunchMode: 'gateway',
+        vanillaLaunchDefault: false
+      })
+      expect(loadWith({})).toMatchObject({
+        agentLaunchMode: 'gateway',
+        vanillaLaunchDefault: false
+      })
+    })
+
+    it('keeps each valid mode authoritative and normalizes invalid values to the default', () => {
+      expect(
+        loadWith({ agentLaunchMode: 'gateway-model', vanillaLaunchDefault: true })
+      ).toMatchObject({ agentLaunchMode: 'gateway-model', vanillaLaunchDefault: false })
+      expect(
+        loadWith({ agentLaunchMode: 'subscription', vanillaLaunchDefault: false })
+      ).toMatchObject({ agentLaunchMode: 'subscription', vanillaLaunchDefault: true })
+      expect(loadWith({ agentLaunchMode: 'unknown', vanillaLaunchDefault: false })).toMatchObject({
+        agentLaunchMode: 'gateway',
+        vanillaLaunchDefault: false
+      })
+    })
+  })
+
   describe('dictation chord seed (one-shot migration)', () => {
     // Same disk fixture as the sibling describes: write a settings.json, load it through the real
     // store, read the merged result back.

--- a/src/core/settings-store.ts
+++ b/src/core/settings-store.ts
@@ -70,6 +70,27 @@ function mergeSettings(saved: Partial<Settings> | null | undefined): Settings {
   if (gpu === false) merged.terminalGpuRendering = "off";
   else if (gpu !== "on" && gpu !== "off" && gpu !== "auto" && gpu !== "shared")
     merged.terminalGpuRendering = "auto";
+  // `agentLaunchMode` is the three-way successor to the `vanillaLaunchDefault` boolean. A saved
+  // file from before this field existed carries only the boolean: `true` was an explicit opt into
+  // subscription/vanilla, so it migrates to `'subscription'`; `false` (or absent) is the default
+  // and maps to `'gateway'`. Once `agentLaunchMode` is present it is the truth and the boolean is
+  // only a downgrade mirror (the renderer write path keeps it in sync for an older build).
+  // Validate to the default for an unrecognized value — settings.json is hand-editable.
+  const savedLaunchMode = (saved as { agentLaunchMode?: unknown } | null | undefined)
+    ?.agentLaunchMode;
+  if (
+    savedLaunchMode === "gateway" ||
+    savedLaunchMode === "gateway-model" ||
+    savedLaunchMode === "subscription"
+  ) {
+    merged.agentLaunchMode = savedLaunchMode;
+  } else if (merged.vanillaLaunchDefault === true) {
+    merged.agentLaunchMode = "subscription";
+  } else {
+    merged.agentLaunchMode = DEFAULT_SETTINGS.agentLaunchMode;
+  }
+  // Keep the mirror in lockstep with the resolved mode so an older build still honors the choice.
+  merged.vanillaLaunchDefault = merged.agentLaunchMode === "subscription";
   return merged;
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1191,7 +1191,16 @@ app.whenReady().then(async () => {
         // healed-swap strands, [glyphgrid] attach/geometry warnings) are exactly what this panel
         // is for, and they triage by tag. Untagged lines fall back to 'renderer'.
         const { tag, rest } = splitTag(String(event.message ?? ''))
-        logBuffer.push({ level, tag: tag || 'renderer', msg: rest })
+        if (tag === 'model-respawn' && contents.getType() !== 'webview') {
+          // This trace is explicitly field-diagnostic and users commonly start dev with
+          // `... | tee nodeterm.log`. Sending it through main's wrapped console lands it in BOTH
+          // stdout/the tee and the same debug ring, once. Never promote a guest page's console by
+          // tag: an untrusted webview must not be able to forge or flood the app's lifecycle log.
+          // Other renderer chatter remains ring-only.
+          console[level](`[model-respawn] ${rest}`)
+        } else {
+          logBuffer.push({ level, tag: tag || 'renderer', msg: rest })
+        }
       } catch {
         /* logging must never break a page */
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1292,7 +1292,11 @@ app.whenReady().then(async () => {
   sshStore.registerIpc()
   // Gateway discovery/credential IPC (peer-reachable by design; the renderer never receives a
   // stored literal key, and discovery resolves key REFERENCES only for the saved gateway URL).
-  registerAgentEnvIpc(() => settingsStore.get().modelGateway, gatewayCredentials)
+  registerAgentEnvIpc(
+    () => settingsStore.get().modelGateway,
+    gatewayCredentials,
+    (scope, models) => ptyManager.setGatewayModels(scope, models)
+  )
   // The `${env:VAR}` snapshot for custom-agent expansion is DESKTOP-WINDOW-ONLY, so it is a raw
   // `ipcMain.handle` on purpose (see the handler-table comment in platform-electron.ts): a
   // `platform().handle` registration would answer relay peers too — a paired phone or remote tab

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -39,6 +39,8 @@ describe('preload sshProject passphrase wiring', () => {
   it('routes foreground process termination through request IPC', async () => {
     await api.pty.terminateForeground('node-1', 'claude')
     expect(h.invoke).toHaveBeenCalledWith(IPC.ptyTerminateForeground, 'node-1', 'claude')
+    await api.pty.agentProcess('node-1', 'claude')
+    expect(h.invoke).toHaveBeenCalledWith(IPC.ptyAgentProcess, 'node-1', 'claude')
   })
 
   it('exposes GitHub issue data and host-control namespaces on their exact channels', async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -85,7 +85,7 @@ const api: NodeTerminalApi = {
     kill: (sessionId, viewerId) => ipcRenderer.send(IPC.ptyKill, sessionId, viewerId),
     destroy: (persistKey, opts) =>
       ipcRenderer.send(IPC.ptyDestroy, persistKey, opts?.everySocket === true),
-    recycle: (persistKey) => ipcRenderer.send(IPC.ptyRecycle, persistKey),
+    recycle: (persistKey) => ipcRenderer.invoke(IPC.ptyRecycle, persistKey),
     generateName: (persistKey, cwd) => ipcRenderer.invoke(IPC.ptyGenerateName, persistKey, cwd),
     generateGroupName: (memberKeys, cwd) =>
       ipcRenderer.invoke(IPC.ptyGenerateGroupName, memberKeys, cwd),
@@ -97,6 +97,8 @@ const api: NodeTerminalApi = {
     paneCommand: (persistKey) => ipcRenderer.invoke(IPC.ptyPaneCommand, persistKey),
     terminateForeground: (persistKey, expectedAgentId) =>
       ipcRenderer.invoke(IPC.ptyTerminateForeground, persistKey, expectedAgentId),
+    agentProcess: (persistKey, expectedAgentId) =>
+      ipcRenderer.invoke(IPC.ptyAgentProcess, persistKey, expectedAgentId),
     readSessionName: (sessionId, accountId, agentId) =>
       ipcRenderer.invoke(IPC.ptyReadSessionName, sessionId, accountId, agentId),
     onData: (sessionId, listener) => {

--- a/src/renderer/bridge/ws-bridge.ts
+++ b/src/renderer/bridge/ws-bridge.ts
@@ -18,6 +18,7 @@ import type { GitHubControlApi, GitHubIssuesApi } from '../../shared/github-issu
 import {
   UNKNOWN_CLAUDE_CLI_CAPS,
   UNKNOWN_GROK_CLI_CAPS,
+  type AgentProcessProof,
   type BoardLogApi,
   type LogApi,
   type LogRecord,
@@ -52,6 +53,7 @@ import {
   type Settings,
   type SpeechApi,
   type SpeechModelInfo,
+  type TerminateForegroundOutcome,
   type TmuxStatus,
   type TranscriptLine,
   type Workspace,
@@ -236,7 +238,7 @@ export function buildRealApi(
     // The trailing flag rides as a plain boolean; the core handler re-checks `=== true`.
     destroy: (persistKey, opts) =>
       client.cast(IPC.ptyDestroy, persistKey, opts?.everySocket === true),
-    recycle: (persistKey) => client.cast(IPC.ptyRecycle, persistKey),
+    recycle: (persistKey) => client.request(IPC.ptyRecycle, persistKey) as Promise<void>,
     // No server handler — degrade gracefully (never reject the boot path).
     generateName: () => Promise.resolve(AI_NAMING_UNAVAILABLE),
     generateGroupName: () => Promise.resolve(AI_NAMING_UNAVAILABLE),
@@ -256,7 +258,38 @@ export function buildRealApi(
     paneCommand: (persistKey) =>
       client.request(IPC.ptyPaneCommand, persistKey).catch(() => null) as Promise<string | null>,
     terminateForeground: (persistKey, expectedAgentId) =>
-      client.request(IPC.ptyTerminateForeground, persistKey, expectedAgentId).catch(() => false) as Promise<boolean>,
+      client
+        .request(IPC.ptyTerminateForeground, persistKey, expectedAgentId)
+        .then((value) =>
+          value === 'terminated' || value === 'already-exited' || value === 'refused'
+            ? value
+            : value === true
+              ? 'terminated'
+              : 'refused'
+        )
+        .catch(() => 'refused') as Promise<TerminateForegroundOutcome>,
+    agentProcess: (persistKey, expectedAgentId) =>
+      client
+        .request(IPC.ptyAgentProcess, persistKey, expectedAgentId)
+        .then((value): AgentProcessProof => {
+          if (!value || typeof value !== 'object') return { verdict: 'unknown' as const }
+          const candidate = value as Record<string, unknown>
+          const verdict = candidate.verdict
+          if (verdict !== 'agent' && verdict !== 'not-agent' && verdict !== 'unknown')
+            return { verdict: 'unknown' as const }
+          const shellPid = candidate.shellPid ?? candidate.panePid
+          const agentPid = candidate.agentPid
+          return {
+            verdict,
+            ...(typeof shellPid === 'number' && Number.isSafeInteger(shellPid) && shellPid > 0
+              ? { shellPid }
+              : {}),
+            ...(typeof agentPid === 'number' && Number.isSafeInteger(agentPid) && agentPid > 0
+              ? { agentPid }
+              : {})
+          }
+        })
+        .catch(() => ({ verdict: 'unknown' as const })),
     // No server handler — the session-name poll degrades to no adopted name. A PRE-EXISTING gap,
     // and not any one agent's: `IPC.ptyReadSessionName` has never been registered server-side, so
     // claude's, grok's and gemini's read legs are equally stubbed here (the write leg works on both

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { playSfx, primeSfx } from '@renderer/lib/sfx'
 import { fanoutStillWorking } from '@renderer/lib/completionAlert'
@@ -172,7 +172,28 @@ import { planSetProjectFolder } from '../lib/setProjectFolder'
 import { observationIsRemote, type ObservationOrigin } from '../lib/accountChip'
 import { transferConversationItems } from '../lib/transferItems'
 import { reopenVariants } from '../lib/reopenVariants'
-import { modelsForAgent } from '@shared/agents/model-gateway'
+import { claudeAutocompactFor, modelContextWindow, modelsForAgent } from '@shared/agents/model-gateway'
+import {
+  modelAvailability,
+  modelLaunchShapeMismatch,
+  modelRecoveryCure,
+  modelRecoverySessionKey,
+  modelRecoveryTrigger,
+  modelWindowChange,
+  modelWindowSessionKey,
+  type ModelRecoveryReason
+} from '@shared/agents/model-availability'
+import { modelRespawnErrorKind, modelRespawnTrace } from '@shared/model-respawn-trace'
+import {
+  modelSwitchProgressCanAutoDismiss,
+  modelSwitchRepairVerdict,
+  modelSwitchShouldAutoForceRetry
+} from '../lib/modelSwitchProgress'
+import {
+  catalogueForModelRecovery,
+  refreshModelRecoveryCatalogue
+} from '../lib/modelRecovery'
+import { Select } from '../ui/Select'
 import { useModelGateway } from '../state/modelGateway'
 import { viewportAtZoom } from '../lib/zoomReset'
 import { containerOrigin, snapPointInRootSpace } from '../lib/gridSnap'
@@ -319,12 +340,15 @@ import {
   guardConcurrentRestart,
   planBulkRestart,
   clearEnvEligibility,
+  RESTART_REFUSAL_COPY,
   restartEligibility,
   restartSessionId,
   settleRestart,
   summarizeBulkRestart,
+  type AgentRestartFn,
   type BulkRestartPlan,
-  type RestartOutcome
+  type RestartOutcome,
+  type RestartRefusalReason
 } from '../terminal/agent-restart'
 import {
   planHibernation,
@@ -624,6 +648,13 @@ function noticeDwellMs(text: string): number {
  *  `confirmFlags`): ONE confirm at a time, decided at call time rather than at the next render. */
 interface ConfirmState {
   message: string
+  /** Optional content ABOVE the message by default (a grouped picker, a scope summary): rendered
+   *  verbatim inside the dialog box, exactly like ConfirmDialog's `body` prop. `bodyPosition`
+   *  moves it below the message when the message refers to the content ("the sessions below"). */
+  body?: ReactNode
+  /** 'below' renders `body` AFTER the message — the reading order the grouped model ask wants
+   *  (reason first, then the rows it refers to). Consent-style bodies stay above. */
+  bodyPosition?: 'above' | 'below'
   onConfirm: () => void
   /** Optional: runs when the user cancels/escapes (e.g. to reply 'denied' to an agent). */
   onCancel?: () => void
@@ -632,6 +663,11 @@ interface ConfirmState {
   danger?: boolean
   /** Report-only (an error, a "not ready yet"): one dismiss button, no destructive default. */
   alert?: boolean
+  /** When false, neither button takes autoFocus — for a dialog the APP raised without the user
+   *  asking (the grouped model ask surfaces on a discovery refresh): a focused button would let
+   *  the next Enter/Space natively activate one they never saw. Undefined keeps autofocus, the
+   *  historical behavior. */
+  autoFocusButtons?: boolean
   /** Set when an AGENT asked for this dialog: it is answered by an explicit click, never by an
    *  Enter the user aimed at their terminal (see components/confirm-key). */
   requestedBy?: string
@@ -773,6 +809,43 @@ const ZOOM_STEP_DURATION_MS = 150
  */
 const resumeCardShown = new Set<string>()
 
+/** Model-change prompts already raised, per node+model+trigger-version. The map is the tombstone:
+ *  it is written when a dialog is ANSWERED (so the grouped ask carries only the pairs the user has
+ *  not yet answered), kept on cancel (a "Keep it" answer is durable for this catalogue) and kept
+ *  after a successful restart, so the same catalogue state does not re-raise every effect run.
+ *  Window and launch-shape triggers include the newly discovered value in the key: answering one
+ *  change must not permanently silence a later, different provider change for the same model. */
+const modelGoneAsked = new Map<string, boolean>()
+
+/** Per-session first observation for nodes created before launch windows were persisted. */
+const modelWindowSeen = new Map<string, number>()
+
+/**
+ * Whether a grouped model-restart batch has UNRESOLVED rows — pending spinner, in-flight, or a
+ * failure the user has not yet clicked away. While truthy, the detection passes
+ * (`considerModelAvailability` via the discovery-refresh effect and the window-focus listener)
+ * hold off re-firing the dialog: a batch whose rows are mid-restart, or whose failures are
+ * being worked, must not be contradicted or nagspammed by a second ask for the same nodes.
+ * Written by the batch (set/cleared in `runRestart`) and read via the focus effect's ref (the
+ * effect's deps do not include the strip). A module-level mirror of the state the strip's
+ * render owns — the strip is the single owner of this latch.
+ */
+type ModelSwitchRepair = {
+  retry: (id: string) => void
+  retryAll: () => void
+  /** Spend ONE failed row's ask (its per-row ✕): the tombstone "Keep it"/Dismiss writes. */
+  spend?: (id: string) => void
+  clear: () => void
+}
+
+/**
+ * The live pick of the grouped "model is gone" dialog, threaded from its <select>'s onChange to
+ * the confirm handler — the same click-time read the model <select> in the node menus uses, with
+ * no React state in between (a useState here would mean an extra whole-canvas render per open of
+ * a dialog the confirm closure can read directly). Null whenever no such dialog is open.
+ */
+let modelGonePick: { pickedId?: string } | null = null
+
 const CONTROL_TRAVEL_TIMEOUT_MS = 8000
 const CONTROL_TRAVEL_POLL_MS = 60
 async function waitForCanvasNode(
@@ -787,6 +860,29 @@ async function waitForCanvasNode(
   }
 }
 
+/** After activating a node's owning project, how long to wait for ITS mount to register the
+ *  restart closure. The project load effect hydrates React Flow within a tick, then the
+ *  TerminalNode mount spawns/adopts the PTY and registers — the same window the canvas-control
+ *  machinery `waitForCanvasNode`s over, plus a little for the mount itself. The registration
+ *  (not the mount) is the gate: a stale closure resolvable earlier is fine, one later is what
+ *  fails the batch item, not the batch. */
+const RESTART_REGISTER_TIMEOUT_MS = CONTROL_TRAVEL_TIMEOUT_MS
+const RESTART_REGISTER_POLL_MS = 120
+function waitRestartRegistered(nodeId: string): Promise<AgentRestartFn | undefined> {
+  return new Promise((resolve) => {
+    let elapsed = 0
+    const tick = (): void => {
+      const fn = agentRestartFn(nodeId)
+      if (fn || elapsed >= RESTART_REGISTER_TIMEOUT_MS) {
+        resolve(fn)
+        return
+      }
+      elapsed += RESTART_REGISTER_POLL_MS
+      setTimeout(tick, RESTART_REGISTER_POLL_MS)
+    }
+    tick()
+  })
+}
 // A "spawned by" / "sequenced after" rope: control-capable agent → node it opened, browser popup →
 // opener, or `--after` dependency → the armed node. Display-only (never a context link) but
 // persisted per project as `ropes`, so the lineage survives restarts. Selectable; removed with ⌫ /
@@ -1209,6 +1305,41 @@ export function Canvas() {
   // The closed-session entry whose transcript is on screen (issue #531), or null. A SNAPSHOT of
   // the ledger row, not a reference into the store: reading it needs only the pointer it carries.
   const [closedTranscript, setClosedTranscript] = useState<ClosedSessionEntry | null>(null)
+  // Per-session LIVE progress for the grouped model restart (the row spinners the user asked
+  // for). Set when the batch begins; each row advances as its own restart resolves — spinner
+  // while in flight, ✓/✗ when done — and the whole strip clears only when EVERY row reached a
+  // terminal outcome (a completed-selectable state the user explicitly required: never dismiss
+  // over a session whose CLI is still cycling). Null = nothing running.
+  const [modelSwitchProgress, setModelSwitchProgress] = useState<{
+    target: string
+    rows: {
+      id: string
+      label: string
+      projectName: string
+      state: 'pending' | 'running' | 'ok' | 'failed'
+      /** Set on failure: WHY the row failed, verbatim (fail loud — never swallowed). */
+      detail?: string
+      /** Mismatch this row was flagged for — shown as current → desired in the dialog AND on
+       *  a failed row, so the user can see what was being fixed when it failed. */
+      from?: string
+      reason?: 'gone' | 'win' | 'shape'
+    }[]
+  } | null>(null)
+  // The live rows, ref-held: `runRestart`'s repair handlers (per-row Retry buttons) read the
+  // CURRENT failed set at click time — a closure taken in the batch would go stale the moment
+  // a retry flipped a row to `running`.
+  const modelSwitchProgressStateRef = useRef(modelSwitchProgress)
+  modelSwitchProgressStateRef.current = modelSwitchProgress
+  // Every batch gets a generation. A success timer from batch N must never clear batch N+1 if a
+  // fresh detection starts during the 1.8s success dwell — especially when N+1 contains failures.
+  const modelSwitchProgressRunRef = useRef(0)
+  // The popup and its imperative repair closure must share the Canvas instance. These used to be
+  // module globals; React Fast Refresh preserved the failed popup state while re-evaluating the
+  // module and resetting its controller to null, leaving the always-visible "Retry failed" button
+  // wired to a silent optional-chain no-op. Refs survive ordinary renders/Fast Refresh together
+  // with the popup and are discarded together when this Canvas genuinely unmounts.
+  const modelSwitchRepairRef = useRef<ModelSwitchRepair | null>(null)
+  const modelSwitchLatchRef = useRef(modelSwitchProgress !== null)
   // Node to center once its project finishes loading (cross-project notification click).
   const pendingFocusRef = useRef<string | null>(null)
   // One-shot: the next active-project load keeps the CURRENT camera instead of applying the
@@ -1331,6 +1462,7 @@ export function Canvas() {
   const gatewayModels = useModelGateway((s) => s.models)
   const gatewayStatus = useModelGateway((s) => s.status)
   const gatewayError = useModelGateway((s) => s.error)
+  const gatewayDiscoveryAt = useModelGateway((s) => s.discoveryAt)
   const discoverModels = useModelGateway((s) => s.discover)
   const clearModels = useModelGateway((s) => s.clear)
 
@@ -2517,6 +2649,756 @@ export function Canvas() {
   // ride the same debounced whole-file save.
   useEffect(() => registerWorkspaceDirty(markDirty), [markDirty])
 
+  // A model the catalogue no longer lists (gateway dropped/renamed it; discovery refreshed) leaves
+  // every node pinned to it launching an id the provider will refuse — and a model the gateway
+  // NOW SERVES with a different context window leaves every large-context session compacting
+  // against a dead autocompact window. ONE grouped dialog asks about every affected session at
+  // once, with a single model pick they all restart onto — per-node asks would both stack and
+  // nag. The restart itself is the EXISTING single-node in-place path (`agentRestartFn` +
+  // `guardConcurrentRestart` inside each node's own closure), run sequentially here — no new
+  // restart machinery: in particular it refuses a busy/blocked session per restartEligibility,
+  // never types an exit command into a permission dialog.
+  //
+  // Detection evaluates only a catalogue that has already landed. Settings changes and boot use
+  // the debounced prime effect above; focus starts one fresh request, whose `discoveryAt` update
+  // invokes this evaluator. Empty/error/loading snapshots cannot judge and never recurse.
+  const considerModelAvailability = useCallback((): void => {
+    // An unresolved batch owns the conversation (rows pending/running, or failures the user is
+    // resolving): no second ask while the strip is live. The focus listener ALSO checks this,
+    // so a focus that lands mid-batch is held off as well. Written by `runRestart`.
+    if (modelSwitchLatchRef.current) {
+      modelRespawnTrace('detection.skipped', { reason: 'progress-latched' })
+      return
+    }
+    const st = useModelGateway.getState()
+    const gatewayModels = catalogueForModelRecovery(st)
+    modelRespawnTrace('detection.begin', {
+      gatewayStatus: st.status,
+      cachedModelCount: st.models.length,
+      activeNodeCount: nodesRef.current.length
+    })
+    if (!gatewayModels) {
+      modelRespawnTrace('detection.aborted', {
+        reason: 'catalogue-unavailable',
+        gatewayStatus: st.status,
+        modelCount: st.models.length
+      })
+      return
+    }
+    const gatewayStatus = st.status
+
+    /** ONE dialog for the WHOLE pass, not one per node: `setConfirm` REPLACES an open dialog
+     *  (`confirmFlags` exists exactly for that), so per-node asks would orphan each other.
+     *  Affected sessions are collected first, then presented together with a single model pick
+     *  that all of them restart onto. */
+    const affected: {
+      id: string
+      model: string
+      label: string
+      ownerProjectId: string
+      projectName: string
+      live: boolean
+      agentId: AgentId
+      reason: ModelRecoveryReason
+      /** Versioned tombstone: later changes on the same session/model ask independently. */
+      askKey: string
+    }[] = []
+    const observeLegacyWindow = (id: string, model: string): boolean => {
+      const key = modelWindowSessionKey(id, model)
+      const change = modelWindowChange(model, gatewayModels, modelWindowSeen.get(key))
+      if (change.fresh && change.contextWindow !== '') {
+        modelWindowSeen.set(key, change.contextWindow)
+      }
+      return change.changed
+    }
+    const askKeyFor = (
+      id: string,
+      model: string,
+      agentId: AgentId,
+      reason: ModelRecoveryReason
+    ): string => {
+      const version =
+        reason === 'shape'
+          ? claudeAutocompactFor(agentId, model, gatewayModels).modelId ?? model
+          : reason === 'win'
+            ? modelContextWindow(model, gatewayModels) ?? 'unknown'
+            : 'absent'
+      return modelRecoverySessionKey(id, model, reason, version)
+    }
+    /** Shared candidate gates for live and serialized project nodes. Legacy nodes may use their
+     *  requested model plus a per-session window ledger for detection; cure still requires the
+     *  actual record written by the accepted relaunch. */
+    const consider = (
+      id: string,
+      agentId: AgentId | undefined,
+      currentModel: unknown,
+      currentLaunchModel: unknown,
+      currentLaunchContextWindow: unknown,
+      persistedSessionId: unknown,
+      ownerProjectId: string,
+      label: string,
+      projectName: string,
+      source: 'active-project' | 'other-project'
+    ): void => {
+      if (!agentId || !canSwitchModel(agentId)) return
+      const status = useAgentStatus.getState().byId[id]
+      const gate = restartEligibility(
+        agentId,
+        status?.state,
+        restartSessionId(status?.sessionId, persistedSessionId)
+      )
+      if (!gate.ok) return
+
+      const launchModel =
+        typeof currentLaunchModel === 'string' ? currentLaunchModel : undefined
+      const launchContextWindow =
+        typeof currentLaunchContextWindow === 'number'
+          ? currentLaunchContextWindow
+          : undefined
+      const requestedModel = typeof currentModel === 'string' ? currentModel : undefined
+      const observedModel = launchModel ?? requestedModel
+      if (!observedModel) return
+      const hasPersistedWindow =
+        typeof launchContextWindow === 'number' &&
+        Number.isFinite(launchContextWindow) &&
+        launchContextWindow > 0
+      let reason: ModelRecoveryReason | null
+      if (hasPersistedWindow) {
+        reason = modelRecoveryTrigger(agentId, observedModel, launchContextWindow, gatewayModels)
+      } else {
+        const availability = modelAvailability(observedModel, gatewayModels)
+        if (availability.unavailable) reason = 'gone'
+        else if (observeLegacyWindow(id, observedModel)) reason = 'win'
+        else if (modelLaunchShapeMismatch(agentId, observedModel, gatewayModels)) reason = 'shape'
+        else reason = null
+      }
+      if (!reason || !modelsForAgent(gatewayModels, agentId).length) return
+
+      modelRespawnTrace('detection.candidate', {
+        nodeId: id,
+        agentId,
+        source,
+        trigger: reason === 'win' ? 'window' : reason,
+        currentModel: observedModel,
+        projectId: ownerProjectId
+      })
+      affected.push({
+        id,
+        model: observedModel,
+        label,
+        ownerProjectId,
+        projectName,
+        live: nodesProjectIdRef.current === ownerProjectId,
+        agentId,
+        reason,
+        askKey: askKeyFor(id, observedModel, agentId, reason)
+      })
+    }
+
+    // The active canvas first, then every other readable local/SSH project. Relay sessions run on
+    // another core and must never receive this machine's gateway selection.
+    const seen = new Set<string>()
+    for (const n of nodesRef.current) {
+      seen.add(n.id)
+      consider(
+        n.id,
+        restartAgentIdOf(n),
+        n.data.agentModel,
+        n.data.agentLaunchModel,
+        n.data.agentLaunchContextWindow,
+        n.data.agentSessionId,
+        nodesProjectIdRef.current ?? '',
+        (typeof n.data.title === 'string' && n.data.title) || n.id,
+        '',
+        'active-project'
+      )
+    }
+    const { projects } = useProjects.getState()
+    for (const project of projects) {
+      if (!project.id || project.id === nodesProjectIdRef.current) continue
+      if (project.remote || project.unavailable) continue
+      if (sessionForProject(project.id).source !== 'local') continue
+      for (const node of project.nodes) {
+        if (seen.has(node.id) || (node.kind ?? 'terminal') !== 'terminal') continue
+        consider(
+          node.id,
+          createdAgentId(node),
+          node.agentModel,
+          node.agentLaunchModel,
+          node.agentLaunchContextWindow,
+          node.agentSessionId,
+          project.id,
+          node.title || node.id,
+          project.name,
+          'other-project'
+        )
+      }
+    }
+    // Per-pair tombstones: a pair already ASKED (kept on cancel, so "Keep it" is durable for this
+    // catalogue) is left out of the group, and if nothing new remains there is no dialog at all.
+    // GONE, WINDOW-CHANGE and SHAPE asks are tombstoned separately — a "keep it" answered for one
+    // reason must not silence the other; a session whose model both left the catalogue AND
+    // changed size could otherwise be asked once and then never again for either.
+    const unasked = affected.filter(({ askKey }) => !modelGoneAsked.has(askKey))
+    modelRespawnTrace('detection.complete', {
+      gatewayStatus,
+      modelCount: gatewayModels.length,
+      affectedCount: affected.length,
+      unaskedCount: unasked.length
+    })
+    if (!unasked.length) return
+    // The union of models every restartable agent base can switch to. One list, because the same
+    // gateway serves them all; a per-capable-base filter would need a second select.
+    const choices = [...new Set(gatewayModels.map((m) => m.id))]
+    // The user's configured default gateway model is the recommendation — sessions restart onto
+    // what new sessions would launch on, not whatever discovery happened to list first. Falls
+    // back to the first entry when the default is unset or left the catalogue itself.
+    const defaultModel = useSettings.getState().settings.modelGatewayDefaultModel
+    const initialPick = defaultModel && choices.includes(defaultModel) ? defaultModel : choices[0]
+    modelGonePick = { pickedId: initialPick }
+    /** Serialized restart, one node at a time, with PER-ROW live progress: each row shows its
+     *  own spinner while its CLI cycles and holds its ✓/✗ only when that row is done. The user
+     *  explicitly required "all complete before dismissing", so the strip (which survives the
+     *  dialog closing) clears only when every row reached a terminal outcome. */
+    const runRestart = async (target: string): Promise<void> => {
+      const progressRun = ++modelSwitchProgressRunRef.current
+      let resolvedDismissScheduled = false
+      let ok = 0
+      let kept = 0
+      let failed = 0
+      // Blocks Retry/Retry failed while the original serialized pass (or another retry sweep) is
+      // still moving between projects. A second sweep would race active-project travel and can
+      // invoke a node's closure in the wrong canvas.
+      let repairSweepRunning = true
+      // Latch the detection off for the whole batch: a pass whose rows are pending/running (or
+      // left failed for the user to resolve) must not be contradicted by a second ask.
+      modelSwitchLatchRef.current = true
+      modelRespawnTrace('batch.begin', {
+        run: progressRun,
+        targetModel: target,
+        rowCount: unasked.length
+      })
+      const initialProgress: NonNullable<typeof modelSwitchProgress> = {
+        target,
+        rows: unasked.map((item) => ({
+          id: item.id,
+          label: item.label,
+          projectName: item.projectName,
+          state: 'pending' as const,
+          from: item.model,
+          reason: item.reason
+        }))
+      }
+      // Publish the ref synchronously as well as React state: the first `repairOne` starts in this
+      // same async turn, before a render is guaranteed, and its running state must not target the
+      // previous batch/null. Every writer below follows this rule so completion checks are live.
+      modelSwitchProgressStateRef.current = initialProgress
+      setModelSwitchProgress(initialProgress)
+      // The view follows each owner's activation below; when the batch needed any travel, hand
+      // the canvas back to where the user was. Safe AFTER the loop: every restart has resolved,
+      // and switching away just parks the (tmux-backed) terminal — its respawn finishes
+      // underneath, or re-adopts on return.
+      const homeProjectId = useProjects.getState().activeProjectId
+      let traveled = false
+      const setRowState = (
+        id: string,
+        state: 'running' | 'ok' | 'failed',
+        detail?: string
+      ): void => {
+        modelRespawnTrace('progress.row', {
+          run: progressRun,
+          nodeId: id,
+          state,
+          hasDetail: detail !== undefined
+        })
+        const cur = modelSwitchProgressStateRef.current
+        if (!cur) return
+        const next = {
+          ...cur,
+          rows: cur.rows.map((r) =>
+            r.id === id ? { ...r, state, detail: detail ?? r.detail } : r
+          )
+        }
+        modelSwitchProgressStateRef.current = next
+        setModelSwitchProgress(next)
+      }
+      /** One row's repair (retry after a failure, or the first attempt — the batch loop below
+       *  DELEGATES to this so a retry and an original run share one code path; two copies of a
+       *  restart choreography are exactly the drift this file's invariants warn about). The
+       *  same travel + registered-closure path, for that one node, onto the SAME target model;
+       *  the shared counters (`ok/kept/failed`) inflate as rows resolve. */
+      /** Called after ANY row resolution (first pass or retry): when NO row is failed any
+       *  more, the strip's job is done — dwell a beat so the last ✓ is readable, then clear
+       *  it and release the detection latch + repair handlers. Idempotent (a second call
+       *  with failures still present does nothing). */
+      const finishIfResolved = (): void => {
+        const rows = modelSwitchProgressStateRef.current?.rows
+        if (!modelSwitchProgressCanAutoDismiss(rows) || resolvedDismissScheduled) {
+          modelRespawnTrace('progress.retain', {
+            run: progressRun,
+            rowCount: rows?.length ?? 0,
+            failedCount: rows?.filter((row) => row.state === 'failed').length ?? 0,
+            alreadyScheduled: resolvedDismissScheduled
+          })
+          return
+        }
+        resolvedDismissScheduled = true
+        modelSwitchLatchRef.current = false
+        modelSwitchRepairRef.current = null
+        modelRespawnTrace('progress.dismiss-scheduled', { run: progressRun, delayMs: 1800 })
+        setTimeout(() => {
+          if (modelSwitchProgressRunRef.current !== progressRun) {
+            modelRespawnTrace('progress.dismiss-cancelled', {
+              run: progressRun,
+              currentRun: modelSwitchProgressRunRef.current
+            })
+            return
+          }
+          // Re-check the LIVE rows. This protects against any repair/state transition that lands
+          // after the timer was armed and makes the timer incapable of hiding unresolved work.
+          setModelSwitchProgress((cur) => {
+            const next = modelSwitchProgressCanAutoDismiss(cur?.rows) ? null : cur
+            modelRespawnTrace(next ? 'progress.dismiss-blocked' : 'progress.dismissed', {
+              run: progressRun,
+              rowCount: cur?.rows.length ?? 0
+            })
+            modelSwitchProgressStateRef.current = next
+            return next
+          })
+        }, 1800)
+      }
+      const actualLaunchRecord = (
+        item: typeof unasked[number]
+      ): { model?: string; contextWindow?: number } => {
+        // TerminalNode owns these fields. Read its live React Flow node when its project is still
+        // mounted; if ownership changed while the restart awaited, read the project's serialized
+        // record. Never replace either with a catalogue-derived expectation.
+        if (nodesProjectIdRef.current === item.ownerProjectId) {
+          const live = getNodes().find((node) => node.id === item.id) as CanvasNode | undefined
+          if (live) {
+            return {
+              model: live.data.agentLaunchModel as string | undefined,
+              contextWindow: live.data.agentLaunchContextWindow as number | undefined
+            }
+          }
+          return {}
+        }
+        const saved = useProjects
+          .getState()
+          .projects.find((project) => project.id === item.ownerProjectId)
+          ?.nodes.find((node) => node.id === item.id)
+        return {
+          model: saved?.agentLaunchModel,
+          contextWindow: saved?.agentLaunchContextWindow
+        }
+      }
+      const repairOne = async (
+        item: typeof unasked[number],
+        autoForceRetry = false
+      ): Promise<void> => {
+        modelRespawnTrace('repair.begin', {
+          run: progressRun,
+          nodeId: item.id,
+          agentId: item.agentId,
+          targetModel: target,
+          live: item.live,
+          projectId: item.ownerProjectId
+        })
+        try {
+          setRowState(item.id, 'running')
+          let fn = agentRestartFn(item.id)
+          // Re-evaluate ownership NOW. A failed-row click can move the user between projects before
+          // Retry/Retry failed, so the batch's original `item.live` snapshot is stale by design.
+          if (
+            !fn &&
+            item.ownerProjectId &&
+            nodesProjectIdRef.current !== item.ownerProjectId
+          ) {
+            traveled = true
+            modelRespawnTrace('repair.travel', {
+              run: progressRun,
+              nodeId: item.id,
+              projectId: item.ownerProjectId
+            })
+            travelToProjectRef.current(item.ownerProjectId)
+            fn = await waitRestartRegistered(item.id)
+            modelRespawnTrace('repair.registration-wait-complete', {
+              run: progressRun,
+              nodeId: item.id,
+              registered: !!fn
+            })
+          }
+          if (!fn) {
+            failed++
+            modelRespawnTrace('repair.failed', {
+              run: progressRun,
+              nodeId: item.id,
+              reason: 'restart-not-registered'
+            })
+            setRowState(item.id, 'failed', 'no restart closure registered — the session’s node never mounted')
+            return
+          }
+          modelRespawnTrace('repair.invoke', { run: progressRun, nodeId: item.id })
+          // `lastRestartRefusal` is a transient outcome side channel, not durable node state.
+          // Clear the prior attempt before invoking this one: otherwise a plain timeout after an
+          // earlier agent-not-running failure can inherit that stale reason and incorrectly earn
+          // the bounded automatic force retry (or show the previous detail on this row).
+          useAgentStatus.getState().setLastRestartRefusal(item.id, null)
+          let o = await fn(undefined, target)
+          let refusal = useAgentStatus.getState().byId[item.id]?.lastRestartRefusal
+          modelRespawnTrace('repair.outcome', {
+            run: progressRun,
+            nodeId: item.id,
+            outcome: o,
+            refusalReason: refusal?.reason,
+            attempt: 1
+          })
+          if (modelSwitchShouldAutoForceRetry(autoForceRetry, o, refusal?.reason)) {
+            // The first replacement shell lived but its separately tracked agent child exited.
+            // Re-run the SAME registered node closure once — a bounded automatic form of the
+            // Retry button the user observed curing transient startup races.
+            let retryFn = agentRestartFn(item.id)
+            if (!retryFn) retryFn = await waitRestartRegistered(item.id)
+            modelRespawnTrace('repair.auto-force-retry', {
+              run: progressRun,
+              nodeId: item.id,
+              registered: !!retryFn
+            })
+            if (retryFn) {
+              useAgentStatus.getState().setLastRestartRefusal(item.id, null)
+              o = await retryFn(undefined, target)
+              refusal = useAgentStatus.getState().byId[item.id]?.lastRestartRefusal
+              modelRespawnTrace('repair.outcome', {
+                run: progressRun,
+                nodeId: item.id,
+                outcome: o,
+                refusalReason: refusal?.reason,
+                attempt: 2
+              })
+            }
+          }
+          if (o === 'restarted') {
+            const record = actualLaunchRecord(item)
+            const currentCatalogue = catalogueForModelRecovery(useModelGateway.getState()) ?? []
+            const cure = modelRecoveryCure(
+              item.reason,
+              item.agentId,
+              record.model,
+              record.contextWindow,
+              currentCatalogue
+            )
+            const verdict = modelSwitchRepairVerdict(o, cure.cured)
+            modelRespawnTrace(cure.cured ? 'repair.cure-verified' : 'repair.cure-not-verified', {
+              run: progressRun,
+              nodeId: item.id,
+              trigger: item.reason === 'win' ? 'window' : item.reason,
+              appliedModel: record.model
+            })
+            if (verdict.state === 'ok') {
+              ok++
+              setRowState(item.id, 'ok')
+              if (verdict.spendAsk) modelGoneAsked.set(item.askKey, true)
+            } else {
+              failed++
+              setRowState(item.id, 'failed', cure.detail ?? 'the restart did not update its launch record')
+            }
+          } else if (o === 'exit-timeout') {
+            failed++
+            // A 'threw' refusal (settleRestart / the phases) put the verbatim exception on the
+            // side channel — render THAT, not the generic timeout wording.
+            setRowState(
+              item.id,
+              'failed',
+              refusal?.detail
+                ? refusal.detail
+                : 'the CLI did not exit in time — its pane may hold a stuck process or an unanswered prompt'
+            )
+          } else {
+            kept++
+            // ONE refusal, ONE reason: the closure wrote `lastRestartRefusal` before its early
+            // return; the row shows the reason's own sentence — plus the site's own detail
+            // (the pane content, the missing var names), not a five-way "or".
+            if (refusal) {
+              setRowState(
+                item.id,
+                'failed',
+                refusal.detail
+                  ? `${RESTART_REFUSAL_COPY[refusal.reason]} (${refusal.detail})`
+                  : RESTART_REFUSAL_COPY[refusal.reason]
+              )
+            } else {
+              // No side-channel entry at all: the closure ran before that writer existed.
+              // Say so — the old bare fallback read as "nothing happened".
+              setRowState(item.id, 'failed', 'refused with no recorded reason — restart again to capture it')
+            }
+          }
+        } catch (err) {
+          failed++
+          modelRespawnTrace('repair.threw', {
+            run: progressRun,
+            nodeId: item.id,
+            errorKind: modelRespawnErrorKind(err)
+          })
+          const text = err instanceof Error ? err.message : String(err)
+          setRowState(item.id, 'failed', text)
+        } finally {
+          // Includes registration/travel failures and the no-closure early return above. A row
+          // must never bypass completion bookkeeping and strand the sweep latch forever.
+          finishIfResolved()
+        }
+      }
+      // The repair handlers the strip's buttons call: retry re-runs ONLY failed rows (per-row
+      // or all), serially, reusing repairOne so a retry lands the SAME closure, writes the SAME
+      // counters and arms the SAME tombstone. Clear spends the failed rows' asks (the same
+      // tombstone the "Keep it" path writes — a user who chooses dismiss has answered the ask).
+      const failedRowIds = (): string[] =>
+        modelSwitchProgressStateRef.current?.rows.filter((r) => r.state === 'failed').map((r) => r.id) ?? []
+      // Spend ONE row's ask (its per-row ✕): the same tombstone "Keep it"/Dismiss writes — the
+      // user has answered this node's ask individually. The strip then clears if nothing failed
+      // remains.
+      const spendRow = (id: string): void => {
+        if (repairSweepRunning) {
+          modelRespawnTrace('progress.row-dismiss-blocked', { run: progressRun, nodeId: id })
+          return
+        }
+        modelRespawnTrace('progress.row-dismissed', { run: progressRun, nodeId: id })
+        const item = unasked.find((x) => x.id === id)
+        if (item) {
+          modelGoneAsked.set(item.askKey, true)
+        }
+        const cur = modelSwitchProgressStateRef.current
+        const next = cur ? { ...cur, rows: cur.rows.filter((r) => r.id !== id) } : cur
+        modelSwitchProgressStateRef.current = next
+        setModelSwitchProgress(next)
+        // A spend that empties the strip (or resolves it) releases the latch with it.
+        const rows = modelSwitchProgressStateRef.current?.rows
+        if (!rows?.some((r) => r.state === 'failed' || r.state === 'pending' || r.state === 'running')) {
+          modelSwitchLatchRef.current = false
+          modelSwitchRepairRef.current = null
+          modelSwitchProgressStateRef.current = null
+          setModelSwitchProgress(null)
+        }
+      }
+      modelSwitchRepairRef.current = {
+        retry: (id: string): void => {
+          const item = unasked.find((x) => x.id === id)
+          const retryable = !repairSweepRunning && !!item && failedRowIds().includes(id)
+          modelRespawnTrace('retry.one', {
+            run: progressRun,
+            nodeId: id,
+            retryable,
+            sweepRunning: repairSweepRunning
+          })
+          if (item && retryable) {
+            repairSweepRunning = true
+            void repairOne(item).finally(() => {
+              repairSweepRunning = false
+              modelRespawnTrace('retry.one-complete', { run: progressRun, nodeId: id })
+            })
+          }
+        },
+        retryAll: (): void => {
+          const retryable = unasked.filter((x) => failedRowIds().includes(x.id))
+          modelRespawnTrace('retry.all', {
+            run: progressRun,
+            rowCount: retryable.length,
+            sweepRunning: repairSweepRunning
+          })
+          if (repairSweepRunning || !retryable.length) return
+          repairSweepRunning = true
+          void (async () => {
+            try {
+              for (const item of retryable) await repairOne(item)
+            } finally {
+              repairSweepRunning = false
+              modelRespawnTrace('retry.all-complete', {
+                run: progressRun,
+                rowCount: retryable.length
+              })
+            }
+          })()
+        },
+        spend: spendRow,
+        clear: (): void => {
+          if (repairSweepRunning) {
+            modelRespawnTrace('progress.dismiss-all-blocked', { run: progressRun })
+            return
+          }
+          modelRespawnTrace('progress.dismiss-all', { run: progressRun })
+          for (const item of unasked) modelGoneAsked.set(item.askKey, true)
+          modelSwitchLatchRef.current = false
+          modelSwitchRepairRef.current = null
+          modelSwitchProgressStateRef.current = null
+          setModelSwitchProgress(null)
+        }
+      }
+      try {
+        for (const item of unasked) {
+          await repairOne(item, true)
+        }
+      } finally {
+        // `repairOne` catches expected restart/travel failures, but this outer release is the
+        // last-resort invariant: no unexpected exception may make every Retry button inert.
+        repairSweepRunning = false
+      }
+      modelGonePick = null
+      if (traveled && homeProjectId && useProjects.getState().activeProjectId !== homeProjectId) {
+        modelRespawnTrace('batch.return-home', { run: progressRun, projectId: homeProjectId })
+        travelToProjectRef.current(homeProjectId)
+      }
+      // Clear the strip ONLY when every live row is `ok`: a refusal is also rendered as a failed
+      // row but increments `kept`, not the `failed` counter — the old `if (!failed)` therefore
+      // auto-dismissed precisely the actionable refusals this strip exists to retain. A failed row stays on screen (with its error
+      // detail and its Retry button) until the user resolves or clicks it away — and while any
+      // failed row sits here, the detection holds off entirely (`modelSwitchLatch`), so focus
+      // does not re-fire the ask the user is already mid-resolving. Successes dwell 1.8s and
+      // clear; failures pin the whole strip. An all-✓ batch releases both with the strip.
+      finishIfResolved()
+      modelRespawnTrace('batch.complete', {
+        run: progressRun,
+        restartedCount: ok,
+        refusedCount: kept,
+        failedCount: failed,
+        retained: !!modelSwitchProgressStateRef.current?.rows.some((row) => row.state === 'failed')
+      })
+      if (ok > 0) {
+        setNotice({
+          kind: 'info',
+          text: `Switched ${ok} session${ok === 1 ? '' : 's'} to ${target}` +
+            (kept ? `, ${kept} refused (busy or not resumable)` : '') +
+            (failed ? `, ${failed} failed` : '') +
+            '.'
+        })
+      } else if (kept > 0 || failed > 0) {
+        setNotice({
+          kind: 'error',
+          text: `No session was verified on ${target}` +
+            (kept ? ` — ${kept} ${kept === 1 ? 'was' : 'were'} refused (busy or not resumable)` : '') +
+            (failed ? `, ${failed} failed` : '') +
+            '.'
+        })
+      }
+    }
+    // Which REASON dominates the ask decides the copy: a catalogue drop, a window delta and a
+    // launch-shape delta read very differently, and a mixed batch is rare enough to spell them.
+    const goneItems = unasked.filter((item) => item.reason === 'gone')
+    const windowItems = unasked.filter((item) => item.reason === 'win')
+    const shapeItems = unasked.filter((item) => item.reason === 'shape')
+    const reasonCount = [goneItems, windowItems, shapeItems].filter((items) => items.length).length
+    const message = reasonCount > 1
+      ? 'Gateway model availability or context settings changed for these sessions. ' +
+        'Pick a model and restart them; each conversation is resumed, nothing is deleted.'
+      : windowItems.length
+        ? `${[...new Set(windowItems.map((x) => x.model))].join(', ')} now reports a different context window than when ` +
+          'these sessions launched — their autocompact window is the old size until they restart. ' +
+          'Pick a model and restart them; each conversation is resumed, nothing is deleted.'
+        : shapeItems.length
+          ? 'These sessions were launched with different context settings than the gateway now reports. ' +
+            'Pick a model and restart them; each conversation is resumed, nothing is deleted.'
+          : `${[...new Set(goneItems.map((x) => x.model))].join(', ')} is no longer listed by the gateway. ` +
+            'Pick a replacement model and restart the sessions below; each conversation is resumed, nothing is deleted.'
+    setConfirm({
+      danger: false,
+      // The app raised this without the user asking (a discovery refresh or a window focus):
+      // neither button takes focus, so their next Enter/Space cannot natively activate one they
+      // never saw. Escape still cancels.
+      autoFocusButtons: false,
+      message,
+      confirmLabel: `Restart ${unasked.length} session${unasked.length === 1 ? '' : 's'}`,
+      cancelLabel: 'Keep it',
+      // The reason leads and the rows follow — the message says "the sessions below", so the
+      // list must actually sit below it (the default 'above' is the ConsentNotice's order).
+      bodyPosition: 'below',
+      body: (
+        <div className="confirm__model-list">
+          <ul className="confirm__model-rows">
+            {unasked.map((item) => (
+              <li key={item.id}>
+                <span className="confirm__model-label">
+                  {item.label}
+                  {item.projectName ? ` — ${item.projectName}` : ''}
+                </span>
+                {item.reason === 'win' && <span className="confirm__model-reason">window changed</span>}
+                {item.reason === 'shape' && (
+                  <span className="confirm__model-reason">launch context settings changed</span>
+                )}
+                <code className="confirm__model-id">{item.model}</code>
+              </li>
+            ))}
+          </ul>
+          <label className="confirm__model-pick">
+            Restart them on:
+            <Select
+              defaultValue={initialPick}
+              className="confirm__model-select"
+              onChange={(e) => {
+                if (modelGonePick) modelGonePick.pickedId = e.target.value
+              }}
+            >
+              {choices.map((id) => (
+                <option key={id} value={id}>
+                  {id}
+                </option>
+              ))}
+            </Select>
+          </label>
+        </div>
+      ),
+      onConfirm: () => {
+        const target = modelGonePick?.pickedId ?? initialPick
+        modelRespawnTrace('dialog.confirmed', { targetModel: target, rowCount: unasked.length })
+        modelGonePick = null
+        // Dismiss the dialog IMMEDIATELY — the restart is a long serialized batch (each node
+        // quits + recycles + resumes), and leaving this one up while it ran kept a modal over
+        // the canvas for its whole duration. Outcomes land in the notice.
+        setConfirm(null)
+        // Tombstones move into runRestart's per-item outcome handling below: a timed-out or
+        // refused exit must re-raise on the next trigger instead of having spent its ask.
+        void runRestart(target)
+      },
+      onCancel: () => {
+        modelRespawnTrace('dialog.cancelled', { rowCount: unasked.length })
+        modelGonePick = null
+        // "Keep it" IS an answer — so it still spends every ask (an unanswered dialog would
+        // re-nag on each focus/refresh). The restart path below, by contrast, tombstones per
+        // OUTCOME: a failed or timed-out restart leaves the ask open to re-raise.
+        for (const item of unasked) modelGoneAsked.set(item.askKey, true)
+        setNotice({
+          kind: 'info',
+          text: `Kept the session${unasked.length === 1 ? '' : 's'} on its current model. ` +
+            'Use “Switch model” on any node to change it.'
+        })
+      }
+    })
+    modelRespawnTrace('dialog.opened', {
+      rowCount: unasked.length,
+      choiceCount: choices.length,
+      initialModel: initialPick
+    })
+  }, [getNodes, setConfirm])
+  const considerRef = useRef(considerModelAvailability)
+  considerRef.current = considerModelAvailability
+  useEffect(() => {
+    const onFocus = (): void => {
+      if (confirmFlags.current.confirm) return
+      // An unresolved batch owns the conversation: rows are mid-restart or sitting failed for
+      // the user to resolve — detection must not re-fire and contradict them.
+      if (modelSwitchLatchRef.current) return
+      void refreshModelRecoveryCatalogue(
+        () => useSettings.getState().settings.modelGateway,
+        (gateway) => useModelGateway.getState().discover(gateway)
+      )
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [])
+  // Evaluate once when the current request lands. Ready-empty and error results stop here; they
+  // never initiate another request.
+  useEffect(() => {
+    if (confirmFlags.current.confirm) return
+    if (modelSwitchLatchRef.current) return
+    considerRef.current()
+  }, [gatewayDiscoveryAt])
   const perProjectKanbanOpen = useViewMode((s) => !!activeProjectId && viewFor(s, activeProjectId) === 'kanban')
   const rawGlobalKanban = useViewMode((s) => s.globalKanban)
   const omniEnabled = useSettings((s) => isOmniKanbanEnabled(s.settings))
@@ -14089,10 +14971,18 @@ export function Canvas() {
       {confirm && (
         <ConfirmDialog
           message={confirm.message}
+          body={confirm.body}
+          bodyPosition={confirm.bodyPosition}
           confirmLabel={confirm.confirmLabel}
           cancelLabel={confirm.cancelLabel}
           danger={confirm.danger}
           alert={confirm.alert}
+          // A dialog the app raised without the user asking (an agent verb, or the grouped model
+          // ask surfacing on a discovery refresh) must not steal focus: autoFocus makes the next
+          // Enter/Space NATIVELY activate a button the user never saw — a path confirm-key cannot
+          // preventDefault. App-raised and agent-raised dialogs keep focus off the buttons; a
+          // dialog the user opened themselves (a worktree remove, a delete) keeps the focus.
+          autoFocusButtons={confirm.autoFocusButtons}
           // The user did not open this one — an agent did. It appeared under their hands, so it is
           // answered by a click, never by a keystroke aimed somewhere else (components/confirm-key).
           enterConfirms={!confirm.requestedBy}
@@ -14102,6 +14992,191 @@ export function Canvas() {
             setConfirm(null)
           }}
         />
+      )}
+
+      {/* Live per-session progress for the grouped model restart — the strip SURVIVES the dialog
+          (the dialog dismisses on confirm, and the batch then runs to completion in the same
+          callback), one spinner per in-flight session, ✗/✓ per finished one. The user's explicit
+          requirement: every row completes before the strip goes away. The dialog is replaced by
+          the strip, not covered by it. */}
+      {modelSwitchProgress && (
+        <div className="model-switch-progress" role="status" aria-live="polite">
+          <div className="model-switch-progress__title">
+            Switching {modelSwitchProgress.rows.length} session{modelSwitchProgress.rows.length === 1 ? '' : 's'} to{' '}
+            <code>{modelSwitchProgress.target}</code>…
+          </div>
+          <ul className="model-switch-progress__rows">
+            {modelSwitchProgress.rows.map((row) => (
+              <li
+                key={row.id}
+                className={`model-switch-progress__row model-switch-progress__row--${row.state}`}
+              >
+                <span className="model-switch-progress__marker" aria-hidden>
+                  {row.state === 'running' && <span className="ui-spinner" />}
+                  {row.state === 'ok' && '✓'}
+                  {row.state === 'failed' && '✕'}
+                  {row.state === 'pending' && '·'}
+                </span>
+                {/* A failed row is one the user asked to SEE (the grouped ask's contract): its
+                    whole session+reason body is one travel button — another project first, then
+                    camera-centre. A tiny label-only target was easy to miss, especially beside
+                    Retry. Non-failed rows stay plain text: they are not work items. */}
+                {row.state === 'failed' ? (
+                  <button
+                    type="button"
+                    className="model-switch-progress__session"
+                    title="Go to this session on the canvas"
+                    onClick={() => {
+                      modelRespawnTrace('progress.row-opened', {
+                        run: modelSwitchProgressRunRef.current,
+                        nodeId: row.id
+                      })
+                      travelToNode(row.id)
+                    }}
+                  >
+                    <span className="model-switch-progress__label">
+                      {row.label}
+                      {row.projectName ? ` — ${row.projectName}` : ''}
+                    </span>
+                    {row.detail && (
+                      <span className="model-switch-progress__detail">
+                        {row.from
+                          ? `moving ${row.from} → ${modelSwitchProgress.target}: ${row.detail}`
+                          : row.detail}
+                      </span>
+                    )}
+                  </button>
+                ) : (
+                  <span className="model-switch-progress__label">
+                    {row.label}
+                    {row.projectName ? ` — ${row.projectName}` : ''}
+                  </span>
+                )}
+                <code className="model-switch-progress__model">
+                  {row.state === 'ok' ? modelSwitchProgress.target : ''}
+                </code>
+                {row.state === 'failed' && (
+                  <span className="model-switch-progress__row-actions">
+                    <button
+                      type="button"
+                      className="model-switch-progress__retry"
+                      disabled={modelSwitchProgress.rows.some(
+                        (candidate) => candidate.state === 'pending' || candidate.state === 'running'
+                      )}
+                      onClick={() => {
+                        const repair = modelSwitchRepairRef.current
+                        modelRespawnTrace('retry.one-clicked', {
+                          run: modelSwitchProgressRunRef.current,
+                          nodeId: row.id,
+                          controllerAvailable: !!repair
+                        })
+                        if (repair) repair.retry(row.id)
+                        else {
+                          modelSwitchLatchRef.current = false
+                          modelSwitchProgressStateRef.current = null
+                          setModelSwitchProgress(null)
+                          setNotice({
+                            kind: 'error',
+                            text: 'The restart controls were refreshed. The unresolved restart prompt will reopen so you can retry.'
+                          })
+                          setTimeout(() => considerRef.current(), 0)
+                        }
+                      }}
+                    >
+                      Retry
+                    </button>
+                    <button
+                      type="button"
+                      className="model-switch-progress__retry model-switch-progress__spend"
+                      title="Keep this session on its current model (spend this ask)"
+                      disabled={modelSwitchProgress.rows.some(
+                        (candidate) => candidate.state === 'pending' || candidate.state === 'running'
+                      )}
+                      onClick={() => {
+                        const repair = modelSwitchRepairRef.current
+                        modelRespawnTrace('progress.row-dismiss-clicked', {
+                          run: modelSwitchProgressRunRef.current,
+                          nodeId: row.id,
+                          controllerAvailable: !!repair
+                        })
+                        if (repair?.spend) repair.spend(row.id)
+                        else {
+                          modelSwitchLatchRef.current = false
+                          modelSwitchProgressStateRef.current = null
+                          setModelSwitchProgress(null)
+                          setNotice({
+                            kind: 'error',
+                            text: 'The restart controls were refreshed. The unresolved restart prompt will reopen.'
+                          })
+                          setTimeout(() => considerRef.current(), 0)
+                        }
+                      }}
+                    >
+                      ✕
+                    </button>
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+          {modelSwitchProgress.rows.some((r) => r.state === 'failed') && (
+            <div className="model-switch-progress__actions">
+              <button
+                type="button"
+                className="model-switch-progress__btn"
+                disabled={modelSwitchProgress.rows.some(
+                  (candidate) => candidate.state === 'pending' || candidate.state === 'running'
+                )}
+                onClick={() => {
+                  const repair = modelSwitchRepairRef.current
+                  modelRespawnTrace('retry.all-clicked', {
+                    run: modelSwitchProgressRunRef.current,
+                    controllerAvailable: !!repair,
+                    failedCount: modelSwitchProgress.rows.filter((row) => row.state === 'failed').length
+                  })
+                  if (repair) repair.retryAll()
+                  else {
+                    // A stale popup can survive a dev Fast Refresh from the old module-global
+                    // controller. Never silently no-op: discard only the orphaned UI (no asks are
+                    // spent), release detection, and immediately rebuild a live prompt/controller.
+                    modelSwitchLatchRef.current = false
+                    modelSwitchProgressStateRef.current = null
+                    setModelSwitchProgress(null)
+                    setNotice({
+                      kind: 'error',
+                      text: 'The restart controls were refreshed. The unresolved restart prompt will reopen so you can retry.'
+                    })
+                    setTimeout(() => considerRef.current(), 0)
+                  }
+                }}
+              >
+                Retry failed
+              </button>
+              <button
+                type="button"
+                className="model-switch-progress__btn model-switch-progress__btn--clear"
+                disabled={modelSwitchProgress.rows.some(
+                  (candidate) => candidate.state === 'pending' || candidate.state === 'running'
+                )}
+                onClick={() => {
+                  const repair = modelSwitchRepairRef.current
+                  modelRespawnTrace('progress.dismiss-all-clicked', {
+                    run: modelSwitchProgressRunRef.current,
+                    controllerAvailable: !!repair
+                  })
+                  if (repair) repair.clear()
+                  else {
+                    modelSwitchLatchRef.current = false
+                    modelSwitchProgressStateRef.current = null
+                    setModelSwitchProgress(null)
+                  }
+                }}
+              >
+                Dismiss list
+              </button>
+            </div>
+          )}
+        </div>
       )}
 
       {pendingPeer && (

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -1349,6 +1349,7 @@ export function Canvas() {
   }, [
     settings.modelGateway.baseUrl,
     settings.modelGateway.apiKey,
+    settings.modelGateway.discoveryPath,
     discoverModels,
     clearModels
   ])

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -2218,6 +2218,7 @@ export function Canvas() {
               title: n.data.title ?? n.id,
               color: n.data.color ?? '#888',
               agentId: n.data.agentId,
+              agentLaunchContextWindow: n.data.agentLaunchContextWindow,
               // The node's creation-time account, for the sidebar row's account chip (the
               // serialized nodes of inactive projects carry it already).
               accountId: n.data.accountId,

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -318,6 +318,7 @@ import {
   agentRestartFn,
   guardConcurrentRestart,
   planBulkRestart,
+  clearEnvEligibility,
   restartEligibility,
   restartSessionId,
   settleRestart,
@@ -412,8 +413,10 @@ import {
   canRename,
   canContextLink,
   canSwitchModel,
+  capabilityAgentId,
   createdAgentId,
   resumeCommand,
+  vanillaEnvStripPattern,
   AGENT_CONFIG,
   BUILTIN_AGENT_IDS,
   type AgentId,
@@ -6108,20 +6111,23 @@ export function Canvas() {
     nodeId: string,
     targetAgentId?: AgentId,
     targetModel?: string,
-    restartShell?: boolean
+    restartShell?: boolean,
+    clearEnv?: boolean
   ) => {
     const fn = agentRestartFn(nodeId)
     if (!fn) return // node unmounted between opening the menu and clicking
-    const action = restartShell
-      ? 'Restart'
-      : targetModel
-        ? 'Model switch'
-        : targetAgentId
-          ? 'Reopen'
-          : 'Restart'
+    const action = clearEnv
+      ? 'Restart on subscription'
+      : restartShell
+        ? 'Restart'
+        : targetModel
+          ? 'Model switch'
+          : targetAgentId
+            ? 'Reopen'
+            : 'Restart'
     let outcome: RestartOutcome
     try {
-      outcome = await fn(targetAgentId, targetModel, restartShell)
+      outcome = await fn(targetAgentId, targetModel, restartShell, clearEnv)
     } catch {
       // The transport under the restart threw (a relay socket still CONNECTING rejects the very
       // first write). Unhandled, this rejection made the action a silent no-op — the user clicked
@@ -6165,11 +6171,13 @@ export function Canvas() {
       outcome === 'restarted'
         ? {
             kind: 'info',
-            text: targetModel
-              ? `Switched to ${targetModel} — conversation resumed.`
-              : targetLabel
-                ? `Session reopened as ${targetLabel} — conversation resumed.`
-                : 'Agent restarted — conversation resumed.'
+            text: clearEnv
+              ? 'Restarted on subscription — conversation resumed.'
+              : targetModel
+                ? `Switched to ${targetModel} — conversation resumed.`
+                : targetLabel
+                  ? `Session reopened as ${targetLabel} — conversation resumed.`
+                  : 'Agent restarted — conversation resumed.'
           }
         : outcome === 'exit-timeout'
           ? {
@@ -7903,6 +7911,44 @@ export function Canvas() {
                     : 'Quits the CLI, respawns a fresh shell (picks up env/profile changes), then resumes.'),
                 onClick: () => void restartAgentNode(ids[0], undefined, undefined, true)
               },
+              // "Restart on subscription": recycle the session VANILLA — strip the gateway + inherited
+              // provider env so the agent falls back to its OWN default provider (Claude's
+              // subscription, Copilot's GitHub routing). No model/agent change; the cold-restore
+              // auto-resume keeps the same conversation. Shown only for an agent with a strip set
+              // (claude/codex/copilot builtins). Gated on `clearEnvEligibility`, NOT the shared `why`:
+              // clearEnv uses `terminateForeground` (SIGTERM by PID, no `/exit` into a dialog), so it
+              // is safe to interrupt a `working`/`blocked` session — which is its primary scenario
+              // (gateway overload shows up mid-turn, and "wait for the turn" is impossible when the
+              // gateway is down). Refused over relay for the same reason "Restart agent and shell" is
+              // — the stripped env belongs to this machine's settings store, not the host's core.
+              // Hideable (unlike the recovery restart rows above), because it is a convenience, not a
+              // recovery lever.
+              ...(vanillaEnvStripPattern(sourceAgentId ?? ('claude' as AgentId)) &&
+              !isHidden('vanilla-restart', hidden)
+                ? [
+                    {
+                      label:
+                        capabilityAgentId(sourceAgentId ?? ('claude' as AgentId)) === 'copilot'
+                          ? 'Restart on Copilot defaults'
+                          : 'Restart on subscription',
+                      icon: <IconPower />,
+                      disabled:
+                        !clearEnvEligibility(sourceAgentId, sessionId).ok ||
+                        session.source === 'relay' ||
+                        !agentRestartFn(ids[0]),
+                      hint:
+                        !clearEnvEligibility(sourceAgentId, sessionId).ok
+                          ? 'Nothing to resume yet — this session has not reported an id.'
+                          : session.source === 'relay'
+                            ? 'Restart the shell on the machine hosting this relay session.'
+                            : !agentRestartFn(ids[0])
+                              ? 'This terminal is not attached right now.'
+                              : 'Restarts the session with gateway/provider env stripped — uses your own subscription/credentials.',
+                      onClick: () =>
+                        void restartAgentNode(ids[0], undefined, undefined, undefined, true)
+                    }
+                  ]
+                : []),
               ...(variants.length
                 ? ([
                     {

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -4677,6 +4677,17 @@ export function Canvas() {
         `[nodeterm] node-create agent=${agentId} project=${targetProjectId} group=${groupId ?? '-'} cwd=${cwd ?? '-'}`
       )
       setNodes((ns) => {
+        // The default gateway model applies ONLY when the launch mode asks for it
+        // (`agentLaunchMode === 'gateway-model'`). 'gateway' launches with the CLI's own default
+        // model, and 'subscription' strips the gateway entirely so its model is moot. Gated on
+        // `canSwitchModel` (base-resolved) so a non-capable agent is left model-less.
+        const settings = useSettings.getState().settings
+        const model =
+          settings.agentLaunchMode === 'gateway-model' &&
+          settings.modelGatewayDefaultModel &&
+          canSwitchModel(agentId)
+            ? settings.modelGatewayDefaultModel
+            : undefined
         const node = createAgentNode(
           agentId,
           ns.length,
@@ -4688,7 +4699,8 @@ export function Canvas() {
           activePermissionMode(agentId),
           // Same funnel as the account above: the active project owns the node, so its own
           // `.nodeterm/settings.json` launch command layers over the global one.
-          targetProjectId
+          targetProjectId,
+          model
         )
         return [...ns, groupId ? parentInto(node, groupId) : node]
       })

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -110,6 +110,41 @@ describe('the trailing gestures are handed to the dispatcher', () => {
   })
 })
 
+describe('model-switch repair controls stay owned by the live Canvas', () => {
+  it('does not split a preserved popup from a module-global retry controller', () => {
+    expect(CANVAS_SRC).not.toContain('let modelSwitchRepair:')
+    expect(CANVAS_SRC).toContain('const modelSwitchRepairRef = useRef<ModelSwitchRepair | null>(null)')
+    expect(CANVAS_SRC).toContain("modelRespawnTrace('retry.all-clicked'")
+    expect(CANVAS_SRC).toContain('controllerAvailable: !!repair')
+  })
+
+  it('makes the initial pass repeat one full recycle after a replacement agent exits', () => {
+    expect(CANVAS_SRC).toContain('await repairOne(item, true)')
+    expect(CANVAS_SRC).toContain("modelRespawnTrace('repair.auto-force-retry'")
+  })
+
+  it('spends a verified cure inside the repair path shared by initial and button retries', () => {
+    const repair = CANVAS_SRC.slice(
+      CANVAS_SRC.indexOf('const repairOne = async'),
+      CANVAS_SRC.indexOf('// The repair handlers the strip\'s buttons call')
+    )
+    expect(repair).toContain('modelRecoveryCure(')
+    expect(repair).toContain('modelGoneAsked.set(item.askKey, true)')
+    expect(CANVAS_SRC).not.toContain('const appliedModels = new Map')
+  })
+
+  it('clears the prior refusal before deciding the current attempt deserves an automatic retry', () => {
+    const repair = CANVAS_SRC.slice(
+      CANVAS_SRC.indexOf('const repairOne = async'),
+      CANVAS_SRC.indexOf('// The repair handlers the strip\'s buttons call')
+    )
+    const clear = repair.indexOf('setLastRestartRefusal(item.id, null)')
+    const invoke = repair.indexOf('await fn(undefined, target)')
+    expect(clear).toBeGreaterThan(-1)
+    expect(clear).toBeLessThan(invoke)
+  })
+})
+
 describe('the end-session confirm describes both things it does', () => {
   // `closeSession` stops the tmux session AND deletes the canvas node. The wording is inherited
   // from the sessions sidebar, where deleting the node is the obvious intent — but the

--- a/src/renderer/canvas/toKanbanSession.test.ts
+++ b/src/renderer/canvas/toKanbanSession.test.ts
@@ -10,6 +10,14 @@ const sticky = (text: string): CanvasNode =>
     data: { text }
   }) as unknown as CanvasNode
 
+const terminal = (data: Record<string, unknown>): CanvasNode =>
+  ({
+    id: 'term-1',
+    type: 'terminal',
+    position: { x: 0, y: 0 },
+    data
+  }) as unknown as CanvasNode
+
 describe('toKanbanSession (sticky)', () => {
   // Issue #285: the card modal's textarea is CONTROLLED by session.text. If the projection trims,
   // every space/newline typed at the end of the note is stripped on the round-trip — the space key
@@ -34,5 +42,27 @@ describe('toKanbanSession (sticky)', () => {
 describe('toKanbanSession (sticky, markdown label)', () => {
   it('strips a leading heading marker from the card label', () => {
     expect(toKanbanSession(sticky('## Plan \nbody'))?.title).toBe('Plan')
+  })
+})
+
+describe('toKanbanSession (terminal launch record)', () => {
+  it('projects the model and context window used by every kanban context meter', () => {
+    const session = toKanbanSession(
+      terminal({
+        title: 'Claude',
+        agentModel: 'old-model',
+        agentLaunchModel: 'new-model[1m]',
+        agentLaunchContextWindow: 400_000
+      })
+    )
+
+    expect(session?.agentModel).toBe('new-model[1m]')
+    expect(session?.agentLaunchContextWindow).toBe(400_000)
+  })
+
+  it('does not present a requested model as an accepted launch record', () => {
+    const session = toKanbanSession(terminal({ agentModel: 'requested-model' }))
+
+    expect(session?.agentModel).toBeUndefined()
   })
 })

--- a/src/renderer/canvas/toKanbanSession.ts
+++ b/src/renderer/canvas/toKanbanSession.ts
@@ -46,6 +46,10 @@ export function toKanbanSession(n: CanvasNode): KanbanSession | null {
     kind: 'terminal',
     agentId: n.data.agentId as string | undefined,
     icon: n.data.icon as NodeIcon | undefined,
+    // The launch record, so both kanban ContextMeter surfaces show the model and denominator the
+    // session was launched with (the transcript trails a switch — see lib/contextMeterModel.ts).
+    agentModel: n.data.agentLaunchModel as string | undefined,
+    agentLaunchContextWindow: n.data.agentLaunchContextWindow as number | undefined,
     // What the card modal's co-attach terminal needs to join THIS node's session the same way the
     // canvas TerminalNode does.
     spawn: {

--- a/src/renderer/components/ConfirmDialog.tsx
+++ b/src/renderer/components/ConfirmDialog.tsx
@@ -6,8 +6,12 @@ import { isTopDialog, nextDialogId, popDialog, pushDialog } from './dialog-stack
 interface ConfirmDialogProps {
   message: string
   /** Optional content rendered ABOVE the message (e.g. the remote-access ConsentNotice), so the
-   *  human reads what they are granting before the SAS body + buttons. */
+   *  human reads what they are granting before the SAS body + buttons. `bodyPosition` moves it. */
   body?: ReactNode
+  /** Where `body` sits relative to `message`. 'above' (default) suits a consent notice the
+   *  reader must see BEFORE the ask; 'below' suits a list the message refers to ("the sessions
+   *  below") — the reason must lead and the rows follow it. */
+  bodyPosition?: 'above' | 'below'
   confirmLabel?: string
   cancelLabel?: string
   danger?: boolean
@@ -55,6 +59,7 @@ interface ConfirmDialogProps {
 export function ConfirmDialog({
   message,
   body,
+  bodyPosition = 'above',
   confirmLabel,
   cancelLabel = 'Cancel',
   danger: dangerProp,
@@ -112,8 +117,9 @@ export function ConfirmDialog({
   return createPortal(
     <div className="confirm-overlay" onClick={dismiss}>
       <div className="confirm" ref={boxRef} onClick={(e) => e.stopPropagation()}>
-        {body}
+        {body && bodyPosition === 'above' && body}
         <p className="confirm__msg">{message}</p>
+        {body && bodyPosition === 'below' && body}
         {option && (
           <label className="confirm__option">
             <input

--- a/src/renderer/components/ContextMeter.tsx
+++ b/src/renderer/components/ContextMeter.tsx
@@ -2,12 +2,22 @@ import { useEffect, useRef, useState } from 'react'
 import { useContextWindow } from '../state/contextWindow'
 import { useSettings } from '../state/settings'
 import { barFillPercent, contextFillColor, contextPillText, formatModelLabel, formatTimeAgo, formatTokensShort, percentText } from '../lib/usageFormat'
+import { contextMeterModel, contextMeterUsage } from '../lib/contextMeterModel'
 
 /**
  * Per-Claude-node context-window meter. A small header pill (mini-bar + "NN%") that toggles
  * a popover with token figures and model. Renders nothing until the session has usage data.
  */
-export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.Element | null {
+export function ContextMeter({
+  sessionId,
+  nodeModel,
+  nodeContextWindow
+}: {
+  sessionId: string | null
+  nodeModel?: string
+  /** Context window baked into this node's launch environment. */
+  nodeContextWindow?: number
+}): JSX.Element | null {
   const usage = useContextWindow((s) => (sessionId ? s.bySessionId[sessionId] : undefined))
   const percentMode = useSettings((s) => s.settings.usagePercentMode)
   const [open, setOpen] = useState(false)
@@ -26,9 +36,21 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
   // The NUMBER honours the used/remaining/tokens display setting; the bar and its color stay
   // keyed to context FILL, so the severity colors keep meaning the same thing in every mode
   // (issue #78).
-  const pillText = contextPillText(usage.usedTokens, usage.windowTokens, usage.usedPercent, percentMode)
-  const color = contextFillColor(usage.usedPercent)
-  const modelLabel = formatModelLabel(usage.model)
+  const { windowTokens, usedPercent } = contextMeterUsage(
+    usage.usedTokens,
+    usage.windowTokens,
+    nodeContextWindow
+  )
+  const pillText = contextPillText(usage.usedTokens, windowTokens, usedPercent, percentMode)
+  const color = contextFillColor(usedPercent)
+  // ONE precedence rule for every ContextMeter surface. The transcript is what the CLI ECHOS,
+  // but it lags a switch: a resumed transcript replays pre-switch rows, so its label can name a
+  // model the process no longer runs (the "GLM-5.2 under the context %" the launch record
+  // disproves). The node's launch record outranks it there; a hand-`claude`'d terminal has no
+  // record, and the transcript keeps its job. The used-token count stays transcript-owned; the
+  // persisted launch window owns the denominator when present.
+  const model = contextMeterModel(usage.model, nodeModel)
+  const modelLabel = formatModelLabel(model)
 
   return (
     <div className="ctx-meter nodrag" ref={ref}>
@@ -36,22 +58,22 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
         <div className="ctx-popover">
           <div className="ctx-popover__title">Context</div>
           <div className="ctx-bar">
-            <div className="ctx-bar__fill" style={{ width: `${barFillPercent(usage.usedPercent, percentMode)}%`, background: color }} />
+            <div className="ctx-bar__fill" style={{ width: `${barFillPercent(usedPercent, percentMode)}%`, background: color }} />
           </div>
           <div className="ctx-popover__meta">
-            ~{formatTokensShort(usage.usedTokens)} / {formatTokensShort(usage.windowTokens)} tokens
+            ~{formatTokensShort(usage.usedTokens)} / {formatTokensShort(windowTokens)} tokens
           </div>
           <div className="ctx-popover__sub">
             {/* No model read ⇒ say nothing. This used to fall back to the literal 'claude', which
                 was harmless while the meter was claude-only and became a mislabel once codex and
                 gemini joined USAGE_CAPABLE — a codex popover would have claimed to be claude. */}
-            {usage.model ? `${usage.model} · ` : ''}Updated {formatTimeAgo(usage.updatedAt)}
+            {model ? `${model} · ` : ''}Updated {formatTimeAgo(usage.updatedAt)}
           </div>
         </div>
       )}
       <button
         className="ctx-pill"
-        title={`Context window — ${percentText(usage.usedPercent, percentMode)}`}
+        title={`Context window — ${percentText(usedPercent, percentMode)}`}
         onClick={(e) => {
           e.stopPropagation()
           setOpen((v) => !v)
@@ -59,7 +81,7 @@ export function ContextMeter({ sessionId }: { sessionId: string | null }): JSX.E
       >
         {modelLabel && <span className="ctx-pill__model">{modelLabel}</span>}
         <span className="ctx-pill__bar">
-          <span className="ctx-pill__fill" style={{ width: `${barFillPercent(usage.usedPercent, percentMode)}%`, background: color }} />
+          <span className="ctx-pill__fill" style={{ width: `${barFillPercent(usedPercent, percentMode)}%`, background: color }} />
         </span>
         <span className="ctx-pill__num">{pillText}</span>
       </button>

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -8,6 +8,7 @@ import { useContextWindow } from '../state/contextWindow'
 import { useSessionNaming } from '../state/sessionNaming'
 import { useSettings } from '../state/settings'
 import { contextFillColor, contextPillText, percentText } from '../lib/usageFormat'
+import { contextMeterUsage } from '../lib/contextMeterModel'
 
 export interface SessionRowProps {
   row: SessionRowVM
@@ -49,6 +50,9 @@ export function SessionRow({
   // The sidebar is one more view of the same nodes, so it gets the canvas header's account chip
   // under the same visibility rule — two rows on two Claude logins are otherwise indistinguishable.
   const accountChip = useAccountChip(row.accountId, row.account)
+  const effectiveUsage = usage
+    ? contextMeterUsage(usage.usedTokens, usage.windowTokens, row.agentLaunchContextWindow)
+    : null
 
   const commit = (): void => {
     const t = draft.trim()
@@ -155,13 +159,18 @@ export function SessionRow({
               {row.loop.kind} · {row.loop.count}
             </span>
           )}
-          {row.usesContext && usage && (
+          {row.usesContext && usage && effectiveUsage && (
             <span
               className="ss-ctx"
-              title={`Context window — ${percentText(usage.usedPercent, percentMode)}`}
-              style={{ background: contextFillColor(usage.usedPercent) }}
+              title={`Context window — ${percentText(effectiveUsage.usedPercent, percentMode)}`}
+              style={{ background: contextFillColor(effectiveUsage.usedPercent) }}
             >
-              {contextPillText(usage.usedTokens, usage.windowTokens, usage.usedPercent, percentMode)}
+              {contextPillText(
+                usage.usedTokens,
+                effectiveUsage.windowTokens,
+                effectiveUsage.usedPercent,
+                percentMode
+              )}
             </span>
           )}
           <button

--- a/src/renderer/components/kanban/CardModal.tsx
+++ b/src/renderer/components/kanban/CardModal.tsx
@@ -326,7 +326,11 @@ export function CardModal({ session, columnTitle, board, onChangeBoard, onClose,
           {isTerminal && (
             <>
               {/* Same context-window pill + popover as the node header (null until usage data). */}
-              <ContextMeter sessionId={agentSessionId ?? null} />
+              <ContextMeter
+                sessionId={agentSessionId ?? null}
+                nodeModel={session.agentModel}
+                nodeContextWindow={session.agentLaunchContextWindow}
+              />
               <button
                 className="kanban-modal__action"
                 title="Search this terminal"

--- a/src/renderer/components/kanban/KanbanView.tsx
+++ b/src/renderer/components/kanban/KanbanView.tsx
@@ -41,6 +41,13 @@ export interface KanbanSession {
   color: string
   kind: 'terminal' | 'sticky' | 'browser'
   agentId?: string
+  /** Terminal-only: the node's launch record, so its ContextMeter shows the
+   *  model the session was launched with (the transcript label trails a switch —
+   *  lib/contextMeterModel.ts). */
+  agentModel?: string
+  /** Terminal-only: the context window baked into that launch. It outranks the transcript's
+   *  stale pre-switch denominator until the agent emits a new usage row. */
+  agentLaunchContextWindow?: number
   /** Sticky note body — shown in the expanded detail row. */
   text?: string
   /** Sticky-only: last canvas-control `sticky` write (cleared on hand edits) — the modal's stamp. */

--- a/src/renderer/components/kanban/SessionCard.tsx
+++ b/src/renderer/components/kanban/SessionCard.tsx
@@ -191,7 +191,11 @@ export const SessionCard = memo(function SessionCard({
             <span className="kanban-card__stickytext">{stickyPreview}</span>
           ) : (
             <>
-              <ContextMeter sessionId={status?.sessionId ?? null} />
+              <ContextMeter
+                sessionId={status?.sessionId ?? null}
+                nodeModel={session.agentModel}
+                nodeContextWindow={session.agentLaunchContextWindow}
+              />
               <AccountChip chip={accountChip} />
               {status?.session && (
                 <span className="kanban-card__session" title={status.session}>

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -67,6 +67,22 @@ const ROWS = {
       'opencode'
     ]
   },
+  vanillaLaunch: {
+    title: 'Launch on subscription',
+    keywords: [
+      'subscription',
+      'vanilla',
+      'gateway',
+      'provider',
+      'default',
+      'anthropic',
+      'openai',
+      'copilot',
+      'env',
+      'credentials',
+      'clear env'
+    ]
+  },
   permissionMode: {
     title: 'Permission mode',
     keywords: [
@@ -362,6 +378,19 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
             </div>
           ))}
         </div>
+      </SearchableRow>
+      <SearchableRow {...ROWS.vanillaLaunch}>
+        <FieldRow
+          label="Launch on subscription"
+          description="Spawn every fresh agent session with gateway and inherited provider env stripped, so it runs against its OWN default provider — Claude's subscription, Copilot's GitHub routing — instead of a configured model gateway or a LaunchAgent-set override. The per-node “Restart on subscription” action does the same for one node; this is its global counterpart. The managed-account config dir is kept, so account isolation survives. Off by default — it changes which provider every agent node uses."
+          control={
+            <Switch
+              checked={settings.vanillaLaunchDefault}
+              ariaLabel="Launch on subscription by default"
+              onChange={(on) => update({ vanillaLaunchDefault: on })}
+            />
+          }
+        />
       </SearchableRow>
       <SearchableRow {...ROWS.permissionMode}>
         <FieldRow

--- a/src/renderer/components/settings/sections/AgentsSection.tsx
+++ b/src/renderer/components/settings/sections/AgentsSection.tsx
@@ -13,7 +13,7 @@ import {
   setDefaultAgent
 } from '../../../state/agentAvailability'
 import { ensureClaudeCliCaps } from '../../../state/permissionMode'
-import type { ClaudeCliCaps } from '@shared/types'
+import type { AgentLaunchMode, ClaudeCliCaps } from '@shared/types'
 import {
   AGENT_CONFIG,
   ALL_PERMISSION_MODES,
@@ -68,13 +68,16 @@ const ROWS = {
     ]
   },
   vanillaLaunch: {
-    title: 'Launch on subscription',
+    title: 'Launch mode',
     keywords: [
+      'launch mode',
       'subscription',
       'vanilla',
       'gateway',
+      'gateway model',
       'provider',
       'default',
+      'default model',
       'anthropic',
       'openai',
       'copilot',
@@ -381,14 +384,24 @@ export function AgentsSection({ isActive }: { isActive: boolean }): React.JSX.El
       </SearchableRow>
       <SearchableRow {...ROWS.vanillaLaunch}>
         <FieldRow
-          label="Launch on subscription"
-          description="Spawn every fresh agent session with gateway and inherited provider env stripped, so it runs against its OWN default provider — Claude's subscription, Copilot's GitHub routing — instead of a configured model gateway or a LaunchAgent-set override. The per-node “Restart on subscription” action does the same for one node; this is its global counterpart. The managed-account config dir is kept, so account isolation survives. Off by default — it changes which provider every agent node uses."
+          label="Launch mode"
+          description="The default provider behavior for a fresh canvas agent session. “Gateway (CLI default)” injects the model gateway but lets the CLI pick its own default model. “Gateway (default model)” additionally launches on the default model chosen in Settings → Model gateway. “Subscription” strips the gateway + inherited provider env so the agent runs against its OWN provider (Claude’s subscription, Copilot’s GitHub routing) — the global counterpart of the per-node “Restart on subscription” action. The managed-account config dir is kept, so account isolation survives."
           control={
-            <Switch
-              checked={settings.vanillaLaunchDefault}
-              ariaLabel="Launch on subscription by default"
-              onChange={(on) => update({ vanillaLaunchDefault: on })}
-            />
+            <Select
+              aria-label="Agent launch mode"
+              value={settings.agentLaunchMode}
+              onChange={(e) =>
+                update({ agentLaunchMode: e.target.value as AgentLaunchMode })
+              }
+            >
+              <option value="gateway">Gateway (CLI default model)</option>
+              <option value="gateway-model">
+                {settings.modelGatewayDefaultModel
+                  ? `Gateway (default model: ${settings.modelGatewayDefaultModel})`
+                  : 'Gateway (default model — none configured)'}
+              </option>
+              <option value="subscription">Subscription (own provider credentials)</option>
+            </Select>
           }
         />
       </SearchableRow>

--- a/src/renderer/components/settings/sections/ModelGatewaySection.test.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.test.tsx
@@ -22,7 +22,7 @@ describe('ModelGatewaySection credential modes', () => {
     ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {
       settings: { save: vi.fn() },
       agent: {
-        discoverModels: vi.fn(),
+        discoverModels: vi.fn(async () => ({ models: [] })),
         gatewayCredentialStatus: vi.fn(async () => ({
           hasStoredKey: false,
           storage: 'encrypted' as const
@@ -132,5 +132,45 @@ describe('ModelGatewaySection credential modes', () => {
     )
     expect(input.value).toBe('')
     expect(host.textContent).not.toContain('literal-secret')
+  })
+
+  it('invalidates a stored-key catalogue before discovering with its replacement', async () => {
+    useSettings.setState({
+      settings: {
+        ...useSettings.getState().settings,
+        modelGateway: {
+          ...useSettings.getState().settings.modelGateway,
+          apiKey: MODEL_GATEWAY_SECRET_REF
+        }
+      }
+    })
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal.agent.gatewayCredentialStatus =
+      vi.fn(async () => ({ hasStoredKey: true, storage: 'encrypted' as const }))
+    useModelGateway.setState({
+      models: [{ id: 'old/model' }],
+      status: 'ready',
+      error: ''
+    })
+    await mount()
+
+    const input = host.querySelector<HTMLInputElement>('#model-gateway-key')!
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(
+        input,
+        'replacement-secret'
+      )
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    const save = [...host.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Save key'
+    )!
+    await act(async () => {
+      save.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(useModelGateway.getState().models).toEqual([])
+    expect(window.nodeTerminal.agent.discoverModels).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: MODEL_GATEWAY_SECRET_REF })
+    )
   })
 })

--- a/src/renderer/components/settings/sections/ModelGatewaySection.test.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.test.tsx
@@ -77,6 +77,28 @@ describe('ModelGatewaySection credential modes', () => {
     expect(useSettings.getState().settings.modelGateway.apiKey).toBe('${env:GATEWAY_KEY}')
   })
 
+  it('persists the selected discovery path and previews its resolved endpoint', async () => {
+    await mount()
+    expect(host.textContent).toContain(
+      'Discovery: https://gateway.example.test/v1/models'
+    )
+
+    const openAiPath = [...host.querySelectorAll<HTMLInputElement>('input[type="radio"]')].find(
+      (input) => input.parentElement?.textContent?.includes('/openai/v1/models')
+    )!
+    await act(async () => {
+      openAiPath.click()
+    })
+
+    expect(useSettings.getState().settings.modelGateway.discoveryPath).toBe(
+      '/openai/v1/models'
+    )
+    expect(openAiPath.checked).toBe(true)
+    expect(host.textContent).toContain(
+      'Discovery: https://gateway.example.test/openai/v1/models'
+    )
+  })
+
   it('keeps a literal key write-only and stores only the secret sentinel in settings', async () => {
     await mount()
     const source = host.querySelector<HTMLSelectElement>('#model-gateway-credential-source')!

--- a/src/renderer/components/settings/sections/ModelGatewaySection.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.tsx
@@ -163,6 +163,9 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
         replacingStoredKey &&
         modelGatewayRoutes(current.baseUrl, current.discoveryPath)
       ) {
+        // The public secret sentinel did not change, but the resolved credential did. Drop both
+        // the visible catalogue and any older in-flight response before querying with the new key.
+        clearModels()
         void discover({ ...current, apiKey: MODEL_GATEWAY_SECRET_REF })
       }
       setCredentialNotice('API key saved securely.')
@@ -482,10 +485,28 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
           </Button>
         </div>
         {models.length ? (
-          <div className="mt-3 max-h-40 overflow-y-auto rounded-lg bg-black/15 px-3 py-2 font-mono text-[11px] text-muted">
-            {models.map((model) => (
-              <div key={model.id}>{model.id}</div>
-            ))}
+          <div className="mt-3 space-y-2">
+            <div className="max-h-40 overflow-y-auto rounded-lg bg-black/15 px-3 py-2 font-mono text-[11px] text-muted">
+              {models.map((model) => (
+                <div key={model.id}>
+                  {model.id}
+                  {model.contextWindow ? ` (${model.contextWindow.toLocaleString()} ctx)` : ''}
+                </div>
+              ))}
+            </div>
+            {models.every((model) => !model.contextWindow) ? (
+              // "We looked and there is nothing" is its own sentence (the same rule the
+              // session-memory panel honours): a list of bare ids must not silently read as
+              // "the numbers are coming later". The window is a per-model fact only the gateway
+              // can supply — nodeterm never guesses it, so nothing downstream (the [1m] marker,
+              // the autocompact env, the meter) can act on these models.
+              <p className="text-[12px] text-muted">
+                None of these models reported a context length, so the Claude autocompact window
+                and the [1m] marker cannot be applied. If your gateway tracks context sizes,
+                check that the selected discovery endpoint serves them
+                {routes ? <> ({routes.discovery})</> : null}.
+              </p>
+            ) : null}
           </div>
         ) : null}
       </SearchableRow>

--- a/src/renderer/components/settings/sections/ModelGatewaySection.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.tsx
@@ -21,6 +21,11 @@ const ROWS = {
     description: 'One gateway root URL for OpenAI-compatible discovery and agent routes.',
     keywords: ['openai compatible', 'bifrost', 'litellm', 'model', 'provider', 'base url', 'endpoint']
   },
+  discoveryPath: {
+    title: 'Discovery path',
+    description: 'Path the model catalogue is read from, appended to the gateway root.',
+    keywords: ['discover', 'models route', 'v1/models', 'openai/v1/models', 'catalogue path']
+  },
   key: {
     title: 'API key',
     description: 'A gateway bearer key from protected storage or an environment variable.',
@@ -83,7 +88,13 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
     useState<ModelGatewayCredentialStatus | null>(null)
   const [credentialBusy, setCredentialBusy] = useState(false)
   const [credentialNotice, setCredentialNotice] = useState('')
-  const routes = modelGatewayRoutes(gateway.baseUrl)
+
+  // The "Model discovery endpoint" picker's transient editing state. The CURRENT selection is
+  // derived from `gateway.discoveryPath` every render (the source of truth); these locals only
+  // hold whether the custom text input is open and what the user is mid-typing into it.
+  const [customMode, setCustomMode] = useState(false)
+  const [customPath, setCustomPath] = useState('')
+  const routes = modelGatewayRoutes(gateway.baseUrl, gateway.discoveryPath)
 
   const patchGateway = (patch: Partial<typeof gateway>): void => {
     const current = useSettings.getState().settings.modelGateway
@@ -148,7 +159,10 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
       const current = useSettings.getState().settings.modelGateway
       // Replacing a key leaves the settings sentinel unchanged, so Canvas's value-based effect has
       // no dependency change to observe. A first save does change it and gets the normal debounce.
-      if (replacingStoredKey && modelGatewayRoutes(current.baseUrl)) {
+      if (
+        replacingStoredKey &&
+        modelGatewayRoutes(current.baseUrl, current.discoveryPath)
+      ) {
         void discover({ ...current, apiKey: MODEL_GATEWAY_SECRET_REF })
       }
       setCredentialNotice('API key saved securely.')
@@ -217,6 +231,137 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
             <div>Anthropic: {routes.anthropic}</div>
           </div>
         ) : null}
+      </SearchableRow>
+
+      <SearchableRow {...ROWS.discoveryPath}>
+        <div className="space-y-2">
+          <div className="flex items-start justify-between gap-6">
+            <div>
+              <div className="text-sm font-medium text-text">Model discovery endpoint</div>
+              <p className="mt-1 max-w-xl text-[13px] text-muted">
+                Which gateway endpoint the model catalogue is read from. Only the discovery request
+                changes — agent launches keep using the OpenAI and Anthropic routes shown under the
+                Gateway URL.
+              </p>
+            </div>
+            {routes ? (
+              <div className="shrink-0 font-mono text-[11px] text-muted">
+                Discovery: {routes.discovery}
+              </div>
+            ) : null}
+          </div>
+          {/* Vertical radio group (the Speech-section pattern): one bordered row per endpoint.
+              `discoveryPath` absent = the conventional /v1/models row. Custom reveals a free-text
+              path so a layout this picker doesn't know is still expressible; the undefined spelling
+              means "use the conventional suffix" on ModelGatewaySettings. */}
+          {(() => {
+            const isCustomValue =
+              !!gateway.discoveryPath &&
+              gateway.discoveryPath !== '/v1/models' &&
+              gateway.discoveryPath !== '/openai/v1/models' &&
+              gateway.discoveryPath !== '/anthropic/v1/models'
+            return (
+              <div role="radiogroup" aria-label="Model discovery endpoint" className="space-y-2">
+                {(
+                  [
+                    {
+                      option: '/v1/models',
+                      label: '/v1/models',
+                      hint: 'OpenAI convention — the default.'
+                    },
+                    {
+                      option: '/openai/v1/models',
+                      label: '/openai/v1/models',
+                      hint: 'Same catalogue under the OpenAI launch-route prefix.'
+                    },
+                    {
+                      option: '/anthropic/v1/models',
+                      label: '/anthropic/v1/models',
+                      hint: 'Same catalogue under the Anthropic launch-route prefix.'
+                    },
+                    { option: 'custom', label: 'Custom path…', hint: 'Enter an exact path below.' }
+                  ] as const
+                ).map((opt) => {
+                  // Custom is a MODE, not a stored alias value: `customMode` (this render
+                  // session's Custom selection) OR a persisted non-canonical path claims the
+                  // custom row. A custom seed of '/v1/models' before typing must NOT light the
+                  // first row — checked is single-owner: while customMode, the canonical rows
+                  // never light, whatever the field currently contains.
+                  const checked =
+                    opt.option === 'custom'
+                      ? customMode || isCustomValue
+                      : !customMode && !isCustomValue && (gateway.discoveryPath ?? '/v1/models') === opt.option
+                  return (
+                    <div
+                      key={opt.option}
+                      className={
+                        'flex items-center justify-between gap-3 rounded-md border p-3 transition-colors' +
+                        // The selected row is the one thing a scan must land on: accent border +
+                        // tinted fill, not just the (small, unstyled) native radio dot.
+                        (checked
+                          ? ' border-[color:var(--accent)] bg-[color:var(--accent)]/10'
+                          : ' border-border')
+                      }
+                    >
+                      <label className="flex min-w-0 flex-1 cursor-pointer items-center gap-3">
+                        <input
+                          type="radio"
+                          name="gateway-discovery-path"
+                          className="shrink-0"
+                          style={{ accentColor: 'var(--accent)' }}
+                          checked={checked}
+                          onChange={() => {
+                            if (opt.option === 'custom') {
+                              // Seed the input with the CURRENT stored path (or the conventional
+                              // default) so the box never shows empty over a live value. The
+                              // stored path is NOT rewritten here — Custom is only a mode until
+                              // the input itself is edited.
+                              setCustomMode(true)
+                              setCustomPath(gateway.discoveryPath ?? '/v1/models')
+                            } else {
+                              setCustomMode(false)
+                              setCustomPath('')
+                              patchGateway({
+                                discoveryPath: opt.option === '/v1/models' ? undefined : opt.option
+                              })
+                            }
+                          }}
+                        />
+                        <div className="min-w-0">
+                          <span
+                            className={
+                              checked
+                                ? 'font-mono text-[13px] font-medium text-text'
+                                : 'font-mono text-[13px] text-text'
+                            }
+                          >
+                            {opt.label}
+                          </span>
+                          <p className="text-[12px] text-muted">{opt.hint}</p>
+                        </div>
+                      </label>
+                    </div>
+                  )
+                })}
+              </div>
+            )
+          })()}
+          {customMode && (
+            <Input
+              id="model-gateway-discovery-path"
+              className="w-64 font-mono"
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="/v1/models"
+              value={customPath}
+              onChange={(e) => {
+                setCustomPath(e.target.value)
+                patchGateway({ discoveryPath: e.target.value || undefined })
+              }}
+            />
+          )}
+        </div>
       </SearchableRow>
 
       <SearchableRow {...ROWS.key}>

--- a/src/renderer/components/settings/sections/ModelGatewaySection.tsx
+++ b/src/renderer/components/settings/sections/ModelGatewaySection.tsx
@@ -30,6 +30,21 @@ const ROWS = {
     title: 'Available models',
     description: 'Refresh the model catalogue used by agent-node context menus.',
     keywords: ['discover', 'refresh', 'switch model', 'catalogue']
+  },
+  defaultModel: {
+    title: 'Default model',
+    description:
+      'A model new canvas agent sessions launch on when the Agents “Launch mode” is set to “Gateway (default model)”.',
+    keywords: [
+      'default',
+      'model',
+      'launch',
+      'gateway model',
+      'new session',
+      'claude',
+      'codex',
+      'copilot'
+    ]
   }
 }
 const ENTRIES = Object.values(ROWS)
@@ -48,6 +63,7 @@ function credentialMessage(error: unknown): string {
 
 export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.JSX.Element {
   const gateway = useSettings((s) => s.settings.modelGateway)
+  const defaultModel = useSettings((s) => s.settings.modelGatewayDefaultModel)
   const update = useSettings((s) => s.update)
   const models = useModelGateway((s) => s.models)
   const status = useModelGateway((s) => s.status)
@@ -327,6 +343,34 @@ export function ModelGatewaySection({ isActive }: { isActive: boolean }): React.
             ))}
           </div>
         ) : null}
+      </SearchableRow>
+
+      <SearchableRow {...ROWS.defaultModel}>
+        <FieldRow
+          label="Default model"
+          description="New canvas agent sessions launch on this model when Settings → Agents → Launch mode is “Gateway (default model)”. Picked from the discovered catalogue — discover models first."
+          control={
+            <Select
+              aria-label="Default gateway model"
+              value={defaultModel ?? ''}
+              disabled={!models.length}
+              onChange={(e) => {
+                const id = e.target.value
+                // An empty value is the one spelling of "no default" (absent), matching how the
+                // launch-commands fields above treat a cleared input. A non-empty id is stored
+                // verbatim — it is the discovered catalogue id, not a credential.
+                update({ modelGatewayDefaultModel: id || undefined })
+              }}
+            >
+              <option value="">(none — CLI default model)</option>
+              {models.map((model) => (
+                <option key={model.id} value={model.id}>
+                  {model.id}
+                </option>
+              ))}
+            </Select>
+          }
+        />
       </SearchableRow>
     </SettingsSection>
   )

--- a/src/renderer/lib/contextMeterModel.test.ts
+++ b/src/renderer/lib/contextMeterModel.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { contextMeterModel, contextMeterUsage } from './contextMeterModel'
+
+describe('contextMeterModel', () => {
+  it('prefers the launch record when present', () => {
+    // Trailing a switch: the transcript replays pre-switch rows, so its label can name a model
+    // the session no longer runs. The record is what the user clicked.
+    expect(contextMeterModel('vllm/GLM-5.2-NVFP4-MTP', 'vllm/GLM-5.3-Flash-NVFP4')).toBe(
+      'vllm/GLM-5.3-Flash-NVFP4'
+    )
+  })
+
+  it('falls back to the transcript when there is no record (hand-launched claude)', () => {
+    expect(contextMeterModel('claude-opus-5', undefined)).toBe('claude-opus-5')
+    expect(contextMeterModel('claude-opus-5', '')).toBe('claude-opus-5')
+  })
+
+  it('falls back when the record is WHITESPACE (an empty record asserts nothing)', () => {
+    expect(contextMeterModel('claude-opus-5', '   ')).toBe('claude-opus-5')
+  })
+
+  it('passes the record through verbatim (no [1m] normalization at DISPLAY time)', () => {
+    // The supervisor already normalizes [1m] where a comparison needs it; the display shows what
+    // the CLI was launched with.
+    expect(contextMeterModel(null, 'vllm/GLM-5.3-Flash-NVFP4[1m]')).toBe('vllm/GLM-5.3-Flash-NVFP4[1m]')
+  })
+
+  it('returns null when neither source has a model', () => {
+    expect(contextMeterModel(null, undefined)).toBe(null)
+    expect(contextMeterModel(null, '   ')).toBe(null)
+  })
+})
+
+describe('contextMeterUsage', () => {
+  it('uses the launch window immediately while the transcript still names the old window', () => {
+    expect(contextMeterUsage(100_000, 1_000_000, 400_000)).toEqual({
+      windowTokens: 400_000,
+      usedPercent: 25
+    })
+  })
+
+  it('falls back to the transcript window for agents Nodeterm did not launch', () => {
+    expect(contextMeterUsage(100_000, 1_000_000)).toEqual({
+      windowTokens: 1_000_000,
+      usedPercent: 10
+    })
+    expect(contextMeterUsage(100_000, 1_000_000, Number.NaN)).toEqual({
+      windowTokens: 1_000_000,
+      usedPercent: 10
+    })
+    expect(contextMeterUsage(100_000, 1_000_000, 0)).toEqual({
+      windowTokens: 1_000_000,
+      usedPercent: 10
+    })
+  })
+
+  it('clamps fill when the recorded usage exceeds the new model window', () => {
+    expect(contextMeterUsage(450_000, 1_000_000, 400_000)).toEqual({
+      windowTokens: 400_000,
+      usedPercent: 100
+    })
+  })
+})

--- a/src/renderer/lib/contextMeterModel.ts
+++ b/src/renderer/lib/contextMeterModel.ts
@@ -1,0 +1,54 @@
+// The context meter's launch-record precedence, as ONE pair of pure decisions shared by the
+// canvas node, the kanban card and the card modal — the same session can be seen from all three.
+
+/**
+ * Which model label a context meter shows. `nodeModel` is the node's launch record
+ * (`data.agentLaunchModel` — the exact id emitted by the launch assembler); `transcriptModel` is what the
+ * transcript's latest usage row names (what the CLI most recently echoed running).
+ *
+ * BOTH are true statements about different instants, and trailing a switch the transcript
+ * one is STALE: a resumed transcript replays pre-switch rows, so `context-tail` keeps
+ * re-publishing the pre-switch model until the CLI's first genuinely new assistant row —
+ * which for an idle session is the user's next prompt, potentially days later. The pivot is
+ * that the launch record is the one the USER has evidence for (they clicked it, or a grouped
+ * restart wrote it), while the transcript label is only as fresh as its last row.
+ *
+ * So: the launch record outranks to give the restarted session the RIGHT label before the
+ * transcript has any post-switch row to name — no lingering "GLM-5.2" under the context %.
+ * Otherwise the transcript stands (a hand-launched `claude` in a plain terminal has no
+ * record anywhere; a node whose record was never set (`clearEnv`, CLI default) falls back to
+ * the live read too — an empty record says nothing, it does not assert).
+ */
+export function contextMeterModel(transcriptModel: string | null, nodeModel?: string): string | null {
+  const record = typeof nodeModel === 'string' ? nodeModel.trim() : ''
+  if (record) return record
+  return transcriptModel
+}
+
+export interface ContextMeterUsage {
+  windowTokens: number
+  usedPercent: number
+}
+
+/**
+ * The denominator and resulting fill shown by a context meter. The used-token count remains
+ * transcript-owned, but a positive launch record outranks the transcript's window: after a
+ * model switch the resumed transcript replays the last pre-switch assistant row until the user
+ * sends another prompt, so its old denominator can otherwise linger indefinitely.
+ *
+ * Nodes that Nodeterm did not launch have no record and retain the transcript's denominator.
+ */
+export function contextMeterUsage(
+  usedTokens: number,
+  transcriptWindow: number,
+  launchWindow?: number
+): ContextMeterUsage {
+  const hasLaunchWindow =
+    typeof launchWindow === 'number' && Number.isFinite(launchWindow) && launchWindow > 0
+  const windowTokens = hasLaunchWindow ? launchWindow : transcriptWindow
+  const usedPercent =
+    Number.isFinite(windowTokens) && windowTokens > 0
+      ? Math.min(100, Math.max(0, (usedTokens / windowTokens) * 100))
+      : 0
+  return { windowTokens, usedPercent }
+}

--- a/src/renderer/lib/modelRecovery.test.ts
+++ b/src/renderer/lib/modelRecovery.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  catalogueForModelRecovery,
+  refreshModelRecoveryCatalogue
+} from './modelRecovery'
+
+describe('catalogueForModelRecovery', () => {
+  it('returns only a successful non-empty catalogue', () => {
+    const models = [{ id: 'served/model' }]
+    expect(catalogueForModelRecovery({ status: 'ready', models })).toBe(models)
+    expect(catalogueForModelRecovery({ status: 'ready', models: [] })).toBeNull()
+    expect(catalogueForModelRecovery({ status: 'loading', models })).toBeNull()
+    expect(catalogueForModelRecovery({ status: 'error', models })).toBeNull()
+  })
+})
+
+describe('refreshModelRecoveryCatalogue', () => {
+  it('reads the latest settings at invocation time and starts exactly one request', async () => {
+    let settings = { baseUrl: 'https://old.test', apiKey: 'old' }
+    const discover = vi.fn(async () => {})
+    const readSettings = (): typeof settings => settings
+
+    settings = { baseUrl: 'https://current.test', apiKey: 'current' }
+    await refreshModelRecoveryCatalogue(readSettings, discover)
+
+    expect(discover).toHaveBeenCalledOnce()
+    expect(discover).toHaveBeenCalledWith(settings)
+  })
+})

--- a/src/renderer/lib/modelRecovery.ts
+++ b/src/renderer/lib/modelRecovery.ts
@@ -1,0 +1,22 @@
+import type { GatewayModel, ModelGatewaySettings } from '@shared/agents/model-gateway'
+import type { ModelDiscoveryStatus } from '../state/modelGateway'
+
+export interface ModelRecoveryCatalogueSnapshot {
+  models: readonly GatewayModel[]
+  status: ModelDiscoveryStatus
+}
+
+/** A recovery decision needs a successful, non-empty catalogue. Empty/error/loading is no proof. */
+export function catalogueForModelRecovery(
+  snapshot: ModelRecoveryCatalogueSnapshot
+): readonly GatewayModel[] | null {
+  return snapshot.status === 'ready' && snapshot.models.length > 0 ? snapshot.models : null
+}
+
+/** Refresh once using the gateway configuration that is current when the refresh is invoked. */
+export async function refreshModelRecoveryCatalogue(
+  readSettings: () => ModelGatewaySettings,
+  discover: (settings: ModelGatewaySettings) => Promise<void>
+): Promise<void> {
+  await discover({ ...readSettings() })
+}

--- a/src/renderer/lib/modelSwitchProgress.test.ts
+++ b/src/renderer/lib/modelSwitchProgress.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  modelSwitchProgressCanAutoDismiss,
+  modelSwitchRepairVerdict,
+  modelSwitchShouldAutoForceRetry
+} from './modelSwitchProgress'
+
+describe('modelSwitchProgressCanAutoDismiss', () => {
+  it('allows only a non-empty all-success batch to auto-dismiss', () => {
+    expect(modelSwitchProgressCanAutoDismiss([{ state: 'ok' }, { state: 'ok' }])).toBe(true)
+    expect(modelSwitchProgressCanAutoDismiss([])).toBe(false)
+    expect(modelSwitchProgressCanAutoDismiss(null)).toBe(false)
+  })
+
+  it.each(['failed', 'pending', 'running'] as const)(
+    'keeps the progress visible while any row is %s',
+    (state) => {
+      expect(modelSwitchProgressCanAutoDismiss([{ state: 'ok' }, { state }])).toBe(false)
+    }
+  )
+})
+
+describe('modelSwitchShouldAutoForceRetry', () => {
+  it('repeats the full recycle once when the initial replacement agent exits', () => {
+    expect(modelSwitchShouldAutoForceRetry(true, 'exit-timeout', 'agent-not-running')).toBe(true)
+  })
+
+  it('does not loop manual retries or unrelated failures', () => {
+    expect(modelSwitchShouldAutoForceRetry(false, 'exit-timeout', 'agent-not-running')).toBe(false)
+    expect(modelSwitchShouldAutoForceRetry(true, 'exit-timeout', 'threw')).toBe(false)
+    expect(modelSwitchShouldAutoForceRetry(true, 'restarted', 'agent-not-running')).toBe(false)
+  })
+})
+
+describe('modelSwitchRepairVerdict', () => {
+  it('marks only a restarted and verified cure successful and spent', () => {
+    expect(modelSwitchRepairVerdict('restarted', true)).toEqual({
+      state: 'ok',
+      spendAsk: true
+    })
+  })
+
+  it('keeps an uncured restart or refusal failed, actionable, and unspent', () => {
+    expect(modelSwitchRepairVerdict('restarted', false)).toEqual({
+      state: 'failed',
+      spendAsk: false
+    })
+    expect(modelSwitchRepairVerdict('not-eligible', true)).toEqual({
+      state: 'failed',
+      spendAsk: false
+    })
+  })
+})

--- a/src/renderer/lib/modelSwitchProgress.ts
+++ b/src/renderer/lib/modelSwitchProgress.ts
@@ -1,0 +1,41 @@
+export type ModelSwitchProgressRowState = 'pending' | 'running' | 'ok' | 'failed'
+
+/**
+ * Auto-dismiss is deliberately narrower than "the loop finished" or "nothing timed out".
+ * Refusals are rendered as failed rows too, and those are exactly the sessions the user must be
+ * able to inspect and retry. Only an all-successful, non-empty batch may disappear on a timer;
+ * failed/pending/running rows remain until an explicit repair or dismissal changes them.
+ */
+export function modelSwitchProgressCanAutoDismiss(
+  rows: readonly { state: ModelSwitchProgressRowState }[] | null | undefined
+): boolean {
+  return !!rows?.length && rows.every((row) => row.state === 'ok')
+}
+
+/**
+ * A replacement shell whose separately proven agent child died is the one failure for which the
+ * initial grouped pass should repeat the full recycle once. This is exactly what the user's later
+ * Retry click does, made bounded and explicit so auth/model/config failures do not loop forever.
+ */
+export function modelSwitchShouldAutoForceRetry(
+  initialPass: boolean,
+  outcome: string,
+  refusalReason: string | undefined
+): boolean {
+  return initialPass && outcome === 'exit-timeout' && refusalReason === 'agent-not-running'
+}
+
+export interface ModelSwitchRepairVerdict {
+  state: 'ok' | 'failed'
+  spendAsk: boolean
+}
+
+/** Lifecycle completion is success only when the accepted launch record proves the cure. */
+export function modelSwitchRepairVerdict(
+  outcome: string,
+  cured: boolean
+): ModelSwitchRepairVerdict {
+  return outcome === 'restarted' && cured
+    ? { state: 'ok', spendAsk: true }
+    : { state: 'failed', spendAsk: false }
+}

--- a/src/renderer/lib/sessionList.test.ts
+++ b/src/renderer/lib/sessionList.test.ts
@@ -163,11 +163,21 @@ describe('buildSessionList', () => {
     expect(a1.usesContext).toBe(true) // claude is USAGE_CAPABLE
   })
 
+  it('carries the recorded launch window to the sidebar context chip', () => {
+    const proj = projects()
+    const agent = proj[0].nodes.find((n) => n.id === 'a1')!
+    agent.agentLaunchContextWindow = 400_000
+    const groups = buildSessionList(proj, null, 'p1', {}, '')
+
+    expect(groups[0].ungrouped.find((s) => s.id === 'a1')?.agentLaunchContextWindow).toBe(400_000)
+  })
+
   it('uses live nodes for the active project instead of serialized ones', () => {
-    const live = [node('t1', { title: 'renamed live' })]
+    const live = [node('t1', { title: 'renamed live', agentLaunchContextWindow: 500_000 })]
     const groups = buildSessionList(projects(), live, 'p1', {}, '')
     const p1 = groups.find((g) => g.projectId === 'p1')!
     expect(p1.ungrouped.map((s) => s.title)).toEqual(['renamed live'])
+    expect(p1.ungrouped[0].agentLaunchContextWindow).toBe(500_000)
   })
 
   it('nests sessions under their canvas group and separates ungrouped ones', () => {

--- a/src/renderer/lib/sessionList.ts
+++ b/src/renderer/lib/sessionList.ts
@@ -13,10 +13,12 @@ export interface SessionNodeInput {
   title: string
   color: string
   agentId?: AgentId
-  /** The node's creation-time managed/linked Claude account (`data.accountId`), for the row's
+  /** The node's creation-time managed/linked Claude account (data.accountId), for the row's
    *  account chip. Absent for a plain terminal — which is exactly the case the OBSERVED account
    *  on the status entry covers. */
   accountId?: string
+  /** Context window baked into this node's launch environment, when discovery knew it. */
+  agentLaunchContextWindow?: number
   cwd?: string
   ssh?: SshConnection
   /** Parent group node id when this node lives inside a canvas group frame. */
@@ -247,6 +249,8 @@ export interface SessionRowVM {
   accountId?: string
   account?: ObservedClaudeAccount
   usesContext: boolean
+  /** Launch-record denominator for the row's context chip; the transcript can trail a switch. */
+  agentLaunchContextWindow?: number
   /** Populated only when the sidebar is grouped by status (rows are flattened across projects):
    *  the project the session belongs to, so the row can show a project monogram and route
    *  project-scoped callbacks. Absent in project mode, where the enclosing group carries it. */
@@ -323,6 +327,7 @@ function toRow(
     accountId: n.accountId,
     account: status?.account,
     usesContext: n.agentId ? hasUsage(n.agentId) : false,
+    agentLaunchContextWindow: n.agentLaunchContextWindow,
     // Only populated in status mode (flattened across projects); absent in project mode.
     projectId: project?.id,
     projectName: project?.name,

--- a/src/renderer/lib/ui-visibility.test.ts
+++ b/src/renderer/lib/ui-visibility.test.ts
@@ -24,7 +24,7 @@ describe('hideable inventories', () => {
   it('list the agreed ids and nothing destructive', () => {
     expect(HIDEABLE_MENU_ITEMS.map((r) => r.id)).toEqual([
       'group', 'remove-from-group', 'colors', 'icon', 'duplicate', 'snap-zone', 'collapse',
-      'markdown-view', 'refresh-terminal'
+      'markdown-view', 'refresh-terminal', 'vanilla-restart'
     ])
     expect(HIDEABLE_HEADER_BUTTONS.map((r) => r.id)).toEqual([
       'maximize', 'refresh', 'mic', 'ai-name', 'comments', 'hide-fanout', 'tidy-fanout'

--- a/src/renderer/lib/ui-visibility.ts
+++ b/src/renderer/lib/ui-visibility.ts
@@ -27,7 +27,8 @@ export const HIDEABLE_MENU_ITEMS: readonly HideableRow[] = [
   { id: 'snap-zone', label: 'Snap to zone' },
   { id: 'collapse', label: 'Collapse / Expand' },
   { id: 'markdown-view', label: 'Markdown view' },
-  { id: 'refresh-terminal', label: 'Refresh terminal' }
+  { id: 'refresh-terminal', label: 'Refresh terminal' },
+  { id: 'vanilla-restart', label: 'Restart on subscription' }
 ]
 
 /** Hideable terminal node header buttons, in header order. */

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -209,6 +209,7 @@ import { withPermissionMode } from '@shared/agents/approval-mode'
 import { assembleLaunchCommand, assembleResumeCommand } from '@shared/agents/launch'
 import { agentEnvSnapshot } from '@renderer/lib/agentEnv'
 import { normalizedAgentModel } from '@shared/agents/model-gateway'
+import { useModelGateway } from '../state/modelGateway'
 import {
   ensureActivePermissionMode,
   claudeCliCapsNow,
@@ -3537,6 +3538,7 @@ export function TerminalNode({
           const customAgent = agentConfig(agentId)
             ? undefined
             : useSettings.getState().settings.customAgents.find((c) => c.id === agentId)
+          const models = useModelGateway.getState().models
           const { command: cmd } = assembleResumeCommand(
             {
               agentId,
@@ -3544,6 +3546,7 @@ export function TerminalNode({
               sessionId: resume.sessionId,
               permissionMode: mode,
               model: data.agentModel,
+              models,
               sharedIdentity: shared,
               // The launch-command override rides the relaunch too, so a wrapper user's node comes
               // back through its wrapper after a reboot — the moment env/account setup matters.
@@ -3674,6 +3677,7 @@ export function TerminalNode({
                     sessionId: undefined,
                     permissionMode: mode,
                     model: data.agentModel,
+                    models,
                     sharedIdentity: shared,
                     launchCmdOverride: agentLaunchOverride(agentId, ownerProjectId)
                   },
@@ -4001,6 +4005,7 @@ export function TerminalNode({
               target,
               getNode(id)?.data.agentModel as string | undefined
             )
+        const gatewayModels = useModelGateway.getState().models
         // A model switch must rebuild the terminal session: URL/key env was fixed when that shell
         // was spawned and may have been configured AFTER this node was created. Do not type the
         // harness's slash-exit command here — an agent composer can treat it as prompt text. Core
@@ -4089,6 +4094,7 @@ export function TerminalNode({
                 sessionId: agentSessionId,
                 permissionMode: await ensureActivePermissionMode(target),
                 model: selectedModel ?? undefined,
+                models: gatewayModels,
                 launchCmdOverride: agentLaunchOverride(target, ownerProjectId)
               },
               launchEnv
@@ -4101,6 +4107,7 @@ export function TerminalNode({
                 sessionId: sessionIdFlagSupported ? agentSessionId : undefined,
                 sessionIdFlagSupported,
                 model: selectedModel ?? undefined,
+                models: gatewayModels,
                 launchCmdOverride: agentLaunchOverride(target, ownerProjectId)
               },
               launchEnv
@@ -4278,6 +4285,7 @@ export function TerminalNode({
             sessionId: agentSessionId,
             permissionMode: await ensureActivePermissionMode(agentId),
             sharedIdentity: false,
+            models: useModelGateway.getState().models,
             // The launch-command override lives on the user's own PATH (or is an absolute path),
             // not in a generated launcher dir, so it rides the wake too — project layer included.
             launchCmdOverride: agentLaunchOverride(agentId, ownerProjectId)

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -35,7 +35,7 @@ import {
 import { fileLinkDialect } from '../terminal/file-link-dialect'
 import { hostPlatformFor } from '../terminal/host-platform'
 import { sshFs } from '../terminal/ssh-fs'
-import type { FsApi, PendingLaunch } from '@shared/types'
+import type { FsApi, PendingLaunch, TerminateForegroundOutcome } from '@shared/types'
 import {
   attachReplay,
   closedByLabel,
@@ -106,7 +106,7 @@ import {
   validCellSize,
   type Vec2
 } from '../lib/glyphGridNode'
-import { cleanEcho, deliverCommand, KILL_LINE, type DeliveryIo } from '../terminal/command-delivery'
+import { cleanEcho, deliverCommand, KILL_LINE, type DeliveryIo, type DeliveryOutcome } from '../terminal/command-delivery'
 import {
   RESUME_MISS_WINDOW_MS,
   detectsResumeMiss,
@@ -131,7 +131,8 @@ import {
   RESTART_EXIT_TIMEOUT_MS,
   type ExitPhaseOutcome,
   type PauseOutcome,
-  type ResumePhaseOutcome
+  type ResumePhaseOutcome,
+  type RestartRefusalReason
 } from '../terminal/agent-restart'
 import { coldResumeDecision, shouldProbeTranscript } from '../terminal/cold-resume-session'
 import type { TranscriptPresence } from '@shared/types'
@@ -142,6 +143,17 @@ import {
   LIVENESS_QUERY_MS
 } from '../terminal/agent-liveness'
 import { shouldAutoWake, shouldColdResume } from '../terminal/hibernation-policy'
+import {
+  AGENT_NOT_RUNNING_AFTER_RESPAWN,
+  agentRespawnPending,
+  beginAgentRespawn,
+  reportAgentRespawn,
+  type AgentRespawnAck
+} from '../terminal/agent-respawn-ack'
+import {
+  agentProcessProofWithin,
+  waitForAgentRespawnProcess
+} from '../terminal/agent-respawn-process'
 import { WakeInputBuffer } from '../terminal/wake-input-buffer'
 import { FindBar } from '../components/FindBar'
 import { IconChat, IconChevronDown, IconChevronRight, IconClose, IconEye, IconEyeOff, IconGrid, IconMic, IconMoveTo, IconPlay, IconReload, IconSearch, IconSparkle } from '../components/icons'
@@ -170,6 +182,7 @@ import { isGlobalKanbanOpen, isKanbanOpen, isOmniKanbanEnabled, useViewMode, vie
 import { useSshConn } from '../state/sshConn'
 import { useWorktrees } from '../state/worktrees'
 import { isRemoteSessionNode } from '@shared/worktree'
+import { modelRespawnErrorKind, modelRespawnTrace } from '@shared/model-respawn-trace'
 import { useSession, useActiveSessionPresence } from '../session/session'
 import { isBrowserRuntime } from '../bridge/runtime'
 import { agentLaunchOverride, COLLAPSED_HEIGHT, NODE_COLORS, type CanvasNode } from '../state/workspace'
@@ -189,13 +202,18 @@ import {
   reportsOwnCopy,
   agentConfig,
   capabilityAgentId,
+  supportsSessionIdFlag,
   type AgentId
 } from '@shared/agents/config'
 import { withPermissionMode } from '@shared/agents/approval-mode'
-import { assembleResumeCommand } from '@shared/agents/launch'
+import { assembleLaunchCommand, assembleResumeCommand } from '@shared/agents/launch'
 import { agentEnvSnapshot } from '@renderer/lib/agentEnv'
 import { normalizedAgentModel } from '@shared/agents/model-gateway'
-import { ensureActivePermissionMode } from '../state/permissionMode'
+import {
+  ensureActivePermissionMode,
+  claudeCliCapsNow,
+  grokCliCapsNow
+} from '../state/permissionMode'
 import { buildSshArgs, sshConnectionIdForProject, sshHostKey, type SshConnection } from '@shared/ssh'
 import {
   chipFor,
@@ -1007,7 +1025,7 @@ export function setRemotelyViewedNodes(nodeIds: readonly string[]): void {
  * decision that turns on attention: the sweep's plan, the exit closure's fire-time re-ask, and the
  * post-mark nudge. It has to be ONE function: the first version of this feature asked the question
  * three times, and the fire-time copy was missing the modal clause — so a card modal opened
- * mid-batch could still have `/exit` typed into it.
+ * mid-batch could still have its live agent terminated out from under the user.
  *
  * Three ways to be watched, and only the first is visible to any observer: the node is on screen,
  * its kanban card modal is open (see `watchedNodeId`), or a phone viewer is attached to its
@@ -1585,8 +1603,8 @@ export function TerminalNode({
   // every non-codex node and for a codex node whose launcher never spoke.
   const codexIdentity = useCodexIdentity((s) => s.byId[id])
   // --- Eco / hibernation wake (see terminal/hibernation-policy.ts) ---
-  // A hibernated node's CLI was asked to `/exit` while nobody was looking; its tmux session, pane
-  // and scrollback are untouched, and the conversation comes back with the provider's own
+  // A hibernated node's exact agent process group was identity-verified and SIGTERM'd while nobody
+  // was looking; its tmux session, pane and scrollback are untouched, and the conversation returns with
   // `--resume`. THREE things ask for that here, all through one function:
   //   1. the visibility observer, on the offscreen→visible edge (the everyday path);
   //   2. mount-while-already-visible — a node the canvas opens ON SCREEN never transitions, so
@@ -1887,10 +1905,20 @@ export function TerminalNode({
   // work, which is exactly why nothing here runs on its own.
   const restartInFolder = (): void => {
     setCo(termKey, { staleCwd: false })
-    transport.recycle(id)
-    updateNodeData(id, (n) => ({
-      respawnNonce: ((n.data.respawnNonce as number | undefined) ?? 0) + 1
-    }))
+    void transport.recycle(id).then(
+      () => {
+        updateNodeData(id, (n) => ({
+          respawnNonce: ((n.data.respawnNonce as number | undefined) ?? 0) + 1
+        }))
+      },
+      (error: unknown) => {
+        console.error('[terminal] restart-in-folder recycle failed', error)
+        setCo(termKey, {
+          staleCwd: true,
+          spawnError: 'The terminal could not be restarted. Try again.'
+        })
+      }
+    )
   }
   const dismissStaleCwd = (): void => setCo(termKey, { staleCwd: false })
   const dismissLostSession = (): void => setCo(termKey, { lostSession: false })
@@ -1981,6 +2009,13 @@ export function TerminalNode({
     // xterm + session are built. `myNonce` vs the render-updated ref tells the cleanup below
     // whether it runs for a respawn (worktree move — must NOT park) or a plain unmount.
     const myNonce = data.respawnNonce
+    const respawnGeneration = data.agentRespawnGeneration
+    const reportThisRespawn = (result: AgentRespawnAck): boolean => {
+      if (typeof respawnGeneration !== 'number') return false
+      const accepted = reportAgentRespawn(id, respawnGeneration, result)
+      if (accepted) updateNodeData(id, { agentRespawnGeneration: undefined })
+      return accepted
+    }
     const parked = parkedTerminals.get(termKey)
     if (parked) {
       parkedTerminals.delete(termKey)
@@ -2979,6 +3014,14 @@ export function TerminalNode({
       setCo(termKey, { offline: false })
       sentCols = term.cols
       sentRows = term.rows
+      modelRespawnTrace('spawn.create-requested', {
+        nodeId: id,
+        agentId: data.agentId,
+        model: data.agentModel,
+        clearEnv: data.clearEnv === true,
+        remote: sshRemoteTmux,
+        respawnNonce: typeof data.respawnNonce === 'number' ? data.respawnNonce : 0
+      })
       transport
         .create({
           cols: term.cols,
@@ -3017,10 +3060,23 @@ export function TerminalNode({
           persistent,
           unavailable
         }) => {
+        modelRespawnTrace('spawn.create-resolved', {
+          nodeId: id,
+          agentId: data.agentId,
+          fresh,
+          persistent: persistent ?? true,
+          unavailable: !!unavailable,
+          closed: !!closed,
+          clearEnv: data.clearEnv === true
+        })
         // REFUSED: `requireRemote` and core could not spawn remotely (the master died inside our
         // round-trip, or `ssh` is missing). Nothing was spawned — land in the same offline state
         // the near-side guard above produces, retry included.
         if (unavailable) {
+          reportThisRespawn({
+            ok: false,
+            detail: 'the replacement terminal could not connect to its host'
+          })
           setCo(termKey, { offline: true })
           if (!disposed)
             term.write('\r\n\x1b[90m[not connected — nothing was started locally]\x1b[0m\r\n')
@@ -3032,6 +3088,10 @@ export function TerminalNode({
         // was spawned — land in the same "closed by <name>" state a subscribed co-viewer gets.
         // BEFORE `onDisposed()`: there is no session here, so there is nothing to kill or unwire.
         if (closed) {
+          reportThisRespawn({
+            ok: false,
+            detail: 'the replacement terminal was closed before it could start'
+          })
           setCo(termKey, { closed })
           if (!disposed) term.write('\r\n\x1b[90m[session closed by another user]\x1b[0m\r\n')
           return
@@ -3045,6 +3105,10 @@ export function TerminalNode({
         const onDisposed = (): boolean => {
           const action = disposalAction({ disposed, handedOff: handedOff?.life })
           if (action !== 'teardown') return false
+          reportThisRespawn({
+            ok: false,
+            detail: 'the replacement terminal was torn down before it became ready'
+          })
           offData?.()
           killSession(sid)
           return true
@@ -3312,10 +3376,14 @@ export function TerminalNode({
             unsub()
           })
         }
-        const writeWhenShellReady = (cmd: string): void => {
+        const writeWhenShellReady = (cmd: string, onSettled?: (outcome: DeliveryOutcome) => void): void => {
+          if (life.dead) {
+            onSettled?.('cancelled')
+            return
+          }
           whenShellSettled(() => {
-            cleanups.push(
-              deliverCommand(
+            try {
+              const cancelDelivery = deliverCommand(
                 {
                   write: (d) => transport.write(sid, d),
                   onData: (cb) => transport.onData(sid, cb)
@@ -3325,12 +3393,24 @@ export function TerminalNode({
                   // The one outcome the caller must act on: the line was longer than the pane's
                   // tty could take, so nothing was submitted (#706). Say so — a refusal that is
                   // only visible as an idle pane is the failure this replaces.
-                  if (outcome === 'line-too-long') {
+                  if (outcome === 'line-too-long' && !life.dead) {
                     setCo(termKey, { launchTooLongBytes: lineBytes(cmd) })
                   }
+                  onSettled?.(life.dead ? 'cancelled' : outcome)
                 }
               )
-            )
+              cleanups.push(cancelDelivery)
+            } catch (error) {
+              modelRespawnTrace('cold-resume.delivery-threw', {
+                nodeId: id,
+                agentId,
+                errorKind: modelRespawnErrorKind(error)
+              })
+              reportThisRespawn({
+                ok: false,
+                detail: 'the replacement terminal rejected the resume command'
+              })
+            }
           })
         }
         // Tell the canvas this node can be typed into — the gate its armed-launch loop waits on.
@@ -3352,6 +3432,7 @@ export function TerminalNode({
         //    design. Nothing auto-resumes here — the branch below is `fresh`-only — and the wake
         //    path owns the relaunch. That is the whole feature.
         if (fresh && useAgentStatus.getState().byId[id]?.hibernated) {
+          modelRespawnTrace('spawn.clear-stale-hibernation', { nodeId: id })
           useAgentStatus.getState().setHibernated(id, false)
         }
         // Paused (see agentStatus.paused) is the ONE exception to the "fresh always resumes" rule
@@ -3362,12 +3443,19 @@ export function TerminalNode({
         // The clear-env strip is one-shot: once this spawn has applied it, clear the flag so a later
         // ordinary Restart re-applies the gateway. (The recycle action re-sets it for its own spawn.)
         if (data.clearEnv) {
+          modelRespawnTrace('spawn.clear-env-consumed', { nodeId: id })
           updateNodeData(id, { clearEnv: undefined })
         }
         // Run a one-shot command on first open (e.g. "gh auth login" or the agent CLI), then
         // forget it.
         if (data.initialCommand) {
           writeWhenShellReady(data.initialCommand)
+          if (agentRespawnPending(id, respawnGeneration)) {
+            reportThisRespawn({
+              ok: false,
+              detail: 'the replacement terminal had a conflicting one-shot command'
+            })
+          }
           updateNodeData(id, { initialCommand: undefined })
         } else if (
           fresh &&
@@ -3376,6 +3464,11 @@ export function TerminalNode({
           !data.pendingLaunch &&
           shouldColdResume(pausedNow)
         ) {
+          modelRespawnTrace('cold-resume.begin', {
+            nodeId: id,
+            agentId,
+            model: data.agentModel
+          })
           // Cold restart of an agent node: the live agent is gone, so re-launch it. Resume the
           // prior conversation by its session id when we have one; otherwise start the agent
           // fresh. Plain terminals get nothing here — just the restored shell.
@@ -3463,6 +3556,66 @@ export function TerminalNode({
             // the exact line it launched with. Empty on browser/relay by design.
             agentEnvSnapshot()
           )
+          let launchAttempt = 0
+          const launchAndVerify = (command: string): void => {
+            const attempt = ++launchAttempt
+            writeWhenShellReady(command, (outcome) => {
+              if (attempt !== launchAttempt) return
+              if (outcome !== 'submitted') {
+                reportThisRespawn({
+                  ok: false,
+                  detail: outcome === 'line-too-long'
+                    ? 'the replacement launch command exceeded the terminal line limit'
+                    : 'the replacement terminal did not submit the agent launch command'
+                })
+                return
+              }
+              if (!agentRespawnPending(id, respawnGeneration)) return
+              modelRespawnTrace('cold-resume.agent-proof-begin', {
+                nodeId: id,
+                agentId,
+                generation: respawnGeneration
+              })
+              void waitForAgentRespawnProcess(() => api.pty.agentProcess(id, agentId), {
+                active: () =>
+                  !life.dead && attempt === launchAttempt && agentRespawnPending(id, respawnGeneration),
+                onAttempt: (probeAttempt, proof, stableForMs) => {
+                  modelRespawnTrace('cold-resume.agent-proof-attempt', {
+                    nodeId: id,
+                    agentId,
+                    generation: respawnGeneration,
+                    attempt: probeAttempt,
+                    verdict: proof.verdict,
+                    shellPid: proof.shellPid,
+                    agentPid: proof.agentPid,
+                    stableForMs
+                  })
+                }
+              }).then((proof) => {
+                if (life.dead || attempt !== launchAttempt || !agentRespawnPending(id, respawnGeneration)) return
+                modelRespawnTrace('cold-resume.agent-proof-complete', {
+                  nodeId: id,
+                  agentId,
+                  generation: respawnGeneration,
+                  running: proof.running,
+                  attempts: proof.attempts,
+                  lastVerdict: proof.lastVerdict,
+                  shellPid: proof.shellPid,
+                  agentPid: proof.agentPid,
+                  reason: proof.reason
+                })
+                reportThisRespawn(
+                  proof.running
+                    ? { ok: true }
+                    : {
+                        ok: false,
+                        reason: 'agent-not-running',
+                        detail: AGENT_NOT_RUNNING_AFTER_RESPAWN
+                      }
+                )
+              })
+            })
+          }
           /**
            * Watch the pane for the CLI's own "that conversation does not exist" line and, if it
            * comes, launch the agent FRESH in the same pane.
@@ -3492,13 +3645,14 @@ export function TerminalNode({
             }
             const timer = setTimeout(() => stop(), RESUME_MISS_WINDOW_MS)
             unsub = transport.onData(sid, (chunk) => {
-              if (fired) return
+              if (fired || life.dead) return
               // Escape sequences and line breaks removed: the CLI colours its own output and tmux
               // re-wraps it at the pane width, so a raw match would miss a line that straddles a
               // column boundary. Bounded, so a chatty pane cannot grow this without limit.
               seen = (seen + cleanEcho(chunk)).slice(-4096)
               if (!resumeSessionMissing(agentId, deadId, seen)) return
               fired = true
+              launchAttempt += 1
               stop()
               void (async () => {
                 const pane = await queryPaneWithin(
@@ -3507,7 +3661,11 @@ export function TerminalNode({
                 )
                 // `null` is "we could not see the pane", never "nothing is running in it" — the
                 // same contract every other reader of this query keeps.
-                if (!isShellCommand(pane)) return
+                if (life.dead) return
+                if (!isShellCommand(pane)) {
+                  reportThisRespawn({ ok: false, detail: 'the missing-session fallback could not verify a shell' })
+                  return
+                }
                 const { command: fresh } = assembleResumeCommand(
                   {
                     agentId,
@@ -3520,15 +3678,17 @@ export function TerminalNode({
                   },
                   agentEnvSnapshot()
                 )
-                if (!fresh) return
+                if (!fresh) {
+                  reportThisRespawn({ ok: false, detail: 'the missing-session fallback could not build a launch command' })
+                  return
+                }
                 useAgentStatus.getState().setSessionId(id, undefined)
                 if (data.agentSessionId) updateNodeData(id, { agentSessionId: undefined })
-                writeWhenShellReady(fresh)
+                launchAndVerify(fresh)
               })()
             })
             cleanups.push(stop)
           }
-          if (cmd) writeWhenShellReady(cmd) // same shell-startup race as initialCommand
           // A resume can name a conversation that does not exist — the minted id whose launch
           // never ran (an armed `--after` node, a truncated launch line), or a hook-fed id whose
           // transcript is gone. The CLI then prints one line, exits, and the node keeps its agent
@@ -3536,8 +3696,16 @@ export function TerminalNode({
           // refusal, naming THIS id, and start the agent fresh instead. Armed only when we
           // actually asked to resume something and only for an agent whose message we measured;
           // everything else is byte-identical to before. See terminal/resume-fallback.ts.
-          if (cmd && priorId && detectsResumeMiss(agentId)) {
-            watchResumeMiss(priorId)
+          if (cmd && resume.sessionId && detectsResumeMiss(agentId)) {
+            watchResumeMiss(resume.sessionId)
+          }
+          if (cmd) {
+            launchAndVerify(cmd)
+          } else {
+            reportThisRespawn({
+              ok: false,
+              detail: 'the replacement terminal could not assemble an agent launch command'
+            })
           }
         } else if (fresh && pausedNow) {
           // The auto-resume above was skipped (that's the feature), but this mount's PANE is
@@ -3552,9 +3720,26 @@ export function TerminalNode({
           // longer exists.
           const settled = await queryPaneWithin(() => api.pty.paneCommand(id), RESTART_EXIT_TIMEOUT_MS)
           useAgentStatus.getState().setHibernatedPane(id, settled)
+        } else if (agentRespawnPending(id, respawnGeneration)) {
+          reportThisRespawn({
+            ok: false,
+            detail: fresh
+              ? 'the replacement terminal could not resume this agent'
+              : 'the old terminal session was reattached instead of being replaced'
+          })
         }
       })
       .catch((err: unknown) => {
+        modelRespawnTrace('spawn.create-threw', {
+          nodeId: id,
+          agentId: data.agentId,
+          errorKind: modelRespawnErrorKind(err),
+          dead: life.dead
+        })
+        reportThisRespawn({
+          ok: false,
+          detail: 'the replacement terminal failed to start'
+        })
         // THE missing handler, and the answer to "some terminals are black" (2026-08-06).
         //
         // A rejected create means core started NOTHING: no session to tear down, no data gate to
@@ -3599,8 +3784,8 @@ export function TerminalNode({
     // Is there still a pane to restart in? A spawn in flight has no session yet; a real teardown
     // flips `life.dead`; and a session another client DESTROYED (or one recycled with no
     // replacement) is gone while this component happily stays mounted showing the overlay — the
-    // same states the park branch in the cleanup below refuses to park. Writing `/exit` into any of
-    // them reaches nothing and would be reported as a 6-second "failed (exit timeout)".
+    // same states the park branch in the cleanup below refuses to park. Trying to terminate any of
+    // them reaches nothing and would otherwise be reported as a 6-second exit timeout.
     const restartTarget = (): boolean => {
       const coNow = getCo(termKey)
       return !!sessionId && !life.dead && !coNow.closed && !coNow.ended
@@ -3608,6 +3793,30 @@ export function TerminalNode({
     const unregisterRestart = registerAgentRestart(
       id,
       guardConcurrentRestart(id, async (targetAgentId?: AgentId, targetModel?: string, restartShell?: boolean, clearEnv?: boolean) => {
+        modelRespawnTrace('node-restart.begin', {
+          nodeId: id,
+          requestedAgentId: targetAgentId,
+          targetModel,
+          restartShell: !!restartShell,
+          clearEnv: !!clearEnv,
+          transportSource: session.source
+        })
+        // Refusal is one-attempt evidence. A timeout path does not manufacture a sharper reason,
+        // so retaining an older attempt here would make every caller attribute the new outcome to
+        // stale state (including the grouped pass's bounded agent-not-running retry decision).
+        useAgentStatus.getState().setLastRestartRefusal(id, null)
+        // One refusal, one reason: every early return below writes the side channel
+        // (`agentStatus.lastRestartRefusal`) through this reporter before returning
+        // `'not-eligible'` — the Canvas notice and the grouped-restart strip render the REASON,
+        // not the old five-conditions-behind-one-string line. A success clears the channel.
+        const refuse = (reason: RestartRefusalReason, detail?: string): void => {
+          modelRespawnTrace('node-restart.refused', {
+            nodeId: id,
+            reason,
+            hasDetail: detail !== undefined
+          })
+          useAgentStatus.getState().setLastRestartRefusal(id, { reason, detail })
+        }
         const st = useAgentStatus.getState().byId[id]
         const currentNode = getNode(id)
         const agentSessionId = restartSessionId(st?.sessionId, currentNode?.data.agentSessionId)
@@ -3616,29 +3825,109 @@ export function TerminalNode({
         // value captured when the pane attached, or a later plain Restart would silently reopen
         // the old agent again.
         const sourceAgentId = createdAgentId(currentNode?.data)
+        // ONE stop mechanism for every restart flavor below. Core proves this exact SOURCE
+        // harness PID is still live in the foreground group, SIGTERMs that group, and this shared
+        // phase waits until the pane is a shell before any recycle/resume follows. The target may
+        // be a same-base variant, but it is not running yet — identity must always name `source`.
+        const terminateSourceForeground = (): Promise<TerminateForegroundOutcome> =>
+          sourceAgentId
+            ? api.pty.terminateForeground(id, sourceAgentId)
+            : Promise.resolve('refused')
+        const stoppedAtShell = (
+          outcome: ExitPhaseOutcome
+        ): outcome is 'exited' | 'already-exited' =>
+          outcome === 'exited' || outcome === 'already-exited'
+        const stopForegroundFor = (resumableAgentId: AgentId): Promise<ExitPhaseOutcome> => {
+          if (!agentSessionId) {
+            refuse('no-session')
+            return Promise.resolve('not-eligible')
+          }
+          modelRespawnTrace('node-restart.stop-requested', {
+            nodeId: id,
+            sourceAgentId,
+            resumableAgentId,
+            hasSessionId: true
+          })
+          return performExitPhase({
+            agentId: resumableAgentId,
+            sessionId: agentSessionId,
+            io: restartIo,
+            paneCommand: () => api.pty.paneCommand(id),
+            terminateForeground: terminateSourceForeground,
+            isLive: restartTarget,
+            onRefusal: refuse
+          })
+        }
+        /** Recycle acknowledgement is only teardown. The next TerminalNode lifecycle must also
+         * confirm that it created a fresh PTY and started the cold-resume delivery before this
+         * restart can report success to the grouped progress strip. */
+        const recycleAndAwaitRespawn = async (
+          branch: 'clear-env' | 'model-switch' | 'restart-shell' | 'agent-already-exited',
+          applyRespawnData: (generation: number) => void
+        ): Promise<'restarted' | 'exit-timeout'> => {
+          modelRespawnTrace('node-restart.recycle', { nodeId: id, reason: branch })
+          try {
+            await transport.recycle(id)
+          } catch (error) {
+            modelRespawnTrace('node-restart.recycle-threw', {
+              nodeId: id,
+              reason: branch,
+              errorKind: modelRespawnErrorKind(error)
+            })
+            throw error
+          }
+          modelRespawnTrace('node-restart.recycle-confirmed', { nodeId: id, reason: branch })
+          // Start the replacement deadline only after teardown acknowledged. A slow backend kill
+          // is a recycle failure/latency problem, not evidence that the new PTY missed its own
+          // create+resume deadline — and this component does not bump the nonce until below.
+          const ticket = beginAgentRespawn(id)
+          applyRespawnData(ticket.generation)
+          const ack = await ticket.promise
+          if (!ack.ok) {
+            refuse(ack.reason === 'agent-not-running' ? 'agent-not-running' : 'threw', ack.detail)
+            modelRespawnTrace('node-restart.respawn-failed', {
+              nodeId: id,
+              reason: branch
+            })
+            return 'exit-timeout'
+          }
+          useAgentStatus.getState().setLastRestartRefusal(id, null)
+          modelRespawnTrace('node-restart.complete', {
+            nodeId: id,
+            outcome: 'restarted',
+            branch
+          })
+          return 'restarted'
+        }
         // "Restart on subscription": recycle the session VANILLA — strip the gateway + inherited
         // provider env so the agent falls back to its OWN default provider (Claude's subscription,
         // Copilot's GitHub routing). No model change, no agent change: same agent, same
         // conversation, resumed by the cold-restore path once the fresh shell is up. It recycles
-        // (not in-place `/exit`) for the same reason a model switch does — tmux env changes do not
+        // (not in-place resume) for the same reason a model switch does — tmux env changes do not
         // retroactively change an existing shell, so the gateway vars baked into the live session
         // can only be dropped by respawning. Relay sessions belong to another core/settings store,
         // so this Mac's gateway-stripped env must never be pushed into one.
         //
-        // This branch is gated SEPARATELY from the shared `restartEligibility` below: clearEnv
-        // uses `terminateForeground` (SIGTERM the foreground group by PID — no `/exit` typed into
-        // the pane), so it is safe to interrupt a `working`/`blocked` session. Gateway overload —
+        // This branch is gated SEPARATELY from the shared `restartEligibility` below: clearEnv is
+        // the explicit force-recovery action, so it may interrupt a `working`/`blocked` session.
+        // Every restart now uses the same identity-gated PID terminator; plain restart still keeps
+        // the conservative "do not interrupt active work" policy. Gateway overload —
         // the scenario this exists for — shows up mid-turn, and "wait for the turn to finish" is
-        // impossible when the gateway is down. `clearEnvEligibility` permits busy for that reason;
-        // `restartEligibility` must NOT, because its `/exit` would answer a permission dialog.
+        // impossible when the gateway is down. `clearEnvEligibility` permits busy for that reason.
         if (clearEnv) {
-          if (session.source === 'relay') return 'not-eligible'
+          modelRespawnTrace('node-restart.branch', { nodeId: id, branch: 'clear-env' })
+          if (session.source === 'relay') {
+            refuse('relay')
+            return 'not-eligible'
+          }
           const clearGate = clearEnvEligibility(sourceAgentId, agentSessionId)
-          if (!clearGate.ok || !sourceAgentId) return 'not-eligible'
-          // Identity-gated (same as a model switch): core SIGTERMs the foreground group ONLY if
-          // this agent still owns it, so a stale menu can never kill vim or a build in this pane.
-          if (!(await api.pty.terminateForeground(id, sourceAgentId))) return 'not-eligible'
-          transport.recycle(id)
+          if (!clearGate.ok || !sourceAgentId) {
+            refuse(clearGate.ok ? 'agent-diverged' : clearGate.reason)
+            return 'not-eligible'
+          }
+          const exited = await stopForegroundFor(sourceAgentId)
+          modelRespawnTrace('node-restart.stop-complete', { nodeId: id, outcome: exited })
+          if (!stoppedAtShell(exited)) return exited
           // `clearEnv` rides the respawn's `transport.create` (read from data above) to strip env at
           // spawn; the cold-restore auto-resume relaunches the same agent against the default provider.
           // The node's `agentModel` is a GATEWAY model id (the one a model switch stored, or the one a
@@ -3648,16 +3937,44 @@ export function TerminalNode({
           // a model name that does not exist there. Drop it: the CLI's own default model is what
           // "subscription" means, and a later model switch (or plain Restart re-applying the gateway)
           // sets it again.
-          updateNodeData(id, (node) => ({
-            clearEnv: true,
-            agentModel: undefined,
-            respawnNonce: ((node.data.respawnNonce as number | undefined) ?? 0) + 1
-          }))
-          return 'restarted'
+          return recycleAndAwaitRespawn('clear-env', (generation) => {
+            updateNodeData(id, (node) => ({
+              clearEnv: true,
+              agentModel: undefined,
+              agentRespawnGeneration: generation,
+              respawnNonce: ((node.data.respawnNonce as number | undefined) ?? 0) + 1
+            }))
+          })
         }
-        const gate = restartEligibility(sourceAgentId, st?.state, agentSessionId)
-        if (!gate.ok || !sourceAgentId || !agentSessionId || !restartTarget())
+        let gate = restartEligibility(sourceAgentId, st?.state, agentSessionId)
+        if (
+          !gate.ok &&
+          gate.reason === 'working' &&
+          (targetModel || restartShell) &&
+          session.source !== 'relay' &&
+          sourceAgentId &&
+          agentSessionId &&
+          restartTarget()
+        ) {
+          const proof = await agentProcessProofWithin(
+            () => api.pty.agentProcess(id, sourceAgentId)
+          )
+          const forceRespawn = proof.verdict === 'not-agent'
+          modelRespawnTrace('node-restart.stale-status-proof', {
+            nodeId: id,
+            sourceAgentId,
+            statusState: st?.state,
+            verdict: proof.verdict,
+            shellPid: proof.shellPid,
+            agentPid: proof.agentPid,
+            forceRespawn
+          })
+          if (forceRespawn) gate = { ok: true }
+        }
+        if (!gate.ok || !sourceAgentId || !agentSessionId || !restartTarget()) {
+          refuse(gate.ok ? 'gone' : gate.reason)
           return 'not-eligible'
+        }
         const target = targetAgentId ?? sourceAgentId
         const settings = useSettings.getState().settings
         const builtinTarget = agentConfig(target)
@@ -3669,8 +3986,10 @@ export function TerminalNode({
         if (
           (!builtinTarget && !customTarget) ||
           capabilityAgentId(target) !== capabilityAgentId(sourceAgentId)
-        )
+        ) {
+          refuse('agent-diverged')
           return 'not-eligible'
+        }
         const selectedModel = targetModel
           ? normalizedAgentModel(target, targetModel)
           : normalizedAgentModel(
@@ -3684,17 +4003,29 @@ export function TerminalNode({
         // replacement shell the current gateway env. Relay sessions belong to another
         // core/settings store, so a local gateway must never be pushed into one.
         if (targetModel) {
-          if (!selectedModel || session.source === 'relay') return 'not-eligible'
-          // Identity-gated: core SIGTERMs the foreground group ONLY if `target`'s harness still
-          // owns it, so a stale model-switch menu can never kill vim or a build in this pane.
-          if (!(await api.pty.terminateForeground(id, target))) return 'not-eligible'
-          transport.recycle(id)
-          updateNodeData(id, (node) => ({
-            agentId: target,
-            agentModel: selectedModel,
-            respawnNonce: ((node.data.respawnNonce as number | undefined) ?? 0) + 1
-          }))
-          return 'restarted'
+          modelRespawnTrace('node-restart.branch', {
+            nodeId: id,
+            branch: 'model-switch',
+            sourceAgentId,
+            targetAgentId: target,
+            targetModel,
+            selectedModel
+          })
+          if (!selectedModel || session.source === 'relay') {
+            refuse(session.source === 'relay' ? 'relay' : 'no-model')
+            return 'not-eligible'
+          }
+          const exited = await stopForegroundFor(target)
+          modelRespawnTrace('node-restart.stop-complete', { nodeId: id, outcome: exited })
+          if (!stoppedAtShell(exited)) return exited
+          return recycleAndAwaitRespawn('model-switch', (generation) => {
+            updateNodeData(id, (node) => ({
+              agentId: target,
+              agentModel: selectedModel,
+              agentRespawnGeneration: generation,
+              respawnNonce: ((node.data.respawnNonce as number | undefined) ?? 0) + 1
+            }))
+          })
         }
         // "Restart agent and shell": same quit + recycle as a model switch, but the agent and model
         // are UNCHANGED — the point is a FRESH shell that re-sources the user's profile/env (a
@@ -3704,21 +4035,21 @@ export function TerminalNode({
         // Relay sessions are excluded for the same reason a model switch is: their shell env belongs
         // to another core/settings store, and recycling here would respawn against this Mac's env.
         if (restartShell) {
-          if (session.source === 'relay') return 'not-eligible'
-          const exited = await performExitPhase({
-            agentId: target,
-            sessionId: agentSessionId,
-            io: restartIo,
-            paneCommand: () => api.pty.paneCommand(id),
-            isLive: restartTarget
+          modelRespawnTrace('node-restart.branch', { nodeId: id, branch: 'restart-shell' })
+          if (session.source === 'relay') {
+            refuse('relay')
+            return 'not-eligible'
+          }
+          const exited = await stopForegroundFor(target)
+          modelRespawnTrace('node-restart.stop-complete', { nodeId: id, outcome: exited })
+          if (!stoppedAtShell(exited)) return exited
+          return recycleAndAwaitRespawn('restart-shell', (generation) => {
+            updateNodeData(id, (node) => ({
+              agentId: target,
+              agentRespawnGeneration: generation,
+              respawnNonce: ((node.data.respawnNonce as number | undefined) ?? 0) + 1
+            }))
           })
-          if (exited !== 'exited') return exited
-          transport.recycle(id)
-          updateNodeData(id, (node) => ({
-            agentId: target,
-            respawnNonce: ((node.data.respawnNonce as number | undefined) ?? 0) + 1
-          }))
-          return 'restarted'
         }
         // Built HERE, not inside the choreography: the shared assembly builder is the single funnel
         // for every CLI launch path (shared/agents/launch.ts) and the mode is a renderer-side, async
@@ -3739,24 +4070,48 @@ export function TerminalNode({
         // first thing a user does after a boot, and a cold snapshot would silently relaunch through
         // the bare CLI. Bounded and never-rejecting (see `warmOwningProjectId`).
         const ownerProjectId = await warmOwningProjectId()
-        const { command, missingEnv } = assembleResumeCommand(
-          {
-            agentId: target,
-            customAgent: customTarget,
-            sessionId: agentSessionId,
-            permissionMode: await ensureActivePermissionMode(target),
-            model: selectedModel ?? undefined,
-            // The launch-command override rides the restart too (the global layer is undefined for
-            // a custom target, which already owns its launchCmd) — it is a property of how the
-            // agent launches, so the owning project's own value applies here as well.
-            launchCmdOverride: agentLaunchOverride(target, ownerProjectId)
-          },
-          launchEnv
+        const hookConfirmed = !!st?.sessionId
+        const sessionIdFlagSupported = supportsSessionIdFlag(
+          target,
+          claudeCliCapsNow().sessionIdFlag,
+          grokCliCapsNow().sessionIdFlag
         )
+        const { command, missingEnv } = hookConfirmed
+          ? assembleResumeCommand(
+              {
+                agentId: target,
+                customAgent: customTarget,
+                sessionId: agentSessionId,
+                permissionMode: await ensureActivePermissionMode(target),
+                model: selectedModel ?? undefined,
+                launchCmdOverride: agentLaunchOverride(target, ownerProjectId)
+              },
+              launchEnv
+            )
+          : assembleLaunchCommand(
+              {
+                agentId: target,
+                customAgent: customTarget,
+                permissionMode: await ensureActivePermissionMode(target),
+                sessionId: sessionIdFlagSupported ? agentSessionId : undefined,
+                sessionIdFlagSupported,
+                model: selectedModel ?? undefined,
+                launchCmdOverride: agentLaunchOverride(target, ownerProjectId)
+              },
+              launchEnv
+            )
         // Never type a knowingly mangled launch line (for example `--token ''`) into the pane.
         // Settings already surfaces these missing names in its preview; a stale menu after an env
         // change degrades to the ordinary not-eligible notice and leaves the shell untouched.
-        if (missingEnv.length) return 'not-eligible'
+        if (missingEnv.length) {
+          modelRespawnTrace('node-restart.command-refused', {
+            nodeId: id,
+            reason: 'missing-env',
+            missingEnvCount: missingEnv.length
+          })
+          refuse('missing-env', missingEnv.join(', '))
+          return 'not-eligible'
+        }
         return performRestartResume({
           // Source and target were proven to share one capability base above, so this resolves to
           // the same exit + resume grammar while the explicit command selects the target binary.
@@ -3769,9 +4124,32 @@ export function TerminalNode({
           // Session-scoped (`api`, not the global preload), like readScrollback above: a relay
           // tab's pane lives on the host, and only its own api can see it.
           paneCommand: () => api.pty.paneCommand(id),
+          terminateForeground: terminateSourceForeground,
+          // If the agent is not running, force the stronger recovery path: recycle the whole local
+          // session without PID-targeting its current owner as the agent, then let cold restore resume
+          // the same conversation in a fresh shell. Relay shells live on another core, so they
+          // omit this callback and use the in-place fallback instead.
+          onAlreadyExited:
+            session.source === 'relay'
+              ? undefined
+              : () => {
+                  modelRespawnTrace('node-restart.force-respawn', {
+                    nodeId: id,
+                    sourceAgentId,
+                    targetAgentId: target
+                  })
+                  return recycleAndAwaitRespawn('agent-already-exited', (generation) => {
+                    updateNodeData(id, (node) => ({
+                      agentId: target,
+                      agentRespawnGeneration: generation,
+                      respawnNonce: ((node.data.respawnNonce as number | undefined) ?? 0) + 1
+                    }))
+                  })
+                },
           // Re-asked on every poll: a session that dies under the restart reports honestly instead
           // of counting a phantom, and stops polling a pane that no longer exists.
           isLive: restartTarget,
+          onRefusal: refuse,
           // The delivery has its own (echo-verify) lifetime, so hand it to the session: a real
           // teardown runs `cleanups`, and a session that died while we waited for the shell cancels
           // it outright rather than parking a timer on a corpse.
@@ -3792,20 +4170,31 @@ export function TerminalNode({
     // (parked → remounted) terminal never reaches the spawn continuation.
     const unregisterHibernate = registerAgentHibernate(id, {
       exit: guardConcurrentRestart(id, async (): Promise<ExitPhaseOutcome> => {
+        // The exit half's refusals also report ONE reason (Eco's own sweep surfaces them via its
+        // skip counts; a manual wake failure reads them).
+        const refuse = (reason: RestartRefusalReason, detail?: string): void => {
+          useAgentStatus.getState().setLastRestartRefusal(id, { reason, detail })
+        }
         // "Is the user looking at this session STILL?" — re-asked at FIRE time, never trusted from
         // the plan, the same discipline as `mayDisposeOffscreen`. A sweep can spend ~12 s working
         // through its batch, and the node whose turn comes last may be one the user panned back to
-        // (or opened as a card modal) and is now typing in: KILL_LINE + `/exit` would land in a
-        // pane they are watching, taking their half-written prompt with it. Worse, the visible
+        // (or opened as a card modal) and is now typing in: terminating the agent would discard
+        // the turn or half-written prompt they are watching. Worse, the visible
         // EDGE has already passed by then, so no wake trigger is left and the node would sit
         // SLEEPING on screen until clicked. Deliberately the SAME `isNodeWatched` the plan and the
         // nudge ask — a second copy of this question is how the modal clause went missing once.
-        if (isNodeWatched(id)) return 'not-eligible'
+        if (isNodeWatched(id)) {
+          refuse('busy')
+          return 'not-eligible'
+        }
         // SSH / relay sessions are excluded in v1, exactly as the offscreen dispose excludes them
         // (offscreen-policy.ts): the exit and its much later resume would race the ControlMaster /
         // relay lifecycle, and a wake that cannot reach the host leaves a dead conversation behind.
         // Read at CALL time — a local project can BECOME an SSH project long after this mount.
-        if (offscreenRemoteRef.current) return 'not-eligible'
+        if (offscreenRemoteRef.current) {
+          refuse('relay')
+          return 'not-eligible'
+        }
         const st = useAgentStatus.getState().byId[id]
         // Already paused (shallow OR deep — deep has `hibernated` unset, so this is the only
         // thing that catches it): the plan already excludes this via `HibernationCandidate.paused`,
@@ -3815,15 +4204,19 @@ export function TerminalNode({
         if (st?.paused) return 'not-eligible'
         const agentSessionId = st?.sessionId
         // Re-asked here, not trusted from the plan: a node that started working between the sweep's
-        // decision and its turn must keep its turn (BUSY_STATES — an exit line typed into a
-        // permission prompt ANSWERS it).
+        // decision and its turn must keep its turn (BUSY_STATES — Eco mode must never interrupt
+        // live work or a permission decision merely because it became offscreen).
         const gate = restartEligibility(agentId, st?.state, agentSessionId)
-        if (!gate.ok || !agentId || !agentSessionId || !restartTarget()) return 'not-eligible'
+        if (!gate.ok || !agentId || !agentSessionId || !restartTarget()) {
+          refuse(gate.ok ? 'gone' : gate.reason)
+          return 'not-eligible'
+        }
         const outcome = await performExitPhase({
           agentId,
           sessionId: agentSessionId,
           io: restartIo,
           paneCommand: () => api.pty.paneCommand(id),
+          terminateForeground: () => api.pty.terminateForeground(id, agentId),
           isLive: restartTarget
         })
         if (outcome === 'exited') {
@@ -3844,9 +4237,15 @@ export function TerminalNode({
         return outcome
       }),
       resume: guardConcurrentRestart(id, async (): Promise<ResumePhaseOutcome> => {
+        const refuse = (reason: RestartRefusalReason, detail?: string): void => {
+          useAgentStatus.getState().setLastRestartRefusal(id, { reason, detail })
+        }
         const st = useAgentStatus.getState().byId[id]
         const agentSessionId = st?.sessionId
-        if (!agentId || !agentSessionId || !restartTarget()) return 'not-eligible'
+        if (!agentId || !agentSessionId || !restartTarget()) {
+          refuse('gone')
+          return 'not-eligible'
+        }
         // Command FIRST, pane check LAST. Both of these awaits can take a moment (the claude
         // version probe behind `ensureActivePermissionMode` most of all), and whatever is asked
         // first is stale by the time the delivery runs — so the fact that must be freshest is the
@@ -3886,7 +4285,10 @@ export function TerminalNode({
         // and would refuse too — but the KILL_LINE below is ours, so leaving this check to it
         // meant an unusable session id erased the pane's line (three times, once per wake trigger)
         // and then declined to resume.
-        if (!command) return 'not-eligible'
+        if (!command) {
+          refuse('no-session')
+          return 'not-eligible'
+        }
         // THE load-bearing gate of the wake half. Hours can pass between the exit and this
         // resume, and the pane is a REPL the user can type into: by now it may belong to vim, to
         // `top`, or to a claude the user launched by hand — and a launch line typed into a live
@@ -3899,7 +4301,12 @@ export function TerminalNode({
         // allowlist-free signal — from being hibernated and never woken.
         const pane = await queryPaneWithin(() => api.pty.paneCommand(id), RESTART_EXIT_TIMEOUT_MS)
         const settled = useAgentStatus.getState().byId[id]?.hibernatedPane
-        if (!isShellCommand(pane) && !(pane !== null && pane === settled)) return 'not-eligible'
+        if (!isShellCommand(pane) && !(pane !== null && pane === settled)) {
+          // The pane's actual foreground command IS the log: `vim` reads differently from a
+          // claude the user launched by hand.
+          refuse('pane-not-shell', typeof pane === 'string' ? pane : 'unreadable pane')
+          return 'not-eligible'
+        }
         // Clear the line before the launch line goes in. The shell above is the one WE exited to,
         // hours ago — nothing stops a passer-by (or a stray paste, or the user's own aborted
         // command) from having left a half-typed line at its prompt, and `deliverCommand`'s first
@@ -3953,6 +4360,7 @@ export function TerminalNode({
               sessionId: agentSessionId,
               io: restartIo,
               paneCommand: () => api.pty.paneCommand(id),
+              terminateForeground: () => api.pty.terminateForeground(id, agentId),
               isLive: restartTarget
             })
         if (outcome !== 'exited') return outcome

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -202,13 +202,18 @@ import {
   reportsOwnCopy,
   agentConfig,
   capabilityAgentId,
+  canSwitchModel,
   supportsSessionIdFlag,
   type AgentId
 } from '@shared/agents/config'
 import { withPermissionMode } from '@shared/agents/approval-mode'
 import { assembleLaunchCommand, assembleResumeCommand } from '@shared/agents/launch'
 import { agentEnvSnapshot } from '@renderer/lib/agentEnv'
-import { normalizedAgentModel } from '@shared/agents/model-gateway'
+import {
+  claudeAutocompactFor,
+  modelContextWindow,
+  normalizedAgentModel
+} from '@shared/agents/model-gateway'
 import { useModelGateway } from '../state/modelGateway'
 import {
   ensureActivePermissionMode,
@@ -3539,6 +3544,11 @@ export function TerminalNode({
             ? undefined
             : useSettings.getState().settings.customAgents.find((c) => c.id === agentId)
           const models = useModelGateway.getState().models
+          const coldLaunchModel =
+            data.agentModel && canSwitchModel(agentId)
+              ? claudeAutocompactFor(agentId, data.agentModel, models).modelId
+              : undefined
+          const coldLaunchContextWindow = modelContextWindow(coldLaunchModel, models)
           const { command: cmd } = assembleResumeCommand(
             {
               agentId,
@@ -3573,6 +3583,10 @@ export function TerminalNode({
                 })
                 return
               }
+              updateNodeData(id, {
+                agentLaunchModel: coldLaunchModel,
+                agentLaunchContextWindow: coldLaunchContextWindow
+              })
               if (!agentRespawnPending(id, respawnGeneration)) return
               modelRespawnTrace('cold-resume.agent-proof-begin', {
                 nodeId: id,
@@ -4006,6 +4020,14 @@ export function TerminalNode({
               getNode(id)?.data.agentModel as string | undefined
             )
         const gatewayModels = useModelGateway.getState().models
+        const selectedLaunchModel =
+          selectedModel && canSwitchModel(target)
+            ? claudeAutocompactFor(target, selectedModel, gatewayModels).modelId
+            : undefined
+        const selectedLaunchContextWindow = modelContextWindow(
+          selectedLaunchModel,
+          gatewayModels
+        )
         // A model switch must rebuild the terminal session: URL/key env was fixed when that shell
         // was spawned and may have been configured AFTER this node was created. Do not type the
         // harness's slash-exit command here — an agent composer can treat it as prompt text. Core
@@ -4124,7 +4146,8 @@ export function TerminalNode({
           refuse('missing-env', missingEnv.join(', '))
           return 'not-eligible'
         }
-        return performRestartResume({
+        let usedColdRespawn = false
+        const outcome = await performRestartResume({
           // Source and target were proven to share one capability base above, so this resolves to
           // the same exit + resume grammar while the explicit command selects the target binary.
           agentId: target,
@@ -4145,6 +4168,10 @@ export function TerminalNode({
             session.source === 'relay'
               ? undefined
               : () => {
+                  // The cold-restore delivery records the catalogue it actually assembles after
+                  // the recycle. Keep that later snapshot authoritative if settings change while
+                  // the old pane is being replaced.
+                  usedColdRespawn = true
                   modelRespawnTrace('node-restart.force-respawn', {
                     nodeId: id,
                     sourceAgentId,
@@ -4170,6 +4197,13 @@ export function TerminalNode({
             else cleanups.push(cancel)
           }
         })
+        if (outcome === 'restarted' && !usedColdRespawn) {
+          updateNodeData(id, {
+            agentLaunchModel: selectedLaunchModel,
+            agentLaunchContextWindow: selectedLaunchContextWindow
+          })
+        }
+        return outcome
       })
     )
 
@@ -5609,7 +5643,13 @@ export function TerminalNode({
             SSH {(data.ssh as SshConnection).user}@{(data.ssh as SshConnection).host}
           </span>
         ) : null}
-        {showUsage && <ContextMeter sessionId={status?.sessionId ?? null} />}
+        {showUsage && (
+          <ContextMeter
+            sessionId={status?.sessionId ?? null}
+            nodeModel={data.agentLaunchModel as string | undefined}
+            nodeContextWindow={data.agentLaunchContextWindow as number | undefined}
+          />
+        )}
         {/* Who else is in this node. Subscribes to presence itself — see PresenceChips. */}
         <PresenceChips nodeId={id} />
         {status?.state === 'working' && (

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -125,6 +125,7 @@ import {
   registerAgentHibernate,
   registerAgentPause,
   registerAgentRestart,
+  clearEnvEligibility,
   restartEligibility,
   restartSessionId,
   RESTART_EXIT_TIMEOUT_MS,
@@ -2994,6 +2995,9 @@ export function TerminalNode({
           ownerProjectId: sshProjectId ?? useProjects.getState().activeProjectId,
           agentId: data.agentId,
           agentModel: data.agentModel,
+          // "Restart on subscription": ride the spawn's env-strip path. Cleared below once the
+          // spawn resolves so an ordinary Restart re-applies the gateway (one-shot).
+          clearEnv: data.clearEnv === true,
           accountId: data.accountId,
           sshRemote,
           // Belt AND braces: the guard above cannot see a `ssh` executable that has gone missing,
@@ -3355,6 +3359,11 @@ export function TerminalNode({
         // the auto-resume branch below must be skipped — only an explicit Resume (which reuses the
         // same command-building path through the registered hibernate/wake pair) may relaunch it.
         const pausedNow = !!useAgentStatus.getState().byId[id]?.paused
+        // The clear-env strip is one-shot: once this spawn has applied it, clear the flag so a later
+        // ordinary Restart re-applies the gateway. (The recycle action re-sets it for its own spawn.)
+        if (data.clearEnv) {
+          updateNodeData(id, { clearEnv: undefined })
+        }
         // Run a one-shot command on first open (e.g. "gh auth login" or the agent CLI), then
         // forget it.
         if (data.initialCommand) {
@@ -3598,7 +3607,7 @@ export function TerminalNode({
     }
     const unregisterRestart = registerAgentRestart(
       id,
-      guardConcurrentRestart(id, async (targetAgentId?: AgentId, targetModel?: string, restartShell?: boolean) => {
+      guardConcurrentRestart(id, async (targetAgentId?: AgentId, targetModel?: string, restartShell?: boolean, clearEnv?: boolean) => {
         const st = useAgentStatus.getState().byId[id]
         const currentNode = getNode(id)
         const agentSessionId = restartSessionId(st?.sessionId, currentNode?.data.agentSessionId)
@@ -3607,6 +3616,37 @@ export function TerminalNode({
         // value captured when the pane attached, or a later plain Restart would silently reopen
         // the old agent again.
         const sourceAgentId = createdAgentId(currentNode?.data)
+        // "Restart on subscription": recycle the session VANILLA — strip the gateway + inherited
+        // provider env so the agent falls back to its OWN default provider (Claude's subscription,
+        // Copilot's GitHub routing). No model change, no agent change: same agent, same
+        // conversation, resumed by the cold-restore path once the fresh shell is up. It recycles
+        // (not in-place `/exit`) for the same reason a model switch does — tmux env changes do not
+        // retroactively change an existing shell, so the gateway vars baked into the live session
+        // can only be dropped by respawning. Relay sessions belong to another core/settings store,
+        // so this Mac's gateway-stripped env must never be pushed into one.
+        //
+        // This branch is gated SEPARATELY from the shared `restartEligibility` below: clearEnv
+        // uses `terminateForeground` (SIGTERM the foreground group by PID — no `/exit` typed into
+        // the pane), so it is safe to interrupt a `working`/`blocked` session. Gateway overload —
+        // the scenario this exists for — shows up mid-turn, and "wait for the turn to finish" is
+        // impossible when the gateway is down. `clearEnvEligibility` permits busy for that reason;
+        // `restartEligibility` must NOT, because its `/exit` would answer a permission dialog.
+        if (clearEnv) {
+          if (session.source === 'relay') return 'not-eligible'
+          const clearGate = clearEnvEligibility(sourceAgentId, agentSessionId)
+          if (!clearGate.ok || !sourceAgentId) return 'not-eligible'
+          // Identity-gated (same as a model switch): core SIGTERMs the foreground group ONLY if
+          // this agent still owns it, so a stale menu can never kill vim or a build in this pane.
+          if (!(await api.pty.terminateForeground(id, sourceAgentId))) return 'not-eligible'
+          transport.recycle(id)
+          // `clearEnv` rides the respawn's `transport.create` (read from data above) to strip env at
+          // spawn; the cold-restore auto-resume relaunches the same agent against the default provider.
+          updateNodeData(id, (node) => ({
+            clearEnv: true,
+            respawnNonce: ((node.data.respawnNonce as number | undefined) ?? 0) + 1
+          }))
+          return 'restarted'
+        }
         const gate = restartEligibility(sourceAgentId, st?.state, agentSessionId)
         if (!gate.ok || !sourceAgentId || !agentSessionId || !restartTarget())
           return 'not-eligible'

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -3641,8 +3641,16 @@ export function TerminalNode({
           transport.recycle(id)
           // `clearEnv` rides the respawn's `transport.create` (read from data above) to strip env at
           // spawn; the cold-restore auto-resume relaunches the same agent against the default provider.
+          // The node's `agentModel` is a GATEWAY model id (the one a model switch stored, or the one a
+          // gateway node was created with): it only resolves through the gateway the strip just removed.
+          // Leaving it set would make the resume line append `--model <gateway-model>`, which the
+          // subscription CLI does not know — so the agent fails to launch against the subscription with
+          // a model name that does not exist there. Drop it: the CLI's own default model is what
+          // "subscription" means, and a later model switch (or plain Restart re-applying the gateway)
+          // sets it again.
           updateNodeData(id, (node) => ({
             clearEnv: true,
+            agentModel: undefined,
             respawnNonce: ((node.data.respawnNonce as number | undefined) ?? 0) + 1
           }))
           return 'restarted'

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -3632,6 +3632,7 @@ export function TerminalNode({
            * minted one on the node), so the next cold restore does not replay it.
            */
           const watchResumeMiss = (deadId: string): void => {
+            if (life.dead) return
             let fired = false
             let seen = ''
             // `unsub` is assigned on the line after the timer is armed, and `stop` is pushed to
@@ -3682,8 +3683,12 @@ export function TerminalNode({
                   reportThisRespawn({ ok: false, detail: 'the missing-session fallback could not build a launch command' })
                   return
                 }
-                useAgentStatus.getState().setSessionId(id, undefined)
-                if (data.agentSessionId) updateNodeData(id, { agentSessionId: undefined })
+                if (useAgentStatus.getState().byId[id]?.sessionId === deadId) {
+                  useAgentStatus.getState().setSessionId(id, undefined)
+                }
+                if (getNode(id)?.data.agentSessionId === deadId) {
+                  updateNodeData(id, { agentSessionId: undefined })
+                }
                 launchAndVerify(fresh)
               })()
             })

--- a/src/renderer/nodes/session-ready-signal.test.ts
+++ b/src/renderer/nodes/session-ready-signal.test.ts
@@ -40,7 +40,9 @@ describe('where readiness is published (source pins)', () => {
     // tty flush comes out mangled, which is exactly what `whenShellSettled` exists to avoid — so
     // the armed launch must not be released on a bare create-resolve.
     expect(src).toContain('whenShellSettled(() => setSessionReady(id, true))')
-    expect(src).toContain('const writeWhenShellReady = (cmd: string): void => {')
+    expect(src).toContain(
+      'const writeWhenShellReady = (cmd: string, onSettled?: (live: boolean) => void): void => {'
+    )
     expect(src).toMatch(/whenShellSettled\(\(\) => \{[\s\S]{0,400}?deliverCommand\(/)
   })
 

--- a/src/renderer/nodes/session-ready-signal.test.ts
+++ b/src/renderer/nodes/session-ready-signal.test.ts
@@ -41,7 +41,7 @@ describe('where readiness is published (source pins)', () => {
     // the armed launch must not be released on a bare create-resolve.
     expect(src).toContain('whenShellSettled(() => setSessionReady(id, true))')
     expect(src).toContain(
-      'const writeWhenShellReady = (cmd: string, onSettled?: (live: boolean) => void): void => {'
+      'const writeWhenShellReady = (cmd: string, onSettled?: (outcome: DeliveryOutcome) => void): void => {'
     )
     expect(src).toMatch(/whenShellSettled\(\(\) => \{[\s\S]{0,400}?deliverCommand\(/)
   })

--- a/src/renderer/nodes/title-gate.test.ts
+++ b/src/renderer/nodes/title-gate.test.ts
@@ -173,7 +173,8 @@ describe('claude-transcript gates', () => {
     // narrowing THAT to claude would take codex's and gemini's meters away.
     const found = sites('<ContextMeter')
     expect(found.length).toBe(1)
-    const [lineNo, text] = found[0]
-    expect(text, `${lineNo}: ${text.trim()}`).toContain('showUsage &&')
+    const [lineNo] = found[0]
+    const guard = lines.slice(Math.max(0, lineNo - 3), lineNo).join('\n')
+    expect(guard, `${lineNo}: ContextMeter guard`).toMatch(/\{showUsage &&\s*(?:\(\s*)?<ContextMeter\b/)
   })
 })

--- a/src/renderer/state/agentStatus.ts
+++ b/src/renderer/state/agentStatus.ts
@@ -3,6 +3,7 @@ import { WORKING_STALE_MS } from '@shared/agents/stale'
 import type { AgentId } from '@shared/agents/config'
 import type { AgentState } from '@shared/agents/normalize'
 import type { NodeTerminalApi, ObservedClaudeAccount } from '@shared/types'
+import type { RestartRefusalReason } from '@renderer/terminal/agent-restart'
 
 /**
  * Transient per-node status for agent (e.g. Claude Code) sessions, driven by the agent's hooks.
@@ -63,9 +64,9 @@ export interface AgentNodeStatus {
   lastEventAt?: number
   /**
    * When this node last launched a BACKGROUND shell task (Claude's `Bash` with
-   * `run_in_background: true`). Such a task lives inside the CLI process, so `/exit` — Eco
-   * hibernation and the bulk in-place restart both type it — kills it silently, with no output and
-   * no error. The stamp is what those two exclude on.
+   * `run_in_background: true`). Such a task lives inside the CLI process, so terminating that
+   * exact process group for Eco or bulk restart kills it silently, with no output and no error.
+   * The stamp is what those two exclude on.
    *
    * TRANSIENT — never persisted, same rationale as `lastEventAt`: after a relaunch Eco is inert
    * until a turn happens anyway, and any turn's `working` would have cleared this. A stale stamp
@@ -118,6 +119,11 @@ export interface AgentNodeStatus {
    * it can still see.
    */
   dropped?: boolean
+  /**
+   * The LAST refusal reason this node's restart/exit reported (see the store method of the same
+   * idea). TRANSIENT — never persisted; absent = no refusal since the last success.
+   */
+  lastRestartRefusal?: { reason: RestartRefusalReason; detail?: string; at: number }
   /** Which agent this node is running (claude/codex/gemini/…), when known. */
   agentId?: AgentId
   /**
@@ -181,7 +187,7 @@ export interface AgentNodeStatus {
      * with its session anyway.
      *
      * It matters beyond the card: `loop` is the ONLY record that this node has a wakeup pending,
-     * and it is what stops Eco mode from hibernating it (`/exit` kills the CLI process, and the
+     * and it is what stops Eco mode from hibernating it (terminating the CLI process also kills the
      * scheduled wakeup dies with it — a silently cancelled job). Clearing the entry on dismiss
      * dropped that guard while the job lived on, so the fact is now retained and only the RENDER
      * filters on it. A real end (CronDelete) still clears the entry.
@@ -265,6 +271,19 @@ export interface AgentStatusStore {
   /** Record a /loop iteration (count++ and append its summary). No-op if not looping. */
   bumpLoop(id: string, message?: string): void
   remove(id: string): void
+  /**
+   * WHY this node's last restart, model switch or hibernation exit refused — ONE refusal, ONE — ONE refusal, ONE
+   * reason. Written by every refusal site in the restart closure (TerminalNode) and the
+   * restart/hibernate phases (agent-restart.ts) immediately before their early return, and read
+   * by the Canvas notice and the grouped-restart strip so an unexplained ✗ row or the old
+   * five-conditions-behind-one-string notice dies. TRANSIENT — never persisted: a stale refusal
+   * from before an app reload would explain a restart that never happened. Cleared on a
+   * successful restart of the node.
+   */
+  setLastRestartRefusal(
+    id: string,
+    refusal: { reason: RestartRefusalReason; detail?: string } | null
+  ): void
 }
 
 const EMPTY: AgentNodeStatus = { unread: false }
@@ -799,6 +818,17 @@ export function createAgentStatusSession(
         delete byId[id]
         save(byId)
         return { byId }
+      }),
+    setLastRestartRefusal: (id, refusal) =>
+      set((s) => {
+        const prev = s.byId[id]
+        if (!prev && !refusal) return s
+        const next: AgentNodeStatus = {
+          ...prev ?? EMPTY,
+          lastRestartRefusal: refusal ? { ...refusal, at: Date.now() } : undefined
+        }
+        // No persistence — see the field's JSDoc.
+        return { byId: { ...s.byId, [id]: next } }
       })
   }))
 

--- a/src/renderer/state/modelGateway.test.ts
+++ b/src/renderer/state/modelGateway.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  sameModelGatewayDiscoveryConfig,
+  useModelGateway
+} from './modelGateway'
+
+describe('model gateway catalogue provenance', () => {
+  beforeEach(() => {
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {
+      agent: { discoverModels: vi.fn() }
+    }
+    useModelGateway.getState().clear()
+  })
+
+  it('treats conventional discovery-path spellings as the same configuration', () => {
+    expect(
+      sameModelGatewayDiscoveryConfig(
+        { baseUrl: 'https://gateway.test/', apiKey: ' key ' },
+        { baseUrl: 'https://gateway.test', apiKey: 'key', discoveryPath: '/v1/models' }
+      )
+    ).toBe(true)
+  })
+
+  it('drops a deferred response after synchronous invalidation', async () => {
+    let resolve!: (value: { models: Array<{ id: string; contextWindow: number }> }) => void
+    vi.mocked(window.nodeTerminal.agent.discoverModels).mockReturnValue(
+      new Promise((done) => { resolve = done })
+    )
+    const pending = useModelGateway.getState().discover({
+      baseUrl: 'https://old.test',
+      apiKey: 'old'
+    })
+
+    useModelGateway.getState().clear()
+    resolve({ models: [{ id: 'old', contextWindow: 1_000_000 }] })
+    await pending
+
+    expect(useModelGateway.getState()).toMatchObject({ models: [], status: 'idle' })
+  })
+})

--- a/src/renderer/state/modelGateway.test.ts
+++ b/src/renderer/state/modelGateway.test.ts
@@ -36,6 +36,53 @@ describe('model gateway catalogue provenance', () => {
     resolve({ models: [{ id: 'old', contextWindow: 1_000_000 }] })
     await pending
 
-    expect(useModelGateway.getState()).toMatchObject({ models: [], status: 'idle' })
+    expect(useModelGateway.getState()).toMatchObject({
+      models: [],
+      status: 'idle',
+      discoveryAt: undefined
+    })
+  })
+
+  it('does not advance completion when an older request lands after the current one', async () => {
+    const resolves: Array<(value: { models: Array<{ id: string }> }) => void> = []
+    vi.mocked(window.nodeTerminal.agent.discoverModels).mockImplementation(
+      () => new Promise((resolve) => resolves.push(resolve))
+    )
+    const older = useModelGateway.getState().discover({ baseUrl: 'https://old.test', apiKey: 'old' })
+    const current = useModelGateway.getState().discover({ baseUrl: 'https://new.test', apiKey: 'new' })
+
+    resolves[1]({ models: [{ id: 'current' }] })
+    await current
+    const completion = useModelGateway.getState().discoveryAt
+    resolves[0]({ models: [{ id: 'stale' }] })
+    await older
+
+    expect(useModelGateway.getState()).toMatchObject({
+      models: [{ id: 'current' }],
+      status: 'ready',
+      discoveryAt: completion
+    })
+  })
+
+  it('advances only the current completion, including ready-empty and error results', async () => {
+    vi.mocked(window.nodeTerminal.agent.discoverModels)
+      .mockResolvedValueOnce({ models: [] })
+      .mockResolvedValueOnce({ models: [], error: 'unavailable' })
+
+    await useModelGateway.getState().discover({ baseUrl: 'https://gateway.test', apiKey: 'key' })
+    expect(useModelGateway.getState()).toMatchObject({
+      models: [],
+      status: 'ready',
+      discoveryAt: expect.any(Number)
+    })
+    const firstCompletion = useModelGateway.getState().discoveryAt
+
+    await useModelGateway.getState().discover({ baseUrl: 'https://gateway.test', apiKey: 'key' })
+    expect(useModelGateway.getState()).toMatchObject({
+      models: [],
+      status: 'error',
+      discoveryAt: expect.any(Number)
+    })
+    expect(useModelGateway.getState().discoveryAt).toBeGreaterThan(firstCompletion ?? 0)
   })
 })

--- a/src/renderer/state/modelGateway.ts
+++ b/src/renderer/state/modelGateway.ts
@@ -1,5 +1,9 @@
 import { create } from 'zustand'
-import type { GatewayModel, ModelGatewaySettings } from '@shared/agents/model-gateway'
+import {
+  modelGatewayRoutes,
+  type GatewayModel,
+  type ModelGatewaySettings
+} from '@shared/agents/model-gateway'
 
 export type ModelDiscoveryStatus = 'idle' | 'loading' | 'ready' | 'error'
 
@@ -14,6 +18,16 @@ interface ModelGatewayState {
 // A later request supersedes an earlier one. Editing the gateway URL/key can otherwise let a slow
 // response from the OLD endpoint land after the new catalogue and silently replace it.
 let requestSeq = 0
+
+/** Renderer-visible equality for catalogue provenance; resolved credentials stay in core. */
+export function sameModelGatewayDiscoveryConfig(
+  left: ModelGatewaySettings,
+  right: ModelGatewaySettings
+): boolean {
+  const leftRoute = modelGatewayRoutes(left.baseUrl, left.discoveryPath)?.discovery ?? null
+  const rightRoute = modelGatewayRoutes(right.baseUrl, right.discoveryPath)?.discovery ?? null
+  return leftRoute === rightRoute && left.apiKey.trim() === right.apiKey.trim()
+}
 
 export const useModelGateway = create<ModelGatewayState>((set) => ({
   models: [],

--- a/src/renderer/state/modelGateway.ts
+++ b/src/renderer/state/modelGateway.ts
@@ -11,6 +11,8 @@ interface ModelGatewayState {
   models: GatewayModel[]
   status: ModelDiscoveryStatus
   error: string
+  /** Monotonic completion marker for the current, non-superseded discovery request. */
+  discoveryAt?: number
   discover(settings: ModelGatewaySettings): Promise<void>
   clear(): void
 }
@@ -47,12 +49,13 @@ export const useModelGateway = create<ModelGatewayState>((set) => ({
     set({
       models: result.models,
       status: result.error ? 'error' : 'ready',
-      error: result.error ?? ''
+      error: result.error ?? '',
+      discoveryAt: seq
     })
   },
 
   clear() {
     requestSeq++
-    set({ models: [], status: 'idle', error: '' })
+    set({ models: [], status: 'idle', error: '', discoveryAt: undefined })
   }
 }))

--- a/src/renderer/state/settings.test.ts
+++ b/src/renderer/state/settings.test.ts
@@ -1,10 +1,20 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_SETTINGS } from '@shared/types'
 import { useSettings } from './settings'
+import { useModelGateway } from './modelGateway'
 
 describe('agent launch mode settings mirror', () => {
   beforeEach(() => {
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {
+      settings: { load: vi.fn(), save: vi.fn() }
+    }
     useSettings.setState({ settings: { ...DEFAULT_SETTINGS }, hydrated: false })
+    useModelGateway.setState({
+      models: [{ id: 'old', contextWindow: 1_000_000 }],
+      status: 'ready',
+      error: ''
+    })
   })
 
   it('keeps the legacy boolean synchronized with every launch mode update', () => {
@@ -16,5 +26,43 @@ describe('agent launch mode settings mirror', () => {
 
     useSettings.getState().update({ agentLaunchMode: 'gateway-model' })
     expect(useSettings.getState().settings.vanillaLaunchDefault).toBe(false)
+  })
+
+  it('invalidates discovery synchronously when gateway configuration changes', () => {
+    useSettings.setState({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        modelGateway: { baseUrl: 'https://gateway.test', apiKey: '${env:OLD}' }
+      },
+      hydrated: true
+    })
+
+    useSettings.getState().update({
+      modelGateway: {
+        baseUrl: 'https://gateway.test',
+        apiKey: '${env:OLD}',
+        discoveryPath: '/openai/v1/models'
+      }
+    })
+
+    expect(useModelGateway.getState()).toMatchObject({ models: [], status: 'idle' })
+  })
+
+  it('invalidates discovery when hydrate loads a different gateway configuration', async () => {
+    useSettings.setState({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        modelGateway: { baseUrl: 'https://old.test', apiKey: 'old' }
+      },
+      hydrated: false
+    })
+    vi.mocked(window.nodeTerminal.settings.load).mockResolvedValue({
+      ...DEFAULT_SETTINGS,
+      modelGateway: { baseUrl: 'https://new.test', apiKey: 'new' }
+    })
+
+    await useSettings.getState().hydrate()
+
+    expect(useModelGateway.getState()).toMatchObject({ models: [], status: 'idle' })
   })
 })

--- a/src/renderer/state/settings.test.ts
+++ b/src/renderer/state/settings.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { DEFAULT_SETTINGS } from '@shared/types'
+import { useSettings } from './settings'
+
+describe('agent launch mode settings mirror', () => {
+  beforeEach(() => {
+    useSettings.setState({ settings: { ...DEFAULT_SETTINGS }, hydrated: false })
+  })
+
+  it('keeps the legacy boolean synchronized with every launch mode update', () => {
+    useSettings.getState().update({ agentLaunchMode: 'subscription' })
+    expect(useSettings.getState().settings.vanillaLaunchDefault).toBe(true)
+
+    useSettings.getState().update({ agentLaunchMode: 'gateway' })
+    expect(useSettings.getState().settings.vanillaLaunchDefault).toBe(false)
+
+    useSettings.getState().update({ agentLaunchMode: 'gateway-model' })
+    expect(useSettings.getState().settings.vanillaLaunchDefault).toBe(false)
+  })
+})

--- a/src/renderer/state/settings.ts
+++ b/src/renderer/state/settings.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { DEFAULT_SETTINGS, type Settings } from '@shared/types'
+import { sameModelGatewayDiscoveryConfig, useModelGateway } from './modelGateway'
 
 interface SettingsState {
   settings: Settings
@@ -43,7 +44,11 @@ export const useSettings = create<SettingsState>((set, get) => ({
 
   async hydrate() {
     const s = await window.nodeTerminal.settings.load()
-    set({ settings: { ...DEFAULT_SETTINGS, ...s }, hydrated: true })
+    const next = { ...DEFAULT_SETTINGS, ...s }
+    if (!sameModelGatewayDiscoveryConfig(get().settings.modelGateway, next.modelGateway)) {
+      useModelGateway.getState().clear()
+    }
+    set({ settings: next, hydrated: true })
   },
 
   update(patch) {
@@ -54,6 +59,11 @@ export const useSettings = create<SettingsState>((set, get) => ({
     // on write.) `'subscription'` ⇒ true (strip env), anything else ⇒ false.
     if ('agentLaunchMode' in patch) {
       next.vanillaLaunchDefault = patch.agentLaunchMode === 'subscription'
+    }
+    if (!sameModelGatewayDiscoveryConfig(get().settings.modelGateway, next.modelGateway)) {
+      // Invalidate now, before Canvas's debounced discovery starts. Otherwise an older response can
+      // land in that interval and feed a launch or recovery pass for the new settings.
+      useModelGateway.getState().clear()
     }
     set({ settings: next })
     scheduleSave(next)

--- a/src/renderer/state/settings.ts
+++ b/src/renderer/state/settings.ts
@@ -48,6 +48,13 @@ export const useSettings = create<SettingsState>((set, get) => ({
 
   update(patch) {
     const next = { ...get().settings, ...patch }
+    // `vanillaLaunchDefault` is the one-release downgrade mirror for `agentLaunchMode`: an older
+    // build reads the boolean, so when the user picks a mode here the mirror must follow. (The
+    // read path in core settings-store keeps them in lockstep on load; this keeps them in lockstep
+    // on write.) `'subscription'` ⇒ true (strip env), anything else ⇒ false.
+    if ('agentLaunchMode' in patch) {
+      next.vanillaLaunchDefault = patch.agentLaunchMode === 'subscription'
+    }
     set({ settings: next })
     scheduleSave(next)
   }

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -762,6 +762,29 @@ describe('model on agent node factory', () => {
     expect(node.data.initialCommand).toContain('--model')
     expect(node.data.initialCommand).toContain('claude-sonnet-5')
   })
+  it('stores the catalogue selection separately from the exact launch model and window', () => {
+    useModelGateway.setState({
+      models: [{ id: 'claude-sonnet-5', contextWindow: 400_000 }],
+      status: 'ready'
+    })
+    const node = createAgentNode(
+      'claude',
+      0,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'claude-sonnet-5'
+    )
+    expect(node.data.agentModel).toBe('claude-sonnet-5')
+    expect(node.data.agentLaunchModel).toBe('claude-sonnet-5[1m]')
+    expect(node.data.agentLaunchContextWindow).toBe(400_000)
+    expect(node.data.initialCommand).toContain('claude-sonnet-5[1m]')
+    useModelGateway.setState({ models: [], status: 'idle' })
+  })
   it('omits agentModel and the --model flag when no model is given', () => {
     const node = createAgentNode('claude', 0)
     expect(node.data.agentModel).toBeUndefined()
@@ -828,15 +851,21 @@ describe('accountId serialization', () => {
         group: null,
         agentId: 'claude',
         agentModel: 'openai/gpt-5',
+        agentLaunchModel: 'openai/gpt-5[1m]',
+        agentLaunchContextWindow: 500_000,
         accountId: 'a1'
       }
     } as unknown as CanvasNode
     const states = flowToNodeStates([node])
     expect(states[0].accountId).toBe('a1')
     expect(states[0].agentModel).toBe('openai/gpt-5')
+    expect(states[0].agentLaunchModel).toBe('openai/gpt-5[1m]')
+    expect(states[0].agentLaunchContextWindow).toBe(500_000)
     const back = nodeStatesToFlow(states)
     expect(back[0].data.accountId).toBe('a1')
     expect(back[0].data.agentModel).toBe('openai/gpt-5')
+    expect(back[0].data.agentLaunchModel).toBe('openai/gpt-5[1m]')
+    expect(back[0].data.agentLaunchContextWindow).toBe(500_000)
   })
   it('leaves accountId undefined when unset', () => {
     const node = {

--- a/src/renderer/state/workspace.test.ts
+++ b/src/renderer/state/workspace.test.ts
@@ -23,7 +23,9 @@ import {
   ungroupNodes
 } from './workspace'
 import type { CanvasNode } from './workspace'
-import type { Project } from '@shared/types'
+import { DEFAULT_SETTINGS, type Project } from '@shared/types'
+import { useModelGateway } from './modelGateway'
+import { useSettings } from './settings'
 
 const term = (id: string, pos: { x: number; y: number }, parentId?: string): CanvasNode =>
   ({
@@ -771,6 +773,44 @@ describe('model on agent node factory', () => {
     const node = createAgentNode('gemini', 0, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'gemini-2.5')
     expect(node.data.agentModel).toBe('gemini-2.5')
     expect(node.data.initialCommand).not.toContain('--model')
+  })
+
+  it('does not assemble a new launch from a catalogue invalidated by a settings change', () => {
+    const previousSettings = useSettings.getState()
+    const previousGateway = useModelGateway.getState()
+    try {
+      useSettings.setState({
+        settings: {
+          ...DEFAULT_SETTINGS,
+          modelGateway: { baseUrl: 'https://gateway.test', apiKey: 'old' }
+        },
+        hydrated: true
+      })
+      useModelGateway.setState({
+        models: [{ id: 'claude-large', contextWindow: 400_000 }],
+        status: 'ready',
+        error: ''
+      })
+      expect(
+        createAgentNode('claude', 0, undefined, undefined, undefined, undefined,
+          undefined, undefined, undefined, 'claude-large').data.initialCommand
+      ).toContain('claude-large[1m]')
+
+      useSettings.getState().update({
+        modelGateway: {
+          baseUrl: 'https://gateway.test',
+          apiKey: 'old',
+          discoveryPath: '/openai/v1/models'
+        }
+      })
+      expect(
+        createAgentNode('claude', 0, undefined, undefined, undefined, undefined,
+          undefined, undefined, undefined, 'claude-large').data.initialCommand
+      ).toContain("'claude-large'")
+    } finally {
+      useSettings.setState(previousSettings)
+      useModelGateway.setState(previousGateway)
+    }
   })
 })
 

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -97,6 +97,8 @@ export interface NodeData {
    * deliberately absent from flowToNodeStates, like initialCommand/expandedHeight.
    */
   respawnNonce?: number
+  /** Generation of a provider-change recycle awaiting acknowledgement from the next lifecycle. */
+  agentRespawnGeneration?: number
   shell?: string
   cwd?: string
   text?: string

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -27,6 +27,7 @@ import { folderTitle } from '../lib/explorerCreate'
 import { sshHostKey } from '@shared/ssh'
 import { normalizeNodeIcon } from '@shared/node-icon'
 import { useSettings } from './settings'
+import { useModelGateway } from './modelGateway'
 
 // Re-exported so Canvas (and anything else in the renderer) keeps importing it from here, while the
 // single implementation lives in src/shared and is shared with the relay host + the canvas-sync
@@ -690,6 +691,7 @@ export function createAgentNode(
   const customAgent = agentConfig(agentId)
     ? undefined
     : useSettings.getState().settings.customAgents.find((c) => c.id === agentId)
+  const gatewayModels = useModelGateway.getState().models
   const { command: initialCommand, missingEnv } = assembleLaunchCommand(
     {
       agentId,
@@ -711,7 +713,8 @@ export function createAgentNode(
       // A model picked at creation (e.g. Transfer-to-agent-with-model). `withAgentModel` appends
       // `--model <value>` for a switch-capable agent and no-ops otherwise, so the line stays
       // byte-identical when no model is chosen.
-      model
+      model,
+      models: gatewayModels
     },
     // The boot-time snapshot of the desktop env (empty on browser/relay by design, where the
     // missing-env warning below is the honest outcome — the same markers the preview shows).

--- a/src/renderer/state/workspace.ts
+++ b/src/renderer/state/workspace.ts
@@ -10,7 +10,12 @@ import type {
 } from '@shared/types'
 import { DEFAULT_SETTINGS } from '@shared/types'
 import type { AgentId, AgentPermissionMode, BuiltinAgentId } from '@shared/agents/config'
-import { agentConfig, capabilityAgentId, supportsSessionIdFlag } from '@shared/agents/config'
+import {
+  agentConfig,
+  capabilityAgentId,
+  canSwitchModel,
+  supportsSessionIdFlag
+} from '@shared/agents/config'
 import { assembleLaunchCommand } from '@shared/agents/launch'
 import { agentAccountColor } from '@shared/agents/account-color'
 import { boundAccountId } from '@shared/agents/account-binding'
@@ -28,6 +33,7 @@ import { sshHostKey } from '@shared/ssh'
 import { normalizeNodeIcon } from '@shared/node-icon'
 import { useSettings } from './settings'
 import { useModelGateway } from './modelGateway'
+import { claudeAutocompactFor, modelContextWindow } from '@shared/agents/model-gateway'
 
 // Re-exported so Canvas (and anything else in the renderer) keeps importing it from here, while the
 // single implementation lives in src/shared and is shared with the relay host + the canvas-sync
@@ -143,6 +149,10 @@ export interface NodeData {
   agentId?: AgentId
   /** Model selected for this node through the shared model gateway. */
   agentModel?: string
+  /** Exact model id emitted by the launch assembler; may include an internal `[1m]` marker. */
+  agentLaunchModel?: string
+  /** Context window baked into this session's launch environment, when discovery knew it. */
+  agentLaunchContextWindow?: number
   /**
    * Claude nodes only: the managed Claude account (config-dir isolated) this node runs under.
    * Persisted so cold-restore resume reads the transcript from the right account dir.
@@ -720,6 +730,13 @@ export function createAgentNode(
     // missing-env warning below is the honest outcome — the same markers the preview shows).
     agentEnvSnapshot()
   )
+  const launchedModel =
+    model && canSwitchModel(agentId)
+      ? claudeAutocompactFor(agentId, model, gatewayModels).modelId
+      : undefined
+  const launchedContextWindow = launchedModel
+    ? modelContextWindow(launchedModel, gatewayModels)
+    : undefined
   if (missingEnv.length) {
     // A missing var in the typed command (launchCmd/args) would launch with a blank — surface it,
     // matching the preview. Env-var VALUES (the env map) are merged main-side and warned there.
@@ -748,6 +765,8 @@ export function createAgentNode(
       // A model chosen at creation (Transfer-to-agent-with-model). Persisted so cold-restore and
       // later restarts keep it; `withAgentModel` re-applies it on relaunch. Only stamped when set.
       ...(model ? { agentModel: model } : {}),
+      ...(launchedModel ? { agentLaunchModel: launchedModel } : {}),
+      ...(launchedContextWindow ? { agentLaunchContextWindow: launchedContextWindow } : {}),
       cwd: ssh ? ssh.remoteCwd : cwd,
       initialCommand,
       ...(ssh ? { ssh: ssh.server, sshRemoteTmux: true } : {})
@@ -1939,6 +1958,8 @@ export function nodeStatesToFlow(states: CanvasNodeState[]): CanvasNode[] {
         highScore: n.highScore,
         agentId,
         agentModel: n.agentModel,
+        agentLaunchModel: n.agentLaunchModel,
+        agentLaunchContextWindow: n.agentLaunchContextWindow,
         accountId: n.accountId,
         agentSessionId: n.agentSessionId,
         pendingLaunch: n.pendingLaunch,
@@ -2019,6 +2040,8 @@ export function flowToNodeStates(nodes: CanvasNode[]): CanvasNodeState[] {
         highScore: n.data.highScore,
         agentId: n.data.agentId,
         agentModel: n.data.agentModel,
+        agentLaunchModel: n.data.agentLaunchModel,
+        agentLaunchContextWindow: n.data.agentLaunchContextWindow,
         accountId: n.data.accountId,
         agentSessionId: n.data.agentSessionId,
         pendingLaunch: n.data.pendingLaunch,

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -5201,6 +5201,251 @@ body,
   padding: 8px 10px;
 }
 
+/* Grouped "model is gone / window changed" ask, rendered BELOW the reason message. The session
+   list is its own scroll region: ConfirmDialog's flex column only makes `.confirm__msg` scroll,
+   and a long list here would otherwise push the model picker and the action buttons past the
+   bottom of the box. */
+.confirm__model-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0 0 16px;
+  min-height: 0;
+  /* Below the `.confirm` max-height budget, so the message + buttons always stay visible
+     beside it — the list compresses instead of growing the box. */
+  max-height: 40vh;
+}
+
+.confirm__model-rows {
+  margin: 0;
+  padding-left: 18px;
+  overflow-y: auto;
+  min-height: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.confirm__model-rows li + li {
+  margin-top: 4px;
+}
+
+.confirm__model-rows code {
+  color: rgba(var(--tint-rgb), 0.65);
+  font-size: 11.5px;
+}
+
+.confirm__model-label {
+  margin-right: 6px;
+}
+
+.confirm__model-id {
+  color: rgba(var(--tint-rgb), 0.65);
+  font-size: 11.5px;
+}
+
+.confirm__model-reason {
+  display: inline-block;
+  margin-right: 6px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 10.5px;
+  background: rgba(255, 159, 10, 0.18);
+  color: #ffb340;
+  vertical-align: 1px;
+}
+
+.confirm__model-pick {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: rgba(var(--tint-rgb), 0.55);
+  flex-shrink: 0;
+}
+
+.confirm__model-select {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Live per-session progress for the grouped model restart — the strip survives the closing
+   dialog; it never hides a still-running row (the dismiss condition IS row completion). */
+.model-switch-progress {
+  position: fixed;
+  bottom: 52px;
+  right: 20px;
+  z-index: 70;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  min-width: 300px;
+  max-width: 400px;
+  max-height: 45vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.45);
+}
+
+.model-switch-progress__title {
+  font-size: 12.5px;
+  color: var(--text);
+  margin-bottom: 10px;
+}
+
+.model-switch-progress__title code {
+  color: rgba(var(--tint-rgb), 0.7);
+  font-size: 11px;
+}
+
+.model-switch-progress__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.model-switch-progress__row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  line-height: 1.4;
+}
+
+/* Fixed marker box so pending/running/success/fail all occupy the same width — the rows do not
+   reflow as a row transitions. */
+.model-switch-progress__marker {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+}
+
+.model-switch-progress__row--ok .model-switch-progress__marker {
+  color: #30d158;
+}
+
+.model-switch-progress__row--failed .model-switch-progress__marker {
+  color: #ff453a;
+}
+
+.model-switch-progress__row--running .ui-spinner {
+  /* The shared .ui-spinner is 14px, sized for a 16px-ish label — matches here. */
+  color: #d97757;
+}
+
+.model-switch-progress__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+}
+
+.model-switch-progress__row--failed .model-switch-progress__label {
+  color: rgba(var(--tint-rgb), 0.6);
+}
+
+/* A FAILED row's session+reason body is one generous travel target: another project first, then
+   camera-centre. Retry/dismiss stay separate sibling buttons. */
+.model-switch-progress__session {
+  appearance: none;
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.model-switch-progress__session:hover .model-switch-progress__label,
+.model-switch-progress__session:focus-visible .model-switch-progress__label {
+  text-decoration: underline;
+}
+
+/* Failure detail + per-row actionable controls: the detail wraps under the label (max two
+   lines); the Retry affordance is an inline button on the row itself. */
+.model-switch-progress__detail {
+  display: block;
+  width: 100%;
+  font-size: 11px;
+  color: rgba(var(--tint-rgb), 0.55);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-switch-progress__retry {
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 11px;
+  padding: 2px 8px;
+  cursor: pointer;
+}
+
+.model-switch-progress__retry:hover {
+  background: rgba(var(--tint-rgb), 0.12);
+}
+
+.model-switch-progress__row-actions {
+  display: inline-flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.model-switch-progress__spend {
+  opacity: 0.55;
+}
+
+.model-switch-progress__model {
+  flex-shrink: 0;
+  color: rgba(var(--tint-rgb), 0.65);
+  font-size: 11px;
+}
+
+/* Footer actions on strip with failures: repair-what-you-can, or spend the asks and dismiss. */
+.model-switch-progress__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.model-switch-progress__btn {
+  background: var(--panel-header);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 12px;
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.model-switch-progress__btn:hover {
+  background: rgba(var(--tint-rgb), 0.12);
+}
+
+.model-switch-progress__btn--clear {
+  opacity: 0.8;
+}
+
 .confirm__textarea {
   /* Task prose, not a one-liner: fixed comfortable height, user-growable. `font-family` because
      a bare textarea falls back to the UA monospace default, unlike input. */

--- a/src/renderer/terminal/agent-respawn-ack.test.ts
+++ b/src/renderer/terminal/agent-respawn-ack.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  __resetAgentRespawnAckForTests,
+  agentRespawnPending,
+  beginAgentRespawn,
+  reportAgentRespawn
+} from './agent-respawn-ack'
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => {
+  __resetAgentRespawnAckForTests()
+  vi.useRealTimers()
+})
+
+describe('agent respawn acknowledgements', () => {
+  it('resolves only from the replacement lifecycle', async () => {
+    const ticket = beginAgentRespawn('node-1')
+    expect(agentRespawnPending('node-1')).toBe(true)
+    expect(reportAgentRespawn('node-1', ticket.generation, { ok: true })).toBe(true)
+    await expect(ticket.promise).resolves.toEqual({ ok: true })
+    expect(agentRespawnPending('node-1')).toBe(false)
+  })
+
+  it('keeps a failed replacement actionable', async () => {
+    const ticket = beginAgentRespawn('node-1')
+    reportAgentRespawn('node-1', ticket.generation, {
+      ok: false,
+      reason: 'agent-not-running',
+      detail: 'replacement failed'
+    })
+    await expect(ticket.promise).resolves.toEqual({
+      ok: false,
+      reason: 'agent-not-running',
+      detail: 'replacement failed'
+    })
+  })
+
+  it('times out a lifecycle that never reports', async () => {
+    const ticket = beginAgentRespawn('node-1', 25)
+    await vi.advanceTimersByTimeAsync(25)
+    await expect(ticket.promise).resolves.toEqual({
+      ok: false,
+      detail: 'the replacement terminal did not become ready in time'
+    })
+  })
+
+  it('ignores a late acknowledgement from an older lifecycle', async () => {
+    const old = beginAgentRespawn('node-1')
+    old.cancel('old attempt ended')
+    const current = beginAgentRespawn('node-1')
+    expect(reportAgentRespawn('node-1', old.generation, { ok: true })).toBe(false)
+    expect(agentRespawnPending('node-1', current.generation)).toBe(true)
+    reportAgentRespawn('node-1', current.generation, { ok: true })
+    await expect(current.promise).resolves.toEqual({ ok: true })
+  })
+})

--- a/src/renderer/terminal/agent-respawn-ack.test.ts
+++ b/src/renderer/terminal/agent-respawn-ack.test.ts
@@ -6,6 +6,10 @@ import {
   reportAgentRespawn
 } from './agent-respawn-ack'
 
+import { DELIVERY_ATTEMPTS, VERIFY_TIMEOUT_MS } from './command-delivery'
+import { RESTART_EXIT_TIMEOUT_MS } from './agent-restart'
+import { AGENT_RESPAWN_PROCESS_TIMEOUT_MS } from './agent-respawn-process'
+
 beforeEach(() => vi.useFakeTimers())
 afterEach(() => {
   __resetAgentRespawnAckForTests()
@@ -42,6 +46,22 @@ describe('agent respawn acknowledgements', () => {
       ok: false,
       detail: 'the replacement terminal did not become ready in time'
     })
+  })
+
+  it('allows a retried resume to fall back fresh and finish process proof', async () => {
+    const ticket = beginAgentRespawn('fallback-node')
+    // Project preflight, both shell settles and echo-verification windows, the missing-session
+    // shell probe, then proof of the replacement process. A 20-second ticket expired mid-fallback.
+    const elapsed =
+      3_000 +
+      2 * 1_500 +
+      2 * DELIVERY_ATTEMPTS * VERIFY_TIMEOUT_MS +
+      RESTART_EXIT_TIMEOUT_MS +
+      AGENT_RESPAWN_PROCESS_TIMEOUT_MS
+    await vi.advanceTimersByTimeAsync(elapsed)
+    expect(agentRespawnPending('fallback-node', ticket.generation)).toBe(true)
+    expect(reportAgentRespawn('fallback-node', ticket.generation, { ok: true })).toBe(true)
+    await expect(ticket.promise).resolves.toEqual({ ok: true })
   })
 
   it('ignores a late acknowledgement from an older lifecycle', async () => {

--- a/src/renderer/terminal/agent-respawn-ack.ts
+++ b/src/renderer/terminal/agent-respawn-ack.ts
@@ -15,7 +15,10 @@ interface PendingRespawn {
 
 const pending = new Map<string, PendingRespawn>()
 let nextGeneration = 0
-export const AGENT_RESPAWN_ACK_TIMEOUT_MS = 20_000
+// A missing-session response adds a shell probe and a second settled/verified delivery before
+// process proof. Those bounded stages alone can take 29 seconds; allow cold PTY creation and
+// project/transcript preflight too, while retaining one finite deadline for the whole attempt.
+export const AGENT_RESPAWN_ACK_TIMEOUT_MS = 60_000
 
 function settle(nodeId: string, generation: number, result: AgentRespawnAck): boolean {
   const entry = pending.get(nodeId)

--- a/src/renderer/terminal/agent-respawn-ack.ts
+++ b/src/renderer/terminal/agent-respawn-ack.ts
@@ -1,0 +1,109 @@
+import { modelRespawnTrace } from '@shared/model-respawn-trace'
+
+export type AgentRespawnAck =
+  | { ok: true }
+  | { ok: false; detail: string; reason?: 'agent-not-running' }
+
+export const AGENT_NOT_RUNNING_AFTER_RESPAWN =
+  'the replacement terminal submitted its resume command, but the agent process did not stay running'
+
+interface PendingRespawn {
+  generation: number
+  timer: ReturnType<typeof setTimeout>
+  resolve: (result: AgentRespawnAck) => void
+}
+
+const pending = new Map<string, PendingRespawn>()
+let nextGeneration = 0
+export const AGENT_RESPAWN_ACK_TIMEOUT_MS = 20_000
+
+function settle(nodeId: string, generation: number, result: AgentRespawnAck): boolean {
+  const entry = pending.get(nodeId)
+  if (!entry || entry.generation !== generation) return false
+  pending.delete(nodeId)
+  clearTimeout(entry.timer)
+  entry.resolve(result)
+  modelRespawnTrace('respawn.ack', {
+    nodeId,
+    generation,
+    ok: result.ok,
+    // `detail` is user-facing and may eventually include provider/transport text. Keep that out
+    // of the log even though today's callers only pass controlled sentences.
+    reason: result.ok ? 'replacement-agent-running' : 'replacement-lifecycle-failed'
+  })
+  return true
+}
+
+/**
+ * Bridge the restart closure (which requests a React lifecycle respawn) to the NEXT lifecycle
+ * effect (which alone knows whether `transport.create` and the cold-resume launch succeeded).
+ */
+export function beginAgentRespawn(
+  nodeId: string,
+  timeoutMs = AGENT_RESPAWN_ACK_TIMEOUT_MS
+): { generation: number; promise: Promise<AgentRespawnAck>; cancel: (detail: string) => void } {
+  const generation = ++nextGeneration
+  const previous = pending.get(nodeId)
+  if (previous) {
+    clearTimeout(previous.timer)
+    previous.resolve({ ok: false, detail: 'a newer respawn superseded this attempt' })
+    modelRespawnTrace('respawn.superseded', {
+      nodeId,
+      oldGeneration: previous.generation,
+      newGeneration: generation
+    })
+  }
+  let resolve!: (result: AgentRespawnAck) => void
+  const promise = new Promise<AgentRespawnAck>((done) => {
+    resolve = done
+  })
+  const timer = setTimeout(() => {
+    settle(nodeId, generation, {
+      ok: false,
+      detail: 'the replacement terminal did not become ready in time'
+    })
+  }, timeoutMs)
+  pending.set(nodeId, { generation, timer, resolve })
+  modelRespawnTrace('respawn.awaiting', { nodeId, generation, timeoutMs })
+  return {
+    generation,
+    promise,
+    cancel: (detail: string) => {
+      settle(nodeId, generation, { ok: false, detail })
+    }
+  }
+}
+
+export function agentRespawnPending(nodeId: string, generation?: number): boolean {
+  const entry = pending.get(nodeId)
+  return !!entry && (generation === undefined || entry.generation === generation)
+}
+
+/** Called by the replacement TerminalNode lifecycle. Stale/no-waiter reports are harmless. */
+export function reportAgentRespawn(
+  nodeId: string,
+  generation: number,
+  result: AgentRespawnAck
+): boolean {
+  const entry = pending.get(nodeId)
+  if (!entry || entry.generation !== generation) {
+    modelRespawnTrace('respawn.report-ignored', {
+      nodeId,
+      generation,
+      pendingGeneration: entry?.generation,
+      reason: entry ? 'stale-generation' : 'no-waiter'
+    })
+    return false
+  }
+  return settle(nodeId, generation, result)
+}
+
+/** Test isolation; production never clears a live ticket except by settling it. */
+export function __resetAgentRespawnAckForTests(): void {
+  for (const entry of pending.values()) {
+    clearTimeout(entry.timer)
+    entry.resolve({ ok: false, detail: 'test reset' })
+  }
+  pending.clear()
+  nextGeneration = 0
+}

--- a/src/renderer/terminal/agent-respawn-process.test.ts
+++ b/src/renderer/terminal/agent-respawn-process.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  agentProcessProofWithin,
+  waitForAgentRespawnProcess
+} from './agent-respawn-process'
+
+describe('agentProcessProofWithin', () => {
+  it('turns a wedged IPC proof into a bounded unknown verdict', async () => {
+    vi.useFakeTimers()
+    const result = agentProcessProofWithin(
+      () => new Promise(() => {}),
+      25
+    )
+
+    await vi.advanceTimersByTimeAsync(25)
+    await expect(result).resolves.toEqual({ verdict: 'unknown' })
+    vi.useRealTimers()
+  })
+})
+
+describe('waitForAgentRespawnProcess', () => {
+  it('waits through shell and unreadable states until the exact agent is observed', async () => {
+    vi.useFakeTimers()
+    const probe = vi
+      .fn()
+      .mockResolvedValueOnce({ verdict: 'not-agent' })
+      .mockResolvedValueOnce({ verdict: 'unknown' })
+      .mockResolvedValue({ verdict: 'agent', shellPid: 10, agentPid: 21 })
+    const attempts: Array<[number, string, number | undefined, number]> = []
+    const resultPromise = waitForAgentRespawnProcess(probe, {
+      timeoutMs: 1_000,
+      pollMs: 25,
+      stableMs: 25,
+      onAttempt: (attempt, proof, stableForMs) =>
+        attempts.push([attempt, proof.verdict, proof.agentPid, stableForMs])
+    })
+
+    await vi.advanceTimersByTimeAsync(75)
+    await expect(resultPromise).resolves.toEqual({
+      running: true,
+      attempts: 4,
+      lastVerdict: 'agent',
+      shellPid: 10,
+      agentPid: 21,
+      reason: 'running'
+    })
+    expect(attempts).toEqual([
+      [1, 'not-agent', undefined, 0],
+      [2, 'unknown', undefined, 0],
+      [3, 'agent', 21, 0],
+      [4, 'agent', 21, 25]
+    ])
+    vi.useRealTimers()
+  })
+
+  it('fails after the deadline when the launched CLI never stays running', async () => {
+    vi.useFakeTimers()
+    const resultPromise = waitForAgentRespawnProcess(async () => ({ verdict: 'not-agent' }), {
+      timeoutMs: 60,
+      pollMs: 25
+    })
+
+    await vi.advanceTimersByTimeAsync(60)
+    await expect(resultPromise).resolves.toEqual({
+      running: false,
+      attempts: 3,
+      lastVerdict: 'not-agent',
+      reason: 'deadline'
+    })
+    vi.useRealTimers()
+  })
+
+  it('stops without another probe when the replacement lifecycle is no longer active', async () => {
+    let active = true
+    const sleep = vi.fn(async () => {
+      active = false
+    })
+    const probe = vi.fn(async () => ({ verdict: 'unknown' as const }))
+
+    await expect(
+      waitForAgentRespawnProcess(probe, { active: () => active, sleep, timeoutMs: 1_000 })
+    ).resolves.toEqual({
+      running: false,
+      attempts: 1,
+      lastVerdict: 'unknown',
+      reason: 'inactive'
+    })
+    expect(probe).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not accept a positive sample when the lifecycle died during the probe', async () => {
+    let active = true
+    const probe = vi.fn(async () => {
+      active = false
+      return { verdict: 'agent' as const, shellPid: 10, agentPid: 21 }
+    })
+
+    await expect(
+      waitForAgentRespawnProcess(probe, {
+        active: () => active,
+        stableMs: 0
+      })
+    ).resolves.toEqual({
+      running: false,
+      attempts: 1,
+      lastVerdict: 'agent',
+      reason: 'inactive'
+    })
+  })
+
+  it('does not accept a positive sample that returned after the proof deadline', async () => {
+    let now = 0
+    const probe = vi.fn(async () => {
+      now = 11
+      return { verdict: 'agent' as const, shellPid: 10, agentPid: 21 }
+    })
+
+    await expect(
+      waitForAgentRespawnProcess(probe, {
+        timeoutMs: 10,
+        stableMs: 0,
+        now: () => now
+      })
+    ).resolves.toEqual({
+      running: false,
+      attempts: 1,
+      lastVerdict: 'agent',
+      reason: 'deadline'
+    })
+  })
+
+  it('treats a rejected transport probe as unknown and keeps polling', async () => {
+    const probe = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('gone'))
+      .mockResolvedValueOnce({ verdict: 'agent', shellPid: 10, agentPid: 21 })
+    const result = await waitForAgentRespawnProcess(probe, {
+      timeoutMs: 10,
+      stableMs: 0,
+      sleep: async () => {}
+    })
+
+    expect(result).toEqual({
+      running: true,
+      attempts: 2,
+      lastVerdict: 'agent',
+      shellPid: 10,
+      agentPid: 21,
+      reason: 'running'
+    })
+  })
+
+  it('restarts stabilization when a crash loop replaces the agent PID', async () => {
+    let now = 0
+    const probe = vi
+      .fn()
+      .mockResolvedValueOnce({ verdict: 'agent', shellPid: 10, agentPid: 21 })
+      .mockResolvedValue({ verdict: 'agent', shellPid: 10, agentPid: 22 })
+
+    await expect(
+      waitForAgentRespawnProcess(probe, {
+        timeoutMs: 100,
+        pollMs: 10,
+        stableMs: 10,
+        now: () => now,
+        sleep: async (ms) => {
+          now += ms
+        }
+      })
+    ).resolves.toEqual({
+      running: true,
+      attempts: 3,
+      lastVerdict: 'agent',
+      shellPid: 10,
+      agentPid: 22,
+      reason: 'running'
+    })
+  })
+
+  it('restarts stabilization when the shell generation changes under the same agent PID', async () => {
+    let now = 0
+    const probe = vi
+      .fn()
+      .mockResolvedValueOnce({ verdict: 'agent', shellPid: 10, agentPid: 21 })
+      .mockResolvedValue({ verdict: 'agent', shellPid: 11, agentPid: 21 })
+
+    await expect(
+      waitForAgentRespawnProcess(probe, {
+        timeoutMs: 100,
+        pollMs: 10,
+        stableMs: 10,
+        now: () => now,
+        sleep: async (ms) => {
+          now += ms
+        }
+      })
+    ).resolves.toEqual({
+      running: true,
+      attempts: 3,
+      lastVerdict: 'agent',
+      shellPid: 11,
+      agentPid: 21,
+      reason: 'running'
+    })
+  })
+})

--- a/src/renderer/terminal/agent-respawn-process.ts
+++ b/src/renderer/terminal/agent-respawn-process.ts
@@ -1,0 +1,125 @@
+import type { AgentProcessProof } from '@shared/types'
+import type { AgentPaneVerdict } from '@shared/agents/pane-owner-predicate'
+
+export const AGENT_RESPAWN_PROCESS_TIMEOUT_MS = 8_000
+export const AGENT_RESPAWN_PROCESS_POLL_MS = 150
+export const AGENT_RESPAWN_PROCESS_STABLE_MS = 1_000
+export const AGENT_PROCESS_PROBE_TIMEOUT_MS = 2_000
+
+export interface AgentRespawnProcessResult {
+  running: boolean
+  attempts: number
+  lastVerdict: AgentPaneVerdict
+  shellPid?: number
+  agentPid?: number
+  reason: 'running' | 'deadline' | 'inactive'
+}
+
+interface AgentRespawnProcessOptions {
+  timeoutMs?: number
+  pollMs?: number
+  stableMs?: number
+  active?: () => boolean
+  onAttempt?: (attempt: number, proof: AgentProcessProof, stableForMs: number) => void
+  now?: () => number
+  sleep?: (ms: number) => Promise<void>
+}
+
+/**
+ * Bound one kernel/transport proof. The overall respawn deadline cannot protect a probe whose IPC
+ * promise itself never settles: execution would never get back to the deadline check and the
+ * progress row would spin forever. Late probe results are deliberately ignored; every accepted
+ * identity must come from a fresh call.
+ */
+export async function agentProcessProofWithin(
+  probe: () => Promise<AgentProcessProof>,
+  timeoutMs = AGENT_PROCESS_PROBE_TIMEOUT_MS
+): Promise<AgentProcessProof> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      probe().catch((): AgentProcessProof => ({ verdict: 'unknown' })),
+      new Promise<AgentProcessProof>((resolve) => {
+        timer = setTimeout(
+          () => resolve({ verdict: 'unknown' }),
+          Math.max(0, timeoutMs)
+        )
+      })
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Poll the core's kernel-backed pane-owner verdict after a replacement command is submitted.
+ * `not-agent` is retried because a shell is the expected foreground owner while the CLI starts;
+ * `unknown` is retried because one transient tmux/SSH read must not manufacture a failure.
+ */
+export async function waitForAgentRespawnProcess(
+  probe: () => Promise<AgentProcessProof>,
+  options: AgentRespawnProcessOptions = {}
+): Promise<AgentRespawnProcessResult> {
+  const timeoutMs = Math.max(0, options.timeoutMs ?? AGENT_RESPAWN_PROCESS_TIMEOUT_MS)
+  const pollMs = Math.max(1, options.pollMs ?? AGENT_RESPAWN_PROCESS_POLL_MS)
+  const stableMs = Math.max(0, options.stableMs ?? AGENT_RESPAWN_PROCESS_STABLE_MS)
+  const active = options.active ?? (() => true)
+  const now = options.now ?? Date.now
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
+  const deadline = now() + timeoutMs
+  let attempts = 0
+  let lastVerdict: AgentPaneVerdict = 'unknown'
+  let stableShellPid: number | undefined
+  let stableAgentPid: number | undefined
+  let stableSince = 0
+
+  while (active()) {
+    const remainingBeforeProbe = deadline - now()
+    if (remainingBeforeProbe <= 0) {
+      return { running: false, attempts, lastVerdict, reason: 'deadline' }
+    }
+    attempts++
+    const proof = await agentProcessProofWithin(probe, remainingBeforeProbe)
+    lastVerdict = proof.verdict
+    const sampledAt = now()
+    if (proof.verdict === 'agent' && proof.shellPid && proof.agentPid) {
+      // Stabilize the PAIR. The root/login shell may stay alive while its child agent dies; the
+      // opposite transition (a replaced shell generation) must reset the proof even if a PID was
+      // rapidly reused for an agent in the new pane.
+      if (proof.shellPid !== stableShellPid || proof.agentPid !== stableAgentPid) {
+        stableShellPid = proof.shellPid
+        stableAgentPid = proof.agentPid
+        stableSince = sampledAt
+      }
+    } else {
+      stableShellPid = undefined
+      stableAgentPid = undefined
+      stableSince = 0
+    }
+    const stableForMs = stableAgentPid ? sampledAt - stableSince : 0
+    options.onAttempt?.(attempts, proof, stableForMs)
+    // The lifecycle/ticket can expire while the IPC probe is in flight. Never let a late positive
+    // sample resurrect that dead attempt, and never let a slow probe succeed after the deadline.
+    if (!active()) break
+    if (sampledAt > deadline) {
+      return { running: false, attempts, lastVerdict, reason: 'deadline' }
+    }
+    if (stableShellPid && stableAgentPid && stableForMs >= stableMs) {
+      return {
+        running: true,
+        attempts,
+        lastVerdict,
+        shellPid: stableShellPid,
+        agentPid: stableAgentPid,
+        reason: 'running'
+      }
+    }
+    const remaining = deadline - now()
+    if (remaining <= 0) {
+      return { running: false, attempts, lastVerdict, reason: 'deadline' }
+    }
+    await sleep(Math.min(pollMs, remaining))
+  }
+
+  return { running: false, attempts, lastVerdict, reason: 'inactive' }
+}

--- a/src/renderer/terminal/agent-restart.test.ts
+++ b/src/renderer/terminal/agent-restart.test.ts
@@ -10,8 +10,8 @@ import {
   exitSequence,
   guardConcurrentRestart,
   isShellCommand,
-  performExitPhase,
-  performRestartResume,
+  performExitPhase as performExitPhaseCore,
+  performRestartResume as performRestartResumeCore,
   performResumePhase,
   planBulkRestart,
   registerAgentHibernate,
@@ -116,6 +116,33 @@ describe('clearEnvEligibility', () => {
   })
 })
 
+describe('clearEnvEligibility', () => {
+  it('permits a busy session — terminateForeground is PID-safe, and gateway overload lands mid-turn', () => {
+    // The shared `restartEligibility` refuses working/blocked because its `/exit` would answer a
+    // permission prompt. clearEnv SIGTERMs the foreground group by PID instead — no slash command is
+    // typed into the pane — so it may interrupt a stuck turn, which is exactly the scenario the
+    // feature exists for.
+    expect(clearEnvEligibility('claude', 'abc')).toEqual({ ok: true })
+    expect(clearEnvEligibility('codex', 'abc')).toEqual({ ok: true })
+    expect(clearEnvEligibility('copilot', 'abc')).toEqual({ ok: true })
+  })
+
+  it('still requires a resumable harness and provider session id', () => {
+    expect(clearEnvEligibility('claude', undefined)).toEqual({
+      ok: false,
+      reason: 'no-session'
+    })
+    expect(clearEnvEligibility('my-custom', 'abc')).toEqual({
+      ok: false,
+      reason: 'not-resumable'
+    })
+    // An agent with no vanillaEnvPattern (gemini) still passes THIS gate — resumability is a
+    // separate fact from "has a strip set." The menu row is hidden upstream on the pattern, so
+    // the gate is only ever reached for claude/codex/copilot. Tested in vanilla-env.test.ts.
+    expect(clearEnvEligibility('gemini', 'abc')).toEqual({ ok: true })
+  })
+})
+
 function fakeIo() {
   const written: string[] = []
   let cb: ((chunk: string) => void) | null = null
@@ -155,11 +182,55 @@ function silentIo() {
   }
 }
 
+// Most choreography tests care about polling/delivery, not core process discovery. Production is
+// required by type to supply the identity-gated terminator; default it to a successful fake here,
+// while the dedicated stop tests below override it to exercise ownership loss/refusal.
+type ExitArgs = Parameters<typeof performExitPhaseCore>[0]
+function performExitPhase(
+  d: Omit<ExitArgs, 'terminateForeground'> & {
+    terminateForeground?: ExitArgs['terminateForeground']
+  }
+) {
+  return performExitPhaseCore({
+    ...d,
+    terminateForeground: d.terminateForeground ?? (async () => 'terminated' as const)
+  })
+}
+
+type RestartArgs = Parameters<typeof performRestartResumeCore>[0]
+function performRestartResume(
+  d: Omit<RestartArgs, 'terminateForeground'> & {
+    terminateForeground?: RestartArgs['terminateForeground']
+  }
+) {
+  return performRestartResumeCore({
+    ...d,
+    terminateForeground: d.terminateForeground ?? (async () => 'terminated' as const)
+  })
+}
+
 describe('performRestartResume', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
-  it('sends exit, waits for the shell, then delivers the resume command', async () => {
+  it('hands an already-idle login shell to the fresh-shell recovery callback', async () => {
+    const { written, io } = fakeIo()
+    const onAlreadyExited = vi.fn(async () => 'restarted' as const)
+    await expect(
+      performRestartResume({
+        agentId: 'claude',
+        sessionId: 'sid-1',
+        io,
+        paneCommand: async () => 'zsh',
+        terminateForeground: async () => 'already-exited',
+        onAlreadyExited
+      })
+    ).resolves.toBe('restarted')
+    expect(onAlreadyExited).toHaveBeenCalledOnce()
+    expect(written).toEqual([])
+  })
+
+  it('terminates the verified process, waits for the shell, then delivers the resume command', async () => {
     const { written, io } = fakeIo()
     let pane = 'claude'
     const p = performRestartResume({
@@ -174,8 +245,8 @@ describe('performRestartResume', () => {
     pane = 'zsh'
     await vi.advanceTimersByTimeAsync(5000)
     expect(await p).toBe('restarted')
-    expect(written.slice(0, 2)).toEqual(['\x15', '/exit\r'])
     expect(written.join('')).toContain('claude --resume sid-1')
+    expect(written.join('')).not.toContain('/exit')
   })
 
   it('gives up without delivering when the pane never returns to a shell', async () => {
@@ -193,15 +264,15 @@ describe('performRestartResume', () => {
     expect(written.join('')).not.toContain('--resume')
   })
 
-  it('gives up when the pane query wedges after the exit was sent', async () => {
+  it('gives up when the pane query wedges after the process was terminated', async () => {
     const { written, io } = fakeIo()
     let first = true
     const p = performRestartResume({
       agentId: 'claude',
       sessionId: 'sid-1',
       io,
-      // The pre-flight answers, so the exit IS written; then the tmux server wedges and no poll
-      // ever settles. The deadline, not the query, has to end the restart.
+      // The pre-flight answers, so termination runs; then the tmux server wedges and no poll ever
+      // settles. The deadline, not the query, has to end the restart.
       paneCommand: () => {
         if (!first) return new Promise<string | null>(() => {})
         first = false
@@ -247,7 +318,7 @@ describe('performRestartResume', () => {
     expect(written).toEqual([])
   })
 
-  it('clears the pending input line before asking the CLI to quit', async () => {
+  it('never writes a stop sequence into the pane before resuming', async () => {
     const { written, io } = fakeIo()
     let pane = 'claude'
     const p = performRestartResume({
@@ -262,9 +333,9 @@ describe('performRestartResume', () => {
     pane = 'zsh'
     await vi.advanceTimersByTimeAsync(5000)
     expect(await p).toBe('restarted')
-    // Half-typed user text in the prompt would otherwise be SUBMITTED as `…the/exit`.
-    expect(written[0]).toBe('\x15')
-    expect(written[1]).toBe('/exit\r')
+    // The exact process is stopped out-of-band; the first pane write belongs to the resume.
+    expect(written[0]).toBe('claude --resume sid-1')
+    expect(written.join('')).not.toContain('/exit')
   })
 
   it('takes a pane command that CHANGED away from the CLI as proof it quit', async () => {
@@ -380,7 +451,7 @@ describe('performRestartResume', () => {
     expect(typeof cancel).toBe('function') // handed out as the delivery STARTS, not when it ends
     const delivered = written.length
     cancel?.()
-    expect(await p).toBe('restarted') // cancelling settles the delivery, and with it the restart
+    await expect(p).rejects.toThrow('resume delivery did not submit')
     await vi.advanceTimersByTimeAsync(30_000)
     // No rewrite retries, no fail-open submit: nothing more reaches the torn-down transport.
     expect(written.length).toBe(delivered)
@@ -492,7 +563,7 @@ describe('performExitPhase', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
-  it('quits the CLI and reports exited once the pane reports a shell — writing nothing after', async () => {
+  it('terminates out-of-band and reports exited once the pane reports a shell', async () => {
     const { written, io } = fakeIo()
     let pane = 'claude'
     const p = performExitPhase({
@@ -507,9 +578,22 @@ describe('performExitPhase', () => {
     pane = 'zsh'
     await vi.advanceTimersByTimeAsync(5000)
     expect(await p).toBe('exited')
-    // The exit phase's ENTIRE output: clear the line, then the CLI's own exit command. The resume
-    // line belongs to the other phase, so nothing here may reach the pane after `/exit`.
-    expect(written).toEqual(['\x15', '/exit\r'])
+    // Process termination is out-of-band. This phase never types into the pane.
+    expect(written).toEqual([])
+  })
+
+  it('reports an agent that already returned to the original login shell separately', async () => {
+    const { written, io } = fakeIo()
+    await expect(
+      performExitPhase({
+        agentId: 'claude',
+        sessionId: 'sid-1',
+        io,
+        paneCommand: async () => 'zsh',
+        terminateForeground: async () => 'already-exited'
+      })
+    ).resolves.toBe('already-exited')
+    expect(written).toEqual([])
   })
 
   it('writes NOTHING and refuses when the pre-flight probe answers null', async () => {
@@ -540,7 +624,24 @@ describe('performExitPhase', () => {
     })
     await vi.advanceTimersByTimeAsync(2000)
     expect(await p).toBe('exit-timeout')
-    expect(written).toEqual(['\x15', '/exit\r']) // never force-killed, never resumed
+    expect(written).toEqual([]) // terminated out-of-band, never resumed
+  })
+
+  it('refuses when the exact expected agent PID is no longer foreground', async () => {
+    const { written, io } = fakeIo()
+    const onRefusal = vi.fn()
+    expect(
+      await performExitPhase({
+        agentId: 'claude',
+        sessionId: 'sid-1',
+        io,
+        paneCommand: async () => 'zsh',
+        terminateForeground: async () => 'refused',
+        onRefusal
+      })
+    ).toBe('not-eligible')
+    expect(written).toEqual([])
+    expect(onRefusal).toHaveBeenCalledWith('lost-foreground')
   })
 
   it('refuses a session we could never resume into — the exit alone would lose it', async () => {
@@ -619,69 +720,25 @@ describe('performExitPhase', () => {
     expect(await p).toBe('not-eligible') // not a timeout: there is no pane left to time out in
   })
 
-  it('splits opencode exit into text then CR (batched-input guard), leaving others one-burst', async () => {
-    // opencode's TUI swallows a one-burst `/exit\r` (measured 1.18.18-1.18.25, Linux, tmux, isolated
-    // socket: `/exit` left in composer with popup armed, exit-timeout at 6s; split CR by 100ms exits
-    // in ~500ms, shipped with 150ms). This pins the split so a refactor cannot silently re-batch it.
-    for (const agentId of ['opencode'] as const) {
-      const { written, io } = fakeIo()
-      let pane = 'opencode'
-      const p = performExitPhase({
-        agentId,
-        sessionId: 'sid-1',
-        io,
-        paneCommand: async () => pane,
-        timeoutMs: 6000,
-        pollMs: 100
-      })
-      // Pre-flight resolves; KILL_LINE + exit text are written, CR not yet.
-      await vi.advanceTimersByTimeAsync(0)
-      expect(written).toEqual(['\x15', '/exit'])
-      await vi.advanceTimersByTimeAsync(150)
-      expect(written).toEqual(['\x15', '/exit', '\r'])
-      pane = 'zsh'
-      await vi.advanceTimersByTimeAsync(5000)
-      expect(await p).toBe('exited')
-    }
-    // Every other agent keeps the historical one-burst path byte-identical.
-    for (const agentId of ['claude', 'codex', 'grok', 'gemini', 'copilot'] as const) {
-      const { written, io } = fakeIo()
-      let pane: string = agentId
-      const p = performExitPhase({
-        agentId,
-        sessionId: 'sid-1',
-        io,
-        paneCommand: async () => pane,
-        timeoutMs: 6000,
-        pollMs: 100
-      })
-      await vi.advanceTimersByTimeAsync(0)
-      const exit = agentId === 'claude' || agentId === 'copilot' ? '/exit' : '/quit'
-      expect(written).toEqual(['\x15', `${exit}\r`])
-      pane = 'zsh'
-      await vi.advanceTimersByTimeAsync(5000)
-      expect(await p).toBe('exited')
-    }
-  })
-
-  it('abandons the split CR when the pane dies mid-delay', async () => {
+  it('terminates opencode out-of-band without typing its split exit sequence', async () => {
     const { written, io } = fakeIo()
-    let live = true
+    let pane = 'opencode'
+    const terminateForeground = vi.fn(async () => 'terminated' as const)
     const p = performExitPhase({
       agentId: 'opencode',
       sessionId: 'sid-1',
       io,
-      paneCommand: async () => 'opencode',
+      paneCommand: async () => pane,
+      terminateForeground,
       timeoutMs: 6000,
-      pollMs: 100,
-      isLive: () => live
+      pollMs: 100
     })
     await vi.advanceTimersByTimeAsync(0)
-    expect(written).toEqual(['\x15', '/exit'])
-    live = false
-    await vi.advanceTimersByTimeAsync(200)
-    expect(await p).toBe('not-eligible')
-    expect(written).toEqual(['\x15', '/exit']) // CR never sent into a dead pane
+    expect(terminateForeground).toHaveBeenCalledOnce()
+    expect(written).toEqual([])
+    pane = 'zsh'
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(await p).toBe('exited')
   })
 })
 
@@ -695,7 +752,7 @@ describe('performResumePhase', () => {
     await vi.advanceTimersByTimeAsync(5000)
     expect(await p).toBe('resumed')
     expect(written.join('')).toContain('claude --resume sid-1')
-    expect(written.join('')).not.toContain('/exit') // the exit belongs to the other phase
+    expect(written.join('')).not.toContain('/exit') // process stop is out-of-band
   })
 
   it("prefers the caller's command (permission mode) over the bare one", async () => {
@@ -739,7 +796,7 @@ describe('performResumePhase', () => {
     expect(typeof cancel).toBe('function')
     const delivered = written.length
     cancel?.()
-    expect(await p).toBe('resumed')
+    await expect(p).rejects.toThrow('resume delivery did not submit')
     await vi.advanceTimersByTimeAsync(30_000)
     expect(written.length).toBe(delivered) // no retries into a torn-down transport
   })
@@ -794,7 +851,7 @@ describe('performRestartResume — grok', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
-  it("quits with grok's own exit line and resumes by session id", async () => {
+  it('terminates grok out-of-band and resumes by session id', async () => {
     const { written, io } = fakeIo()
     let pane = 'grok'
     const p = performRestartResume({
@@ -809,9 +866,8 @@ describe('performRestartResume — grok', () => {
     pane = 'zsh'
     await vi.advanceTimersByTimeAsync(5000)
     expect(await p).toBe('restarted')
-    // `/quit`, not claude's `/exit` — the table is per CLI.
-    expect(written.slice(0, 2)).toEqual(['\x15', '/quit\r'])
     expect(written.join('')).toContain('grok --resume abc-1')
+    expect(written.join('')).not.toContain('/quit')
   })
 
   it("delivers the caller's permission-mode resume line, composed as TerminalNode composes it", async () => {
@@ -870,7 +926,7 @@ describe('performRestartResume — gemini', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
-  it('quits with /quit and resumes by session id', async () => {
+  it('terminates gemini out-of-band and resumes by session id', async () => {
     const { written, io } = fakeIo()
     let pane = 'gemini'
     const p = performRestartResume({
@@ -885,10 +941,8 @@ describe('performRestartResume — gemini', () => {
     pane = 'zsh'
     await vi.advanceTimersByTimeAsync(5000)
     expect(await p).toBe('restarted')
-    // `/quit` (alias `/exit`) measured in gemini's bundled docs/reference/commands.md:325.
-    // `\x15` is the kill-line that clears any half-typed prompt first.
-    expect(written.slice(0, 2)).toEqual(['\x15', '/quit\r'])
     expect(written.join('')).toContain('gemini --resume abc-1')
+    expect(written.join('')).not.toContain('/quit')
   })
 
   it('never types the history-destroying --delete flag', async () => {
@@ -954,34 +1008,42 @@ describe('performRestartResume — the delivery await is bounded', () => {
     vi.resetModules()
   })
 
-  it('stops waiting on a delivery that never announces it settled', async () => {
+  it('cancels and rejects a delivery that never announces it settled', async () => {
     // A transport whose write() throws used to kill deliverCommand's retry callback before it
     // could submit — `onSettled` then never fired, this await never settled, the node stayed
     // locked out by guardConcurrentRestart for the app's life and the bulk loop hung with no
     // summary. The transport is fixed in command-delivery.ts; this is the belt to that braces —
     // NOTHING may wait forever, whatever the delivery does.
+    let cancelled = 0
     vi.doMock('./command-delivery', () => ({
       VERIFY_TIMEOUT_MS: 2000,
       DELIVERY_ATTEMPTS: 3,
       KILL_LINE: '\x15',
-      deliverCommand: () => () => {} // started, never settles
+      deliverCommand: () => () => {
+        cancelled += 1
+      } // started, never settles
     }))
     const mod = await import('./agent-restart')
-    let outcome: string | undefined
+    let outcome = 'pending'
     void mod
       .performRestartResume({
         agentId: 'claude',
         sessionId: 'sid-1',
         io: { write: () => {}, onData: () => () => {} },
         paneCommand: async () => 'zsh',
+        terminateForeground: async () => 'terminated',
         timeoutMs: 1000,
         pollMs: 100
       })
-      .then((o) => (outcome = o))
+      .then(
+        () => (outcome = 'resolved'),
+        () => (outcome = 'rejected')
+      )
     await vi.advanceTimersByTimeAsync(200)
-    expect(outcome).toBeUndefined() // still holding the node, as designed
+    expect(outcome).toBe('pending') // still holding the node, as designed
     await vi.advanceTimersByTimeAsync(60_000)
-    expect(outcome).toBe('restarted')
+    expect(outcome).toBe('rejected')
+    expect(cancelled).toBe(1)
   })
 })
 
@@ -1011,11 +1073,11 @@ describe('guardConcurrentRestart', () => {
     await vi.advanceTimersByTimeAsync(150)
     // The resume line is in the pane but NOT submitted (no echo to verify it).
     expect(written.join('')).toContain('claude --resume sid-1')
-    // A second menu/bulk click landing in that window would splice `/exit` into the pending line
-    // and submit `claude --resume sid-1/exit`.
+    // A second menu/bulk click landing in that window could terminate the new process or splice a
+    // second resume line into the pending one.
     expect(await run()).toBe('not-eligible')
     expect(await probe()).toBe('not-eligible')
-    expect(written.filter((w) => w === '/exit\r')).toHaveLength(1)
+    expect(written.filter((w) => w === '/exit\r')).toHaveLength(0)
     await vi.advanceTimersByTimeAsync(10_000) // the fail-open submit ends the delivery
     expect(await first).toBe('restarted')
     expect(await probe()).toBe('restarted') // pane free again

--- a/src/renderer/terminal/agent-restart.test.ts
+++ b/src/renderer/terminal/agent-restart.test.ts
@@ -6,6 +6,7 @@ import {
   __resetAgentRestartForTests,
   agentHibernateFns,
   agentRestartFn,
+  clearEnvEligibility,
   exitSequence,
   guardConcurrentRestart,
   isShellCommand,
@@ -85,6 +86,33 @@ describe('restartEligibility', () => {
       ok: false,
       reason: 'not-resumable'
     })
+  })
+})
+
+describe('clearEnvEligibility', () => {
+  it('permits a busy session — terminateForeground is PID-safe, and gateway overload lands mid-turn', () => {
+    // The shared `restartEligibility` refuses working/blocked because its `/exit` would answer a
+    // permission prompt. clearEnv SIGTERMs the foreground group by PID instead — no slash command is
+    // typed into the pane — so it may interrupt a stuck turn, which is exactly the scenario the
+    // feature exists for.
+    expect(clearEnvEligibility('claude', 'abc')).toEqual({ ok: true })
+    expect(clearEnvEligibility('codex', 'abc')).toEqual({ ok: true })
+    expect(clearEnvEligibility('copilot', 'abc')).toEqual({ ok: true })
+  })
+
+  it('still requires a resumable harness and provider session id', () => {
+    expect(clearEnvEligibility('claude', undefined)).toEqual({
+      ok: false,
+      reason: 'no-session'
+    })
+    expect(clearEnvEligibility('my-custom', 'abc')).toEqual({
+      ok: false,
+      reason: 'not-resumable'
+    })
+    // An agent with no vanillaEnvPattern (gemini) still passes THIS gate — resumability is a
+    // separate fact from "has a strip set." The menu row is hidden upstream on the pattern, so
+    // the gate is only ever reached for claude/codex/copilot. Tested in vanilla-env.test.ts.
+    expect(clearEnvEligibility('gemini', 'abc')).toEqual({ ok: true })
   })
 })
 

--- a/src/renderer/terminal/agent-restart.ts
+++ b/src/renderer/terminal/agent-restart.ts
@@ -1,7 +1,8 @@
 /**
- * Pure helpers for restarting an agent CLI IN PLACE inside its tmux pane — quit the CLI, then
- * relaunch it with the provider's own `--resume`, so a newly released model shows up in the CLI's
- * model list without losing the conversation. Kept free of DOM/IPC so the node menu, the bulk
+ * Pure helpers for restarting an agent CLI IN PLACE inside its tmux pane — stop the exact
+ * identity-verified foreground process group, then relaunch with the provider's own `--resume`,
+ * so a newly released model shows up in the CLI's model list without losing the conversation.
+ * Kept free of DOM/IPC so the node menu, the bulk
  * filter and the restart choreography can all share exactly one set of rules.
  */
 import {
@@ -12,28 +13,30 @@ import {
   type AgentId
 } from '../../shared/agents/config'
 import { isShellCommand } from '@shared/agents/pane'
+import { modelRespawnErrorKind, modelRespawnTrace } from '@shared/model-respawn-trace'
+import type { TerminateForegroundOutcome } from '@shared/types'
 import {
   DELIVERY_ATTEMPTS,
-  KILL_LINE,
   VERIFY_TIMEOUT_MS,
   deliverCommand,
   type DeliveryIo
 } from './command-delivery'
 
-/** In-band exit command per agent CLI. Only agents listed here can be restarted in place —
- *  an unknown CLI has no safe way to be asked to quit. One entry turns on both surfaces at once:
+/** Historical in-band exit grammar per agent CLI. Production restarts no longer TYPE these
+ *  strings — they use the exact-PID `terminateForeground` path — but the table remains the
+ *  deliberately reviewed support allowlist for restart/hibernation. One entry turns on both surfaces at once:
  *  the single-node "Restart agent (resume)" row in the node context menu, and the bulk "restart
  *  idle agents" action (pane menu + command palette). There is no header button for either —
  *  `HIDEABLE_HEADER_BUTTONS` is refresh / mic / ai-name / comments. The matching relaunch line
  *  always comes from `resumeCommand`.
  *
- *  Each value is the CLI's own DOCUMENTED PRIMARY, and is sent BARE:
+ *  Each value is the CLI's own DOCUMENTED PRIMARY and stays BARE in this reviewed table:
  *    - grok:   `/quit` (its `/exit` is an alias).
  *    - gemini: `/quit` (alias `/exit`), measured in its bundled `docs/reference/commands.md:325`.
  *
- *  Bare is a safety rule, not a style: gemini's `/quit` also takes a `--delete` flag that exits AND
- *  *permanently deletes* the session's history and temporary files — the very conversation the
- *  `--resume` behind it is meant to return to. Nothing may append arguments to a value here. */
+ *  Bare is still a safety rule, not a style: gemini's `/quit` also takes a `--delete` flag that
+ *  permanently deletes session history. Runtime restart does not write the value, but support
+ *  metadata must never normalize the destructive variant into this allowlist. */
 const EXIT_SEQUENCES: Record<string, string> = {
   claude: '/exit',
   codex: '/quit',
@@ -56,13 +59,53 @@ export { isShellCommand }
 
 export type IneligibleReason = 'working' | 'no-session' | 'not-resumable'
 
+/**
+ * Everyone who can refuse a restart, exit or wake, and why. The outcome unions stay bare
+ * strings (`'not-eligible'` — spec-frozen by tests and the bulk summary), so the REASON rides
+ * the transient agentStatus side channel (`lastRestartRefusal`); this union is the one
+ * vocabulary both readers (Canvas notice, grouped-restart strip) and every writer render or
+ * compose from. Never prose at a refusal site — a member of this union plus optional detail.
+ */
+export type RestartRefusalReason =
+  | IneligibleReason      // from the shared eligibility gate (busy / no id / not drivable)
+  | 'busy'                // a restart/exit of this node is already in flight (concurrent guard)
+  | 'unwatchable'         // the pane cannot be watched (pre-flight paneCommand null)
+  | 'agent-diverged'      // the session's agent changed/deleted under a stale menu
+  | 'no-model'            // a model switch named a model the harness cannot express
+  | 'missing-env'         // the relaunch line references env that no longer resolves
+  | 'relay'               // relay sessions belong to another core
+  | 'gone'                // the session died under the restart (delete/respawn/destroy)
+  | 'lost-foreground'     // the pane's foreground changed hands before we could act
+  | 'pane-not-shell'      // the pane is held by another program (vim/top/…) — wake refuses
+  | 'agent-not-running'   // replacement shell lived, but its separately tracked agent PID exited
+  | 'threw'               // the machinery itself errored (fail loud: detail = the exception)
+
+/** ONE sentence per reason. Composed ONCE here so the Canvas notice and the strip row cannot
+ *  disagree; a detail from the refusal site (the pane content, the missing var names, the thrown
+ *  error) is appended by the renderer when it has one. */
+export const RESTART_REFUSAL_COPY: Record<RestartRefusalReason, string> = {
+  working: 'the session is mid-turn or blocked on a permission prompt — nothing was written to the pane.',
+  'no-session': 'there is no session id to resume into (the CLI never reported one) — nothing was written to the pane.',
+  'not-resumable': 'this agent has no resume grammar nodeterm can drive — no exit line to ask it to quit, nothing to relaunch.',
+  busy: 'another restart, model switch or hibernation of this session is already in flight.',
+  unwatchable: 'the pane cannot be watched without persistent tmux sessions (or tmux at all), so the restart cannot verify the CLI quit before relaunching.',
+  'agent-diverged': 'the session changed agent (or the agent was deleted) since the menu was built.',
+  'no-model': 'the model to switch to is not expressible in this harness’s grammar.',
+  'missing-env': 'the relaunch line references an environment variable that no longer resolves — check the agent config.',
+  relay: 'relay sessions run on another machine’s core — this machine cannot restart them.',
+  gone: 'the tmux session died during the restart.',
+  'lost-foreground': 'the pane’s foreground process changed hands before the restart could act.',
+  'pane-not-shell': 'the pane is held by another program — bring it back to a prompt first.',
+  'agent-not-running': 'the replacement shell started, but the agent process exited during startup.',
+  threw: 'the restart machinery threw an exception — see the detail.'
+}
+
 /** States in which the pane must be left alone. `blocked` is here for a sharper reason than
  *  politeness: it means a permission / question dialog owns the prompt (see normalize.ts —
  *  Claude's PermissionRequest, codex's permission.asked / question.asked, gemini's
- *  Notification/ToolPermission), so writing the exit line would be typed AS THE ANSWER to that
- *  dialog instead of quitting the CLI — whichever line it is (`/exit` for claude, `/quit` for the
- *  rest). Both states report the reason `'working'`: to the user they are the same "busy, try
- *  again in a moment". */
+ *  Notification/ToolPermission). Even though PID termination cannot answer that dialog by
+ *  accident, an ordinary restart must not discard active work or a pending user decision. Both
+ *  states report `'working'`: to the user they are the same "busy, try again in a moment". */
 const BUSY_STATES = new Set(['working', 'blocked'])
 
 /** Single gate shared by the node menu, the bulk filter and the choreography itself.
@@ -75,8 +118,8 @@ export function restartEligibility(
 ): { ok: true } | { ok: false; reason: IneligibleReason } {
   if (!agentId || !canResume(agentId) || !exitSequence(agentId))
     return { ok: false, reason: 'not-resumable' }
-  // Quitting mid-turn would abandon work the agent is in the middle of; quitting a blocked
-  // session would answer its dialog with the exit command (see BUSY_STATES).
+  // Stopping mid-turn would abandon work the agent is in the middle of; stopping a blocked
+  // session would discard a decision that belongs to the user (see BUSY_STATES).
   if (BUSY_STATES.has(state ?? '')) return { ok: false, reason: 'working' }
   // Without a provider session id there is nothing to resume into.
   if (!sessionId) return { ok: false, reason: 'no-session' }
@@ -97,10 +140,10 @@ export function restartSessionId(live: unknown, persisted: unknown): string | un
 
 /**
  * "Restart on subscription" (clear-env) has the same interruption contract as a model switch: it
- * never writes the harness exit command into the composer — core proves the expected agent owns
- * the foreground process group and terminates that group by PID before the pane is recycled — so a
- * `working` or `blocked` session may be interrupted safely (unlike `restartEligibility`, which must
- * reject those states because its `/exit` would be typed AS THE ANSWER to a permission dialog).
+ * is the explicit force-recovery action: core proves the expected agent owns the foreground
+ * process group and terminates that group by PID before the pane is recycled, so a `working` or
+ * `blocked` session may be interrupted intentionally. Ordinary `restartEligibility` keeps its
+ * conservative do-not-interrupt-active-work policy even though it shares the same safe terminator.
  * Gateway overload — the scenario this feature exists for — shows up mid-turn: the turn is stuck or
  * failing, and "wait for the turn to finish" is exactly what you cannot do when the gateway is down.
  *
@@ -160,25 +203,32 @@ export async function queryPaneWithin(
   }
 }
 
-/** The exit half's own outcomes. `'exited'` means only that the CLI let go of the pane — the
- *  conversation is not back until the resume half has delivered. */
-export type ExitPhaseOutcome = 'exited' | 'exit-timeout' | 'not-eligible'
+/** The exit half's own outcomes. `'exited'` means this call stopped the CLI and observed the shell;
+ *  `'already-exited'` means core successfully observed that the expected agent no longer owns the
+ *  foreground group. The distinction lets a local restart force the fresh-session respawn path
+ *  without misidentifying whatever replaced the agent as a safe PID target. */
+export type ExitPhaseOutcome =
+  | 'exited'
+  | 'already-exited'
+  | 'exit-timeout'
+  | 'not-eligible'
 
 /** The resume half's own outcomes. `'not-eligible'` covers both refusals: a session id that could
  *  never reach a command line, and a pane that stopped existing under the delivery. */
 export type ResumePhaseOutcome = 'resumed' | 'not-eligible'
 
 /**
- * PHASE 1 — ask the agent to quit and wait until the CLI has let go of the pane. Never
- * force-kills: on timeout the CLI is left running and the caller reports the node. Once the exit
- * has been sent, `paneCommand` errors count as "not a shell yet"; the timeout is the backstop.
+ * PHASE 1 — terminate the exact, identity-verified agent process group and wait until the CLI has
+ * let go of the pane. The terminator is supplied by the session-scoped caller and implemented in
+ * core (`pty.terminateForeground`): it proves the expected harness's PID is STILL live in the
+ * foreground group immediately before SIGTERM. Nothing is typed into the pane, so a stale restart
+ * can never submit `/exit` to a raw shell, permission prompt, editor, or replacement process.
  *
- * NOTHING is written until one `paneCommand` has come back non-null. The exit command is
- * irreversible — the conversation is only recoverable through the `--resume` that follows it — so
- * a pane we cannot WATCH must never be quit: with tmux switched off in Settings, or absent from
- * the machine, the query answers null forever, and quitting first would leave the agent dead, the
- * relaunch never sent, and the user told (after 6s of polling) that "the session was left
- * running". The pre-flight makes that state a plain `'not-eligible'`, with an untouched pane.
+ * NOTHING is terminated until one `paneCommand` has come back non-null. The stop is irreversible
+ * until the `--resume` that follows, so a pane we cannot WATCH must never be stopped: with tmux
+ * switched off in Settings, or absent from the machine, the query answers null forever and the
+ * relaunch could never be timed safely. The pre-flight makes that state a plain
+ * `'not-eligible'`, with an untouched pane.
  *
  * The bare `resumeCommand` is a gate HERE too, not only in the resume half: a session this app
  * would refuse to resume must not be exited either, or the exit alone would lose it. Hibernation
@@ -188,8 +238,13 @@ export type ResumePhaseOutcome = 'resumed' | 'not-eligible'
 export async function performExitPhase(d: {
   agentId: string
   sessionId: string
+  /** Kept beside the resume dependency so the composed restart has one IO bundle. This phase no
+   *  longer writes to it; the process terminator below is the only stop mechanism. */
   io: DeliveryIo
   paneCommand: () => Promise<string | null>
+  /** Identity-gated core operation. It distinguishes an exact-PID termination, an expected agent
+   *  absent from a successfully read foreground group, and an unreadable/unsafe refusal. */
+  terminateForeground: () => Promise<TerminateForegroundOutcome>
   timeoutMs?: number
   pollMs?: number
   /**
@@ -198,58 +253,89 @@ export async function performExitPhase(d: {
    * destroys the tmux session), and there is then no pane left to fail in.
    */
   isLive?: () => boolean
+  /** WHY did we refuse? Rides the transient side channel (`agentStatus.lastRestartRefusal`) so
+   *  the Canvas notice and strip can render one refusal with one reason; the outcome unions stay
+   *  bare strings. Optional so refusals keep their existing behavior when unset (tests). */
+  onRefusal?: (reason: RestartRefusalReason, detail?: string) => void
 }): Promise<ExitPhaseOutcome> {
+  modelRespawnTrace('exit.begin', {
+    agentId: d.agentId,
+    hasSessionId: !!d.sessionId,
+    timeoutMs: d.timeoutMs ?? RESTART_EXIT_TIMEOUT_MS
+  })
   const exit = exitSequence(d.agentId)
   // The eligibility GATE (not the command): `canResumeWith` validates the session id the way
   // `resumeCommand` does, without building the command — which for a custom agent needs its
   // `launchCmd` from settings (unavailable in this pure module). The typed resume line is the
   // caller's job (`performResumePhase` takes it as `d.command`); the exit half only needs to know
   // the session is one we WOULD resume into, so it does not quit a conversation it cannot bring back.
-  if (!exit || !canResumeWith(d.agentId, d.sessionId)) return 'not-eligible'
+  if (!exit || !canResumeWith(d.agentId, d.sessionId)) {
+    modelRespawnTrace('exit.refused', { agentId: d.agentId, reason: 'not-resumable' })
+    d.onRefusal?.('not-resumable')
+    return 'not-eligible'
+  }
   const timeoutMs = d.timeoutMs ?? RESTART_EXIT_TIMEOUT_MS
   const pollMs = d.pollMs ?? RESTART_POLL_MS
   // A dead session is not a restart that failed — there is no pane left to fail in. `'not-eligible'`
   // (uncounted) rather than `'exit-timeout'`, which claims something sharper and false: that the CLI
   // is still running and refused to quit, sending the user to look at a pane that is gone.
   const gone = (): boolean => !!d.isLive && !d.isLive()
-  if (gone()) return 'not-eligible'
+  if (gone()) {
+    modelRespawnTrace('exit.refused', { agentId: d.agentId, reason: 'gone-before-preflight' })
+    d.onRefusal?.('gone')
+    return 'not-eligible'
+  }
   // ── Pre-flight: prove we can SEE this pane before quitting anything in it (see the header).
   // Reported as `'not-eligible'`, the outcome that means "not a target right now" and is the one
   // the menu and the notice already have wording for. Nothing has been written at this point.
   const before = await queryPaneWithin(d.paneCommand, timeoutMs)
-  if (before === null || gone()) return 'not-eligible'
-  // Clear the prompt before typing the exit command. The pane is a REPL the user types into: a
-  // half-written prompt left in it would otherwise be submitted as `…refactor the/exit` — the
-  // draft lost and a real turn started (tokens, possibly edits) — and the CLI, still running,
-  // would then be reported as an exit timeout.
-  //
-  // ASSUMPTION, unverified on a real build: Ctrl-U is "clear line" inside every TUI in
-  // EXIT_SEQUENCES (claude, codex, grok, gemini) — it is in every readline/ZLE prompt, and it is
-  // what command-delivery.ts already relies on for its rewrites. Each agent added to that table
-  // inherits this assumption; only a device check retires it, per agent. If a TUI binds Ctrl-U to
-  // something else this becomes one stray keystroke before the exit command — no worse than
-  // today's blind write. Belongs in the manual test matrix.
-  d.io.write(KILL_LINE)
-  // opencode's TUI does not submit when text and CR arrive in the same input burst
-  // (batched-input handling). Measured on 1.18.18-1.18.25, Linux, tmux, isolated socket:
-  // one-burst `/exit\r` leaves `/exit` in the composer with popup armed and times out
-  // at 6s; splitting CR by 100ms exits in ~500ms. The resume half already uses
-  // echo-verified delivery (command-delivery.ts) for this shape; for exit we keep
-  // the minimal split so the other agents' blind-write contract stays unchanged.
-  if (d.agentId === 'opencode') {
-    d.io.write(exit)
-    await new Promise((r) => setTimeout(r, 150))
-    if (gone()) return 'not-eligible'
-    d.io.write('\r')
-  } else {
-    d.io.write(exit + '\r')
+  modelRespawnTrace('exit.preflight', {
+    agentId: d.agentId,
+    paneVisible: before !== null,
+    paneCommand: before ?? 'unavailable'
+  })
+  if (before === null || gone()) {
+    modelRespawnTrace('exit.refused', { agentId: d.agentId, reason: 'unwatchable' })
+    d.onRefusal?.('unwatchable')
+    return 'not-eligible'
+  }
+  // Re-prove ownership at the destructive boundary. `paneCommand` above only says the pane is
+  // watchable; it is deliberately NOT treated as identity evidence (npm-installed CLIs commonly
+  // all appear as `node`). Core reads full argv + PID and refuses on any uncertainty or handoff.
+  let termination: TerminateForegroundOutcome = 'refused'
+  try {
+    termination = await d.terminateForeground()
+  } catch (error) {
+    modelRespawnTrace('exit.terminate-threw', {
+      agentId: d.agentId,
+      errorKind: modelRespawnErrorKind(error)
+    })
+    termination = 'refused'
+  }
+  modelRespawnTrace('exit.termination', { agentId: d.agentId, outcome: termination })
+  if (gone()) {
+    modelRespawnTrace('exit.refused', { agentId: d.agentId, reason: 'gone-after-terminate' })
+    d.onRefusal?.('gone')
+    return 'not-eligible'
+  }
+  if (termination === 'already-exited') {
+    modelRespawnTrace('exit.complete', { agentId: d.agentId, outcome: 'already-exited' })
+    return 'already-exited'
+  }
+  if (termination !== 'terminated') {
+    modelRespawnTrace('exit.refused', { agentId: d.agentId, reason: 'lost-foreground' })
+    d.onRefusal?.('lost-foreground')
+    return 'not-eligible'
   }
   const deadline = Date.now() + timeoutMs
   let last: string | null = null
   for (;;) {
     await new Promise((r) => setTimeout(r, pollMs))
     const pane = await queryPaneWithin(d.paneCommand, Math.max(0, deadline - Date.now()))
-    if (gone()) return 'not-eligible' // stop polling a pane that no longer exists
+    if (gone()) {
+      d.onRefusal?.('gone')
+      return 'not-eligible' // stop polling a pane that no longer exists
+    }
     // Two ways to know the CLI let go of the pane. The allowlist is the confident one and is
     // taken immediately. The other — "the foreground command is no longer what it was before the
     // exit" — covers the shells the allowlist cannot know (`nu`, `xonsh`, `pwsh`, anything the
@@ -257,10 +343,32 @@ export async function performExitPhase(d: {
     // already quit and never resumed. It is required on two CONSECUTIVE polls: a single changed
     // reading can be a momentary foreground child of a still-running CLI, and typing the resume
     // line into a live CLI would send it as a message.
-    if (isShellCommand(pane)) return 'exited'
-    if (pane !== null && pane !== before && pane === last) return 'exited'
+    if (isShellCommand(pane)) {
+      modelRespawnTrace('exit.complete', {
+        agentId: d.agentId,
+        outcome: 'exited',
+        evidence: 'shell'
+      })
+      return 'exited'
+    }
+    if (pane !== null && pane !== before && pane === last) {
+      modelRespawnTrace('exit.complete', {
+        agentId: d.agentId,
+        outcome: 'exited',
+        evidence: 'stable-command-change',
+        paneCommand: pane
+      })
+      return 'exited'
+    }
     last = pane
-    if (Date.now() > deadline) return 'exit-timeout'
+    if (Date.now() > deadline) {
+      modelRespawnTrace('exit.complete', {
+        agentId: d.agentId,
+        outcome: 'exit-timeout',
+        lastPaneCommand: pane ?? 'unavailable'
+      })
+      return 'exit-timeout'
+    }
   }
 }
 
@@ -309,55 +417,96 @@ export async function performResumePhase(d: {
    * would put a phantom in the bulk summary.
    */
   isLive?: () => boolean
+  /** WHY did we refuse? See the exit half. */
+  onRefusal?: (reason: RestartRefusalReason, detail?: string) => void
 }): Promise<ResumePhaseOutcome> {
+  modelRespawnTrace('resume.begin', {
+    agentId: d.agentId,
+    hasSessionId: !!d.sessionId,
+    hasAssembledCommand: !!d.command
+  })
   // The eligibility GATE (see performExitPhase): `canResumeWith` validates the session id without
   // building the command. The typed line is the caller's `d.command`; for a builtin with no
   // override, `resumeCommand` supplies the bare resume command. A custom agent MUST pass
   // `d.command` (its baseAgent-aware line, built by `assembleResumeCommand` in the node) — it has
   // no `resumeCommand` here, so a missing `command` for a custom agent refuses before any write.
-  if (!canResumeWith(d.agentId, d.sessionId)) return 'not-eligible'
+  if (!canResumeWith(d.agentId, d.sessionId)) {
+    modelRespawnTrace('resume.refused', { agentId: d.agentId, reason: 'not-resumable' })
+    d.onRefusal?.('not-resumable')
+    return 'not-eligible'
+  }
   const base = resumeCommand(d.agentId, d.sessionId)
   const cmd = d.command ?? base
-  if (!cmd) return 'not-eligible'
+  if (!cmd) {
+    modelRespawnTrace('resume.refused', { agentId: d.agentId, reason: 'no-session' })
+    d.onRefusal?.('no-session')
+    return 'not-eligible'
+  }
   const gone = (): boolean => !!d.isLive && !d.isLive()
   // Awaited, not fire-and-forget: see the header. `deliverCommand` is started inside the executor
   // (synchronously, so `onDelivery` still hands the cancel out before any await) and announces the
-  // end of the delivery — submitted, fail-open or cancelled — through `settle`.
+  // end of the delivery — successfully submitted, failed, or cancelled — through `settle`.
   await new Promise<void>((resolve, reject) => {
     let lapse: ReturnType<typeof setTimeout> | undefined
     let settled = false
+    let settledSubmitted = false
     let started = false
+    let cancelDelivery: (() => void) | undefined
     // A settle announced from INSIDE deliverCommand's synchronous body is only applied below,
     // after it has returned: that body can announce the end of the delivery and then throw (a
     // transport that rejects the very first write ends the delivery, then reports), and a promise
     // resolved first could no longer be rejected — the restart would claim success for a resume
     // line that never reached the pane.
-    const settle = (): void => {
+    const settle = (submitted: boolean): void => {
       settled = true
+      settledSubmitted = submitted
       if (!started) return
       clearTimeout(lapse)
-      resolve()
+      if (submitted) resolve()
+      else reject(new Error('resume delivery did not submit'))
     }
     try {
       // Two statements on purpose: `d.onDelivery?.(deliverCommand(…))` short-circuits the ARGUMENT
       // too when no callback was passed — nothing would be delivered and this promise would never
       // settle.
-      const cancelDelivery = deliverCommand(d.io, cmd, settle)
+      cancelDelivery = deliverCommand(d.io, cmd, (outcome) => settle(outcome === 'submitted'))
       started = true
+      modelRespawnTrace('resume.delivery-started', { agentId: d.agentId })
       d.onDelivery?.(cancelDelivery)
     } catch (e) {
+      modelRespawnTrace('resume.delivery-threw', {
+        agentId: d.agentId,
+        errorKind: modelRespawnErrorKind(e)
+      })
       reject(e) // the caller counts a failure; no timer has been armed yet
       return
     }
-    if (settled) return resolve() // an io that echoes inside write() finishes the delivery there
+    if (settled) {
+      // A synchronous echo can settle inside the first write, including an Enter write that
+      // rejects inside that re-entrant callback. Preserve its actual submission verdict.
+      return settledSubmitted
+        ? resolve()
+        : reject(new Error('resume delivery did not submit'))
+    }
     // Bounded even so. The delivery's own retry chain is finite, but this await holds the node
     // (and, in a bulk run, every node after it and the summary), so it must not depend on a third
     // party announcing itself.
-    lapse = setTimeout(resolve, d.deliveryTimeoutMs ?? RESTART_DELIVERY_TIMEOUT_MS)
+    lapse = setTimeout(() => {
+      // A timeout is not proof that Enter reached the pane. Stop the still-live retry chain before
+      // failing so it cannot submit later, after the restart owner has already released the node.
+      cancelDelivery?.()
+      reject(new Error('resume delivery timed out before submission'))
+    }, d.deliveryTimeoutMs ?? RESTART_DELIVERY_TIMEOUT_MS)
   })
   // The session can have died while the line was being verified — the delivery is then cancelled by
   // the teardown and nothing reached the pane, so don't claim a resume.
-  return gone() ? 'not-eligible' : 'resumed'
+  if (gone()) {
+    modelRespawnTrace('resume.refused', { agentId: d.agentId, reason: 'gone-after-delivery' })
+    d.onRefusal?.('gone')
+    return 'not-eligible'
+  }
+  modelRespawnTrace('resume.complete', { agentId: d.agentId, outcome: 'resumed' })
+  return 'resumed'
 }
 
 /**
@@ -377,6 +526,11 @@ export async function performRestartResume(d: {
   sessionId: string
   io: DeliveryIo
   paneCommand: () => Promise<string | null>
+  /** The one stop mechanism used by every production restart path; see `performExitPhase`. */
+  terminateForeground: () => Promise<TerminateForegroundOutcome>
+  /** Local terminals use this to force the same recycle path as "Restart agent and shell" when
+   *  the expected agent no longer owns the pane. Relay callers may omit it and resume in place. */
+  onAlreadyExited?: () => Promise<RestartOutcome>
   /** See `performResumePhase`: the caller's launch line (permission mode), gated by the bare one. */
   command?: string
   timeoutMs?: number
@@ -392,19 +546,37 @@ export async function performRestartResume(d: {
    * io then silently no-ops and reporting `'restarted'` would put a phantom in the bulk summary.
    */
   isLive?: () => boolean
+  /** WHY did we refuse? See performExitPhase. Composed down to both halves. */
+  onRefusal?: (reason: RestartRefusalReason, detail?: string) => void
 }): Promise<RestartOutcome> {
+  modelRespawnTrace('restart.compose-begin', {
+    agentId: d.agentId,
+    hasSessionId: !!d.sessionId,
+    forceRecycleAvailable: !!d.onAlreadyExited
+  })
   const exited = await performExitPhase({
     agentId: d.agentId,
     sessionId: d.sessionId,
     io: d.io,
     paneCommand: d.paneCommand,
+    terminateForeground: d.terminateForeground,
     timeoutMs: d.timeoutMs,
     pollMs: d.pollMs,
-    isLive: d.isLive
+    isLive: d.isLive,
+    onRefusal: d.onRefusal
   })
-  // `'exit-timeout'` / `'not-eligible'` mean the same things they always did, so they are the
-  // restart's outcome verbatim — nothing has been resumed and nothing more may be written.
-  if (exited !== 'exited') return exited
+  // A local caller can force-recycle a session whose expected agent is absent. With no callback
+  // (notably a relay session), the caller deliberately falls back to its in-place resume path.
+  if (exited === 'already-exited' && d.onAlreadyExited) {
+    modelRespawnTrace('restart.force-recycle', { agentId: d.agentId })
+    const outcome = await d.onAlreadyExited()
+    modelRespawnTrace('restart.compose-complete', { agentId: d.agentId, outcome })
+    return outcome
+  }
+  if (exited !== 'exited' && exited !== 'already-exited') {
+    modelRespawnTrace('restart.compose-complete', { agentId: d.agentId, outcome: exited })
+    return exited
+  }
   const resumed = await performResumePhase({
     agentId: d.agentId,
     sessionId: d.sessionId,
@@ -412,9 +584,12 @@ export async function performRestartResume(d: {
     command: d.command,
     deliveryTimeoutMs: d.deliveryTimeoutMs,
     onDelivery: d.onDelivery,
-    isLive: d.isLive
+    isLive: d.isLive,
+    onRefusal: d.onRefusal
   })
-  return resumed === 'resumed' ? 'restarted' : resumed
+  const outcome = resumed === 'resumed' ? 'restarted' : resumed
+  modelRespawnTrace('restart.compose-complete', { agentId: d.agentId, outcome })
+  return outcome
 }
 
 // ── One restart at a time, per node ──────────────────────────────────────────────────────
@@ -422,8 +597,8 @@ const inFlight = new Set<string>()
 
 /**
  * Serialize a node's restarts. The per-node menu action and the bulk palette action can both
- * reach the same node, and two runs against one pane would write two `/exit` lines (the second
- * typed INTO the CLI the first is resuming) and two resume commands.
+ * reach the same node, and two runs against one pane would stop the replacement process and emit
+ * two resume commands.
  *
  * ONE set for every kind of run: a hibernation exit, a wake resume and a user restart all pass
  * through here, so a sweep cannot quit the pane a menu restart is already resuming, and vice versa.
@@ -432,9 +607,8 @@ const inFlight = new Set<string>()
  * member of every one of those unions.
  *
  * The node is held for the WHOLE run, delivery included (see performResumePhase's header): a
- * second `/exit` arriving while the resume line sits un-submitted in the pane would be spliced
- * into it and submit `claude --resume <sid>/exit` — the exact mangled line command-delivery.ts
- * exists to prevent, and likeliest precisely when echo verification is being slow.
+ * second run arriving while the resume line sits un-submitted could terminate the new process or
+ * splice a second launch line into the first — likeliest precisely when echo verification is slow.
  *
  * The refused call reports `'not-eligible'` deliberately: the run already in flight owns this
  * node's outcome and will report it, and `'not-eligible'` is the one outcome `summarizeOutcomes`
@@ -446,27 +620,40 @@ export function guardConcurrentRestart<T extends string, Args extends unknown[]>
   fn: (...args: Args) => Promise<T>
 ): (...args: Args) => Promise<T | 'not-eligible'> {
   return async (...args: Args) => {
-    if (inFlight.has(nodeId)) return 'not-eligible'
+    if (inFlight.has(nodeId)) {
+      modelRespawnTrace('restart.concurrent-refused', { nodeId })
+      return 'not-eligible'
+    }
+    modelRespawnTrace('restart.guard-acquired', { nodeId })
     inFlight.add(nodeId)
     try {
-      return await fn(...args)
+      const outcome = await fn(...args)
+      modelRespawnTrace('restart.guard-complete', { nodeId, outcome })
+      return outcome
+    } catch (error) {
+      modelRespawnTrace('restart.guard-threw', {
+        nodeId,
+        errorKind: modelRespawnErrorKind(error)
+      })
+      throw error
     } finally {
       // Released on rejection too: a transport that threw once must not leave the node
       // permanently un-restartable for the rest of the app's run.
       inFlight.delete(nodeId)
+      modelRespawnTrace('restart.guard-released', { nodeId })
     }
   }
 }
 
 // ── Node registry (same park-surviving pattern as TerminalNode's restartSubs) ────────────
 // The closure's optional args select what kind of restart:
-//  - no args                  → plain "Restart agent": quit + resume the SAME agent in the SAME shell.
-//  - `targetAgentId`          → "Reopen session as <variant>": quit + resume the SAME session id
+//  - no args                  → plain "Restart agent": terminate + resume the SAME agent in the SAME shell.
+//  - `targetAgentId`          → "Reopen session as <variant>": terminate + resume the SAME session id
 //                               under a same-base agent's binary (the id is harness-portable within
 //                               a base; see lib/reopenVariants.ts).
 //  - `targetModel`            → switch the gateway model: quit + RECYCLE the tmux session so a fresh
 //                               shell spawns with the new gateway env, then the agent auto-resumes.
-//  - `restartShell: true`     → "Restart agent and shell": quit + RECYCLE for a FRESH shell (picks up
+//  - `restartShell: true`     → "Restart agent and shell": terminate + RECYCLE for a FRESH shell (picks up
 //                               profile/env changes the same-shell restart cannot) keeping the SAME
 //                               agent + model, then the agent auto-resumes. The recycle-after-exit
 //                               mechanism is the one a model switch already uses, exposed as its own
@@ -507,8 +694,8 @@ export function agentRestartFn(nodeId: string): AgentRestartFn | undefined {
  * wake and a user restart can never write into one pane at once.
  */
 export interface AgentHibernateFns {
-  /** Ask the CLI to quit and wait for the pane. `'exited'` is the only outcome that may be
-   *  recorded as hibernated — anything else leaves the node exactly as it was. */
+  /** Stop the CLI and wait for the pane. Only a CLI this call actually stopped (`'exited'`) may be
+   *  recorded as hibernated; an already-absent agent and every refusal leave the node as it was. */
   exit: () => Promise<ExitPhaseOutcome>
   /** Re-launch the conversation with the provider's own `--resume`. */
   resume: () => Promise<ResumePhaseOutcome>
@@ -650,15 +837,22 @@ export function planBulkRestart(candidates: BulkRestartCandidate[]): BulkRestart
  * whatever went wrong on the one node.
  *
  * `'exit-timeout'` — the "N failed" bucket — rather than the uncounted `'not-eligible'`: a throw
- * means the restart was attempted and did not complete, possibly leaving a stray `/exit` in the
- * pane, so it needs the same "go look at that node" reading a timeout gets. Filing it as a skip
+ * means the restart was attempted and did not complete, possibly leaving the pane between stop
+ * and resume, so it needs the same "go look at that node" reading a timeout gets. Filing it as a skip
  * would tell the user nothing happened there, which is exactly what we do not know. (A fifth
  * outcome is not an option — the summary line is spec-frozen at four parts.)
  */
-export async function settleRestart(fn: () => Promise<RestartOutcome>): Promise<RestartOutcome> {
+export async function settleRestart(
+  fn: () => Promise<RestartOutcome>,
+  /** Present in the real callers so a THROWN exception fails LOUD: the verbatim error text rides
+   *  the side channel (reason `'threw'`) instead of vanishing into the generic timeout wording.
+   *  Tests that pass no reporter get the behavior unchanged. */
+  onRefusal?: (reason: RestartRefusalReason, detail?: string) => void
+): Promise<RestartOutcome> {
   try {
     return await fn()
-  } catch {
+  } catch (e) {
+    onRefusal?.('threw', e instanceof Error ? e.message : String(e))
     return 'exit-timeout'
   }
 }

--- a/src/renderer/terminal/agent-restart.ts
+++ b/src/renderer/terminal/agent-restart.ts
@@ -95,6 +95,29 @@ export function restartSessionId(live: unknown, persisted: unknown): string | un
   return undefined
 }
 
+/**
+ * "Restart on subscription" (clear-env) has the same interruption contract as a model switch: it
+ * never writes the harness exit command into the composer — core proves the expected agent owns
+ * the foreground process group and terminates that group by PID before the pane is recycled — so a
+ * `working` or `blocked` session may be interrupted safely (unlike `restartEligibility`, which must
+ * reject those states because its `/exit` would be typed AS THE ANSWER to a permission dialog).
+ * Gateway overload — the scenario this feature exists for — shows up mid-turn: the turn is stuck or
+ * failing, and "wait for the turn to finish" is exactly what you cannot do when the gateway is down.
+ *
+ * The durable requirements are shared with restart: the harness must support resume and there must
+ * be a provider session id to carry into the replacement process. The strip set itself is checked
+ * by the caller through `vanillaEnvStripPattern` (only claude/codex/copilot builtins have one).
+ */
+export function clearEnvEligibility(
+  agentId: string | undefined,
+  sessionId: string | undefined
+): { ok: true } | { ok: false; reason: Exclude<IneligibleReason, 'working'> } {
+  if (!agentId || !canResume(agentId) || !exitSequence(agentId))
+    return { ok: false, reason: 'not-resumable' }
+  if (!sessionId) return { ok: false, reason: 'no-session' }
+  return { ok: true }
+}
+
 export type RestartOutcome = 'restarted' | 'exit-timeout' | 'not-eligible'
 
 export const RESTART_EXIT_TIMEOUT_MS = 6000
@@ -451,7 +474,13 @@ export function guardConcurrentRestart<T extends string, Args extends unknown[]>
 export type AgentRestartFn = (
   targetAgentId?: AgentId,
   targetModel?: string,
-  restartShell?: boolean
+  restartShell?: boolean,
+  // "Restart on subscription": recycle the session VANILLA — strip the gateway + inherited
+  // provider env so the agent falls back to its OWN default provider. No model/agent change; the
+  // cold-restore auto-resume keeps the same conversation. Uses `clearEnvEligibility` (permits busy,
+  // since `terminateForeground` is PID-safe — no `/exit` typed into a dialog) and recycles the same
+  // way a model switch does, because tmux env changes do not retroactively change an existing shell.
+  clearEnv?: boolean
 ) => Promise<RestartOutcome>
 
 const restartFns = new Map<string, AgentRestartFn>()

--- a/src/renderer/terminal/command-delivery.test.ts
+++ b/src/renderer/terminal/command-delivery.test.ts
@@ -1,3 +1,4 @@
+import type { DeliveryOutcome } from './command-delivery'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   DELIVERY_ATTEMPTS,
@@ -226,11 +227,32 @@ describe('deliverCommand', () => {
 
   it('does not let a throwing Enter escape into the echo listener', () => {
     const f = throwingIo((d) => d === '\r')
-    let ends = 0
-    deliverCommand(f.io, CMD, () => (ends += 1))
+    const verdicts: DeliveryOutcome[] = []
+    deliverCommand(f.io, CMD, (outcome) => verdicts.push(outcome))
     expect(() => f.emit(CMD)).not.toThrow() // the throw would surface inside the PTY data callback
-    expect(ends).toBe(1) // the line was written and verified; only Enter was lost
+    expect(verdicts).toEqual(['cancelled']) // verified text is not a submission when Enter was lost
     expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('reports submitted only after the final Enter write succeeds', () => {
+    const f = fakeIo()
+    const verdicts: DeliveryOutcome[] = []
+    deliverCommand(f.io, CMD, (outcome) => verdicts.push(outcome))
+    expect(verdicts).toEqual([])
+    f.emit(CMD)
+    expect(verdicts).toEqual(['submitted'])
+    expect(f.writes.at(-1)).toBe('\r')
+  })
+
+  it('invokes a throwing settlement callback exactly once', () => {
+    const f = fakeIo()
+    const settled = vi.fn(() => {
+      throw new Error('consumer failed')
+    })
+    deliverCommand(f.io, CMD, settled)
+    expect(() => f.emit(CMD)).toThrow('consumer failed')
+    expect(settled).toHaveBeenCalledOnce()
+    expect(settled).toHaveBeenCalledWith('submitted')
   })
 
   it('ignores echo arriving after submit (no double Enter)', () => {

--- a/src/renderer/terminal/command-delivery.ts
+++ b/src/renderer/terminal/command-delivery.ts
@@ -85,9 +85,10 @@ export interface DeliveryIo {
 }
 
 /** Deliver `cmd` + Enter, echo-verified with bounded retries. Returns a cancel function
- *  (call on node teardown). `onSettled` fires exactly once when the delivery is over — submitted
- *  (verified or fail-open) or cancelled — for callers that must know when the LINE has left the
- *  pane, not merely when it was started: the retries run for up to
+ *  (call on node teardown). `onSettled` fires exactly once when the delivery is over and reports
+ *  whether the final Enter write succeeded, the line was too long, or delivery was cancelled.
+ *  Callers can use this to know when the LINE has left the pane, not merely when it was started:
+ *  the retries run for up to
  *  DELIVERY_ATTEMPTS × VERIFY_TIMEOUT_MS, and anything typed into the pane during that window
  *  lands inside the un-submitted line. The outcome argument is optional to read: every caller
  *  that only needs "the line has left the pane" keeps working unchanged. */
@@ -134,12 +135,25 @@ export function deliverCommand(
       return false
     }
   }
-  // Close the delivery BEFORE writing Enter: an io whose write echoes back synchronously (the
-  // in-place restart choreography feeds one) would otherwise re-enter the listener below while
-  // the tail still matches, and submit forever.
+  // Mark closed BEFORE writing Enter: an io whose write echoes back synchronously (the in-place
+  // restart choreography feeds one) would otherwise re-enter the listener below while the tail
+  // still matches, and submit forever. Announce success only AFTER that final write returns: the
+  // old ordering let a rejected Enter auto-dismiss a restart as successful.
   const submit = (): void => {
-    finish('submitted')
-    write('\r')
+    if (done) return
+    done = true
+    if (timer) clearTimeout(timer)
+    unsub?.()
+    let outcome: DeliveryOutcome = 'cancelled'
+    try {
+      io.write('\r')
+      outcome = 'submitted'
+    } catch {
+      // The transport rejected Enter. Report the failed submission below.
+    }
+    // Deliberately outside the transport try/catch: a caller callback that throws must still be
+    // invoked exactly once, and its own exception keeps propagating to that caller.
+    onSettled?.(outcome)
   }
   const tryOnce = (): void => {
     if (done) return
@@ -178,5 +192,5 @@ export function deliverCommand(
     }
   })
   tryOnce()
-  return finish
+  return () => finish()
 }

--- a/src/renderer/terminal/local-transport.ts
+++ b/src/renderer/terminal/local-transport.ts
@@ -61,8 +61,8 @@ export class LocalTransport implements TerminalTransport {
     this.pty.destroy(persistKey, opts)
   }
 
-  recycle(persistKey: string): void {
-    this.pty.recycle(persistKey)
+  recycle(persistKey: string): Promise<void> {
+    return this.pty.recycle(persistKey)
   }
 
   onData(sessionId: string, listener: (data: string) => void): () => void {

--- a/src/renderer/terminal/resume-fallback.test.ts
+++ b/src/renderer/terminal/resume-fallback.test.ts
@@ -79,14 +79,14 @@ const src = readFileSync(join(__dirname, '..', 'nodes', 'TerminalNode.tsx'), 'ut
 
 describe('how the fallback is wired (source pins)', () => {
   it('is armed only when we actually asked to resume something we can recognise', () => {
-    expect(src).toContain('if (cmd && priorId && detectsResumeMiss(agentId)) {')
+    expect(src).toContain('if (cmd && resume.sessionId && detectsResumeMiss(agentId)) {')
   })
 
   it('re-reads the pane and requires a SHELL before it writes anything', () => {
     // The CLI exits after printing, so a shell is what SHOULD own the pane. Anything else means
     // we misread the situation, and `null` ("could not see the pane") is not evidence either.
     expect(src).toMatch(
-      /resumeSessionMissing\(agentId, deadId, seen\)[\s\S]{0,900}?if \(!isShellCommand\(pane\)\) return/
+      /resumeSessionMissing\(agentId, deadId, seen\)[\s\S]{0,900}?if \(!isShellCommand\(pane\)\) \{[\s\S]{0,200}?return/
     )
   })
 
@@ -106,7 +106,7 @@ describe('how the fallback is wired (source pins)', () => {
 
   it('stops on unmount and after the window, and fires at most once', () => {
     expect(src).toMatch(/const timer = setTimeout\(\(\) => stop\(\), RESUME_MISS_WINDOW_MS\)/)
-    expect(src).toMatch(/if \(fired\) return[\s\S]{0,600}?fired = true/)
+    expect(src).toMatch(/if \(fired \|\| life\.dead\) return[\s\S]{0,600}?fired = true/)
     expect(src).toMatch(/cleanups\.push\(stop\)/)
   })
 })

--- a/src/renderer/terminal/transport.ts
+++ b/src/renderer/terminal/transport.ts
@@ -39,7 +39,7 @@ export interface TerminalTransport {
    * the node is not going anywhere. Co-viewers therefore get `onRecycled` (restart, re-attach to
    * the replacement session), never the permanent, un-respawnable closed state.
    */
-  recycle(persistKey: string): void
+  recycle(persistKey: string): Promise<void>
 
   /** Listens for output; returns an unsubscribe function. */
   onData(sessionId: string, listener: (data: string) => void): () => void

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -232,7 +232,11 @@ export async function startServer(
   // exactly the secret store that must never cross that boundary. Browser clients hardcode an
   // empty snapshot and `${env:VAR}` expansion degrades to the missing-env refusal; discovery
   // resolves key REFERENCES only for the saved gateway URL (the exfil-oracle gate in core).
-  registerAgentEnvIpc(() => settingsStore.get().modelGateway, gatewayCredentials)
+  registerAgentEnvIpc(
+    () => settingsStore.get().modelGateway,
+    gatewayCredentials,
+    (scope, models) => ptyManager.setGatewayModels(scope, models)
+  )
   ptyManager.init(
     () => settingsStore.get(),
     () => gatewayCredentials.readForHost()

--- a/src/shared/agents/config.capabilities.test.ts
+++ b/src/shared/agents/config.capabilities.test.ts
@@ -57,7 +57,8 @@ describe('copilot capabilities', () => {
       color: '#8957e5',
       launchCmd: 'copilot',
       promptInjectionMode: 'flag-interactive',
-      expectedProcess: 'copilot'
+      expectedProcess: 'copilot',
+      vanillaEnvPattern: '^COPILOT_PROVIDER_'
     })
     expect(hasHooks('copilot')).toBe(true)
     expect(canResume('copilot')).toBe(true)

--- a/src/shared/agents/config.ts
+++ b/src/shared/agents/config.ts
@@ -32,6 +32,23 @@ export interface AgentConfig {
    */
   argvPromptSeparator?: string
   expectedProcess: string
+  /**
+   * Env var NAME pattern (regex source) to unset so the agent runs against its OWN default
+   * provider instead of a gateway/inherited override. Matched against the var name only, never
+   * the value. Stripped at spawn only when the node opts into "clear env" (a one-shot
+   * context-menu action) or the global `vanillaLaunchDefault` setting is on. Defined per builtin
+   * so the spawn site and the Settings toggle share one source of truth (a duplicated rule
+   * drifts). Resolved through the base harness via `vanillaEnvStripPattern`, so a custom agent
+   * inheriting a builtin (once custom-agent baseAgent lands) gets the same strip set.
+   *
+   * SECURITY: builtin patterns are static/trusted literals, but the value is a regex source applied
+   * to env var names. `vanillaEnvStripPattern` compiles it once behind a try/catch and caches; a
+   * malformed literal throws at compile (caught) and yields null (no strip). It is only ever
+   * `regex.test(envVarName)` in core — never `eval`'d or interpolated into a command. This mirrors
+   * the "re-validate at the interpolation site" rule (`isPermissionMode`, `SAFE_SESSION_ID`): the
+   * type is compile-time, the runtime match is guarded.
+   */
+  vanillaEnvPattern?: string
 }
 
 export const BUILTIN_AGENT_IDS: readonly BuiltinAgentId[] = [
@@ -49,14 +66,24 @@ export const AGENT_CONFIG: Record<BuiltinAgentId, AgentConfig> = {
     color: '#d97757',
     launchCmd: 'claude',
     promptInjectionMode: 'argv',
-    expectedProcess: 'claude'
+    expectedProcess: 'claude',
+    // `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_API_KEY` (gateway + inherited) + the
+    // OAuth token. Deliberately EXCLUDES `CLAUDE_CONFIG_DIR` — that is the managed-account dir, not
+    // a provider credential; stripping it would break account isolation and is unrelated to "run on
+    // subscription". A broad `CLAUDE_*` is unsafe (`CLAUDE_CONFIG_DIR`, and nodeterm's own
+    // `CLAUDE_HOOK_EVENTS` etc. are code constants, not env the pane sets).
+    vanillaEnvPattern: '^(ANTHROPIC_|CLAUDE_CODE_OAUTH_TOKEN$)'
   },
   codex: {
     label: 'Codex',
     color: '#10a37f',
     launchCmd: 'codex',
     promptInjectionMode: 'argv',
-    expectedProcess: 'codex'
+    expectedProcess: 'codex',
+    // The gateway vars only. Codex credentials live under `CODEX_HOME` (a config dir, like claude's)
+    // not `CODEX_*` env, so a broad `CODEX_*` strip is unverified and excluded. Narrowing to the two
+    // known gateway vars avoids touching unrelated `OPENAI_*` the user may set.
+    vanillaEnvPattern: '^(OPENAI_BASE_URL|OPENAI_API_KEY)$'
   },
   gemini: {
     label: 'Gemini',
@@ -95,7 +122,10 @@ export const AGENT_CONFIG: Record<BuiltinAgentId, AgentConfig> = {
     // `--prompt` is explicitly non-interactive and exits after one response. The installed
     // 1.0.80 CLI's `--interactive <prompt>` starts the ordinary TUI and submits the prompt there.
     promptInjectionMode: 'flag-interactive',
-    expectedProcess: 'copilot'
+    expectedProcess: 'copilot',
+    // All `COPILOT_PROVIDER_*` gateway vars. Excludes `COPILOT_HOME` (config dir) and
+    // `COPILOT_HOOK_*` (nodeterm constants).
+    vanillaEnvPattern: '^COPILOT_PROVIDER_'
   }
 }
 
@@ -343,6 +373,31 @@ export function baseAgentOf(id: AgentId): BuiltinAgentId | undefined {
  *  automatic everywhere a predicate is called — no per-call-site plumbing. */
 export function capabilityAgentId(id: AgentId): AgentId {
   return baseAgentOf(id) ?? id
+}
+
+/**
+ * The compiled env-var-NAME strip pattern for an agent, resolved through its base harness (so a
+ * custom agent inheriting a builtin gets the builtin's strip set once custom-agent baseAgent lands).
+ * `null` ⇒ the agent has no strip set (gemini/grok/opencode, or any unknown id) ⇒ the vanilla
+ * relaunch action is hidden and the strip is a no-op. Compiled once and cached; a malformed
+ * `vanillaEnvPattern` literal throws at compile, is caught, and yields `null` (no strip) — see the
+ * security note on `AgentConfig.vanillaEnvPattern`. The cache key is the regex SOURCE string, so two
+ * agents sharing a pattern share one compiled `RegExp`.
+ */
+const VANILLA_PATTERN_CACHE = new Map<string, RegExp | null>()
+export function vanillaEnvStripPattern(id: AgentId): RegExp | null {
+  const source = AGENT_CONFIG[capabilityAgentId(id) as BuiltinAgentId]?.vanillaEnvPattern
+  if (!source) return null
+  const cached = VANILLA_PATTERN_CACHE.get(source)
+  if (cached !== undefined) return cached
+  let compiled: RegExp | null
+  try {
+    compiled = new RegExp(source)
+  } catch {
+    compiled = null
+  }
+  VANILLA_PATTERN_CACHE.set(source, compiled)
+  return compiled
 }
 
 const includes = (list: readonly string[], id: AgentId): boolean =>

--- a/src/shared/agents/launch.test.ts
+++ b/src/shared/agents/launch.test.ts
@@ -432,3 +432,102 @@ describe('promptFilePathError', () => {
     expect(promptFilePathError('/tmp/a\nb')).toMatch(/newlines/)
   })
 })
+
+describe('autocompact [1m] model-id suffix — applied at assembly from discovery', () => {
+  // A claude-base model whose discovered context window is above the threshold gets a `[1m]`
+  // suffix on its --model id; non-claude agents and below-threshold models do not. The env half
+  // is injected spawn-side (pty-manager); this covers the id half that reaches the typed command.
+  const largeModels = [
+    { id: 'anthropic/claude-opus-5', contextWindow: 1_000_000 },
+    { id: 'anthropic/claude-sonnet-5', contextWindow: 200_000 }
+  ]
+
+  it('appends [1m] to a large-context claude model on a fresh launch', () => {
+    expect(
+      assembleLaunchCommand(
+        { agentId: 'claude', model: 'anthropic/claude-opus-5', models: largeModels },
+        ENV
+      ).command
+    ).toBe("claude --model 'anthropic/claude-opus-5[1m]'")
+  })
+
+  it('appends [1m] on a cold-restore resume too (same id as launch)', () => {
+    expect(
+      assembleResumeCommand(
+        { agentId: 'claude', sessionId: 'abc-123', model: 'anthropic/claude-opus-5', models: largeModels },
+        ENV
+      ).command
+    ).toBe("claude --resume abc-123 --model 'anthropic/claude-opus-5[1m]'")
+  })
+
+  it('does NOT append [1m] for a model at the threshold (200k is not above it)', () => {
+    expect(
+      assembleLaunchCommand(
+        { agentId: 'claude', model: 'anthropic/claude-sonnet-5', models: largeModels },
+        ENV
+      ).command
+    ).toBe("claude --model 'anthropic/claude-sonnet-5'")
+  })
+
+  it('does NOT append [1m] for a non-claude agent, even with a large-context model', () => {
+    // codex does not take a --model suffix convention; its model stays the discovered id.
+    expect(
+      assembleResumeCommand(
+        { agentId: 'codex', sessionId: 't-1', model: 'openai/gpt-5.5-codex', models: largeModels },
+        ENV
+      ).command
+    ).toBe("codex resume t-1 --model 'openai/gpt-5.5-codex'")
+  })
+
+  it('leaves an already-suffixed id alone (no double [1m])', () => {
+    const withSuffix = [{ id: 'vllm/GLM-5.2-NVFP4-MTP[1m]', contextWindow: 1_000_000 }]
+    expect(
+      assembleLaunchCommand(
+        { agentId: 'claude', model: 'vllm/GLM-5.2-NVFP4-MTP[1m]', models: withSuffix },
+        ENV
+      ).command
+    ).toBe("claude --model 'vllm/GLM-5.2-NVFP4-MTP[1m]'")
+  })
+
+  it('fails open with no discovery list — the id is used unchanged', () => {
+    expect(
+      assembleLaunchCommand({ agentId: 'claude', model: 'anthropic/claude-opus-5' }, ENV).command
+    ).toBe("claude --model 'anthropic/claude-opus-5'")
+  })
+})
+
+describe('cold-restore resume vs fresh re-claim — the hook-confirmed discriminator', () => {
+  // A node MINTS a session id at creation and launches claude with `--session-id <minted>`. If the
+  // user switches model/subscription (or restarts) BEFORE any turn, no transcript was written, so
+  // `claude --resume <minted>` errors. The fix lives in TerminalNode's cold-restore gate: resume
+  // ONLY off a hook-confirmed id (`st.sessionId`); when only the minted id is known, re-launch
+  // FRESH with `--session-id <minted>` (re-claiming the same id) instead of `--resume`. These two
+  // assertions pin the assembler outputs the component chooses between — the contract the gate
+  // depends on — so a refactor that collapses them is caught.
+  it('a hook-confirmed id resumes: assembleResumeCommand emits --resume', () => {
+    expect(
+      assembleResumeCommand(
+        { agentId: 'claude', sessionId: 'abc-123', models: [] },
+        ENV
+      ).command
+    ).toBe('claude --resume abc-123')
+  })
+
+  it('a minted-only id re-claims: assembleLaunchCommand emits --session-id, NOT --resume', () => {
+    expect(
+      assembleLaunchCommand(
+        { agentId: 'claude', sessionId: 'abc-123', sessionIdFlagSupported: true, models: [] },
+        ENV
+      ).command
+    ).toBe('claude --session-id abc-123')
+  })
+
+  it('a minted-only id on an older CLI (no --session-id flag) launches bare — claude mints its own', () => {
+    expect(
+      assembleLaunchCommand(
+        { agentId: 'claude', sessionId: 'abc-123', sessionIdFlagSupported: false, models: [] },
+        ENV
+      ).command
+    ).toBe('claude')
+  })
+})

--- a/src/shared/agents/launch.ts
+++ b/src/shared/agents/launch.ts
@@ -27,7 +27,7 @@ import {
 } from './config'
 import { withPermissionMode } from './approval-mode'
 import { resolveAgentConfig } from './custom-agent'
-import { withAgentModel } from './model-gateway'
+import { withAgentModel, claudeAutocompactFor, type GatewayModel } from './model-gateway'
 
 export interface LaunchInputs {
   agentId: AgentId
@@ -65,6 +65,11 @@ export interface LaunchInputs {
    *  CLI? The caller's answer to "will the launcher actually be there?" — false (the default) emits
    *  the bare command byte-for-byte. A remote node must pass false (the host has no launcher). */
   sharedIdentity?: boolean
+  /** The discovered gateway models, so a claude-base agent whose model reports a context window
+   *  above the threshold launches with the `[1m]` suffix on its `--model` id (the id half of the
+   *  autocompact story; the env half is injected spawn-side). Absent ⇒ the id is used unchanged
+   *  (fail open). */
+  models?: readonly GatewayModel[]
 }
 
 export interface ResumeInputs {
@@ -81,6 +86,9 @@ export interface ResumeInputs {
   /** Should a SHARED_IDENTITY_CAPABLE agent (codex) name its managed launcher on resume? Same
    *  semantics as `LaunchInputs.sharedIdentity`. */
   sharedIdentity?: boolean
+  /** The discovered gateway models, so a cold-restore resume uses the same `[1m]` `--model` id the
+   *  fresh launch used. Absent ⇒ the id is used unchanged (fail open). */
+  models?: readonly GatewayModel[]
 }
 
 export interface AssembledCommand {
@@ -166,6 +174,11 @@ export function assembleLaunchCommand(
 ): AssembledCommand {
   const eff = resolveAgentConfig(inputs.agentId, inputs.customAgent)
   const capId = capabilityAgentId(inputs.agentId)
+  // The `[1m]` suffix for a claude-base model whose discovered context window is above the
+  // threshold — applied here so fresh launch, cold-restore resume and the Settings preview all
+  // agree on the id. Non-claude / unknown / below-threshold ⇒ the id unchanged (fail open). The
+  // matching autocompact env is injected spawn-side (pty-manager).
+  const modelId = claudeAutocompactFor(capId, inputs.model, inputs.models ?? []).modelId
 
   // A per-builtin launch-command override replaces the resolved program (a wrapper the user runs
   // the CLI through). It is expanded + quoted like any launchCmd, and — like a custom agent's own
@@ -223,9 +236,9 @@ export function assembleLaunchCommand(
     // Session-id minting: claude-base + CLI supports the flag. On resume this branch is never
     // taken (assembleResumeCommand does not pass sessionId).
     if (inputs.sessionId && mintsSessionId(capId) && inputs.sessionIdFlagSupported) {
-      return withAgentModel(withSessionId(withMode, capId, inputs.sessionId), capId, inputs.model)
+      return withAgentModel(withSessionId(withMode, capId, inputs.sessionId), capId, modelId)
     }
-    return withAgentModel(withMode, capId, inputs.model)
+    return withAgentModel(withMode, capId, modelId)
   }
 
   const command = usesSep ? `${flagged(baseCmd)} ${sep} ${promptArg}` : flagged(withPrompt)
@@ -245,6 +258,9 @@ export function assembleResumeCommand(
 ): AssembledCommand {
   const eff = resolveAgentConfig(inputs.agentId, inputs.customAgent)
   const capId = capabilityAgentId(inputs.agentId)
+  // Same `[1m]` suffix resolution as the fresh-launch path, so a cold-restore resume uses the id
+  // the session launched with.
+  const modelId = claudeAutocompactFor(capId, inputs.model, inputs.models ?? []).modelId
 
   // A per-builtin launch-command override wins over the program and the launcher (same rule as the
   // fresh-launch path), so a cold-restore / restart resumes through the same wrapper.
@@ -263,6 +279,6 @@ export function assembleResumeCommand(
   const withMode = inputs.permissionMode
     ? withPermissionMode(base, capId, inputs.permissionMode)
     : base
-  const command = withAgentModel(withMode, capId, inputs.model)
+  const command = withAgentModel(withMode, capId, modelId)
   return { command, missingEnv: [...m1, ...m2] }
 }

--- a/src/shared/agents/model-availability.test.ts
+++ b/src/shared/agents/model-availability.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  modelAvailability,
+  modelLaunchShapeMismatch,
+  modelRecoveryCure,
+  modelRecoverySessionKey,
+  modelRecoveryTrigger,
+  modelWindowChange,
+  modelWindowSessionKey
+} from './model-availability'
+import type { GatewayModel } from './model-gateway'
+
+const CATALOGUE: GatewayModel[] = [
+  { id: 'vllm/large', contextWindow: 400_000 },
+  { id: 'openai/small', contextWindow: 128_000 },
+  { id: 'anthropic/no-window' }
+]
+
+describe('modelAvailability', () => {
+  it('flags an absent id and accepts either [1m] spelling', () => {
+    expect(modelAvailability('gone/model', CATALOGUE).unavailable).toBe(true)
+    expect(modelAvailability('vllm/large', CATALOGUE).unavailable).toBe(false)
+    expect(modelAvailability('vllm/large[1m]', CATALOGUE).unavailable).toBe(false)
+  })
+
+  it('does not judge an absent record or empty catalogue', () => {
+    expect(modelAvailability(undefined, CATALOGUE).unavailable).toBe(false)
+    expect(modelAvailability('gone/model', []).unavailable).toBe(false)
+  })
+})
+
+describe('modelLaunchShapeMismatch', () => {
+  it('compares the exact launch record with today’s assembler output', () => {
+    expect(modelLaunchShapeMismatch('claude', 'vllm/large', CATALOGUE)).toBe(true)
+    expect(modelLaunchShapeMismatch('claude', 'vllm/large[1m]', CATALOGUE)).toBe(false)
+    expect(modelLaunchShapeMismatch('codex', 'vllm/large', CATALOGUE)).toBe(false)
+  })
+})
+
+describe('legacy model-window observations', () => {
+  it('seeds once, then detects a change per session', () => {
+    expect(modelWindowChange('vllm/large', CATALOGUE, undefined)).toEqual({
+      changed: false,
+      contextWindow: 400_000,
+      fresh: true
+    })
+    expect(modelWindowChange('vllm/large[1m]', CATALOGUE, 200_000).changed).toBe(true)
+    expect(modelWindowSessionKey('node-a', 'vllm/large[1m]')).toBe('node-a:vllm/large')
+    expect(modelWindowSessionKey('node-b', 'vllm/large')).not.toBe(
+      modelWindowSessionKey('node-a', 'vllm/large')
+    )
+  })
+})
+
+describe('modelRecoveryTrigger', () => {
+  it('detects removed, changed-window, and stale-shape launch records', () => {
+    expect(modelRecoveryTrigger('claude', 'gone/model', 200_000, CATALOGUE)).toBe('gone')
+    expect(modelRecoveryTrigger('claude', 'vllm/large[1m]', 200_000, CATALOGUE)).toBe('win')
+    expect(modelRecoveryTrigger('claude', 'vllm/large', 400_000, CATALOGUE)).toBe('shape')
+  })
+
+  it('fails closed for legacy records and missing reported windows', () => {
+    expect(modelRecoveryTrigger('claude', undefined, 200_000, CATALOGUE)).toBeNull()
+    expect(modelRecoveryTrigger('claude', 'vllm/large[1m]', undefined, CATALOGUE)).toBeNull()
+    expect(modelRecoveryTrigger('claude', 'anthropic/no-window', 200_000, CATALOGUE)).toBeNull()
+  })
+})
+
+describe('modelRecoveryCure', () => {
+  it('requires the actual restarted record to cure each trigger', () => {
+    expect(modelRecoveryCure('gone', 'claude', 'openai/small', 128_000, CATALOGUE).cured).toBe(true)
+    expect(modelRecoveryCure('win', 'claude', 'vllm/large[1m]', 400_000, CATALOGUE).cured).toBe(true)
+    expect(modelRecoveryCure('shape', 'claude', 'vllm/large[1m]', 400_000, CATALOGUE).cured).toBe(true)
+  })
+
+  it('fails closed for missing or stale actual records', () => {
+    expect(modelRecoveryCure('gone', 'claude', undefined, undefined, CATALOGUE).cured).toBe(false)
+    expect(modelRecoveryCure('gone', 'claude', 'gone/model', 200_000, CATALOGUE).cured).toBe(false)
+    expect(modelRecoveryCure('win', 'claude', 'vllm/large[1m]', 200_000, CATALOGUE).cured).toBe(false)
+    expect(modelRecoveryCure('shape', 'claude', 'vllm/large', 400_000, CATALOGUE).cured).toBe(false)
+    expect(modelRecoveryCure('gone', 'claude', 'openai/small', 128_000, []).cured).toBe(false)
+  })
+})
+
+describe('modelRecoverySessionKey', () => {
+  it('keeps nodes, reasons, and trigger versions independent', () => {
+    const key = modelRecoverySessionKey('node-a', 'vllm/large', 'win', 400_000)
+    expect(key).not.toBe(modelRecoverySessionKey('node-b', 'vllm/large', 'win', 400_000))
+    expect(key).not.toBe(modelRecoverySessionKey('node-a', 'vllm/large', 'shape', 'large[1m]'))
+    expect(key).not.toBe(modelRecoverySessionKey('node-a', 'vllm/large', 'win', 500_000))
+  })
+})

--- a/src/shared/agents/model-availability.ts
+++ b/src/shared/agents/model-availability.ts
@@ -1,0 +1,159 @@
+import type { AgentId } from './config'
+import {
+  claudeAutocompactFor,
+  modelContextWindow,
+  type GatewayModel
+} from './model-gateway'
+
+export type ModelRecoveryReason = 'gone' | 'win' | 'shape'
+
+export interface ModelAvailability {
+  unavailable: boolean
+  modelId: string
+}
+
+/** Presence check tolerant of the launch-only `[1m]` suffix. Empty discovery cannot judge. */
+export function modelAvailability(
+  nodeModel: string | undefined,
+  models: readonly GatewayModel[]
+): ModelAvailability {
+  const modelId = nodeModel?.trim() ?? ''
+  if (!modelId || models.length === 0) return { unavailable: false, modelId }
+  const base = modelId.replace(/\[1m\]$/, '')
+  const listed = models.some((model) => model.id.replace(/\[1m\]$/, '') === base)
+  return { unavailable: !listed, modelId }
+}
+
+export interface ModelWindowChange {
+  changed: boolean
+  contextWindow: number | ''
+  fresh: boolean
+}
+
+/** Compare a reported window with a persisted launch value or a legacy observation ledger. */
+export function modelWindowChange(
+  nodeModel: string | undefined,
+  models: readonly GatewayModel[],
+  lastSeen: number | undefined
+): ModelWindowChange {
+  const modelId = nodeModel?.trim() ?? ''
+  if (!modelId) return { changed: false, contextWindow: '', fresh: false }
+  const current = modelContextWindow(modelId, models)
+  if (current === undefined) return { changed: false, contextWindow: '', fresh: false }
+  if (lastSeen === undefined) return { changed: false, contextWindow: current, fresh: true }
+  return {
+    changed: Number.isFinite(lastSeen) && current !== lastSeen,
+    contextWindow: current,
+    fresh: false
+  }
+}
+
+export function modelWindowKey(nodeModel: string): string {
+  return nodeModel.trim().replace(/\[1m\]$/, '')
+}
+
+export function modelWindowSessionKey(nodeId: string, nodeModel: string): string {
+  return `${nodeId}:${modelWindowKey(nodeModel)}`
+}
+
+/** Whether today's assembler would emit a different exact id for this launch record. */
+export function modelLaunchShapeMismatch(
+  agentId: AgentId,
+  launchModel: string | undefined,
+  models: readonly GatewayModel[]
+): boolean {
+  const modelId = launchModel?.trim()
+  if (!modelId || models.length === 0 || modelAvailability(modelId, models).unavailable) {
+    return false
+  }
+  const today = claudeAutocompactFor(agentId, modelId, models).modelId
+  return today != null && today !== modelId
+}
+
+/**
+ * Decide whether one actual launch record needs recovery. Every trigger fails closed when the
+ * record it needs is absent: requested-only legacy nodes cannot prove what their process runs.
+ */
+export function modelRecoveryTrigger(
+  agentId: AgentId,
+  launchModel: string | undefined,
+  launchContextWindow: number | undefined,
+  models: readonly GatewayModel[]
+): ModelRecoveryReason | null {
+  const modelId = launchModel?.trim()
+  if (!modelId || models.length === 0) return null
+  if (modelAvailability(modelId, models).unavailable) return 'gone'
+
+  const currentWindow = modelContextWindow(modelId, models)
+  if (
+    typeof launchContextWindow === 'number' &&
+    Number.isFinite(launchContextWindow) &&
+    launchContextWindow > 0 &&
+    currentWindow !== undefined &&
+    currentWindow !== launchContextWindow
+  ) {
+    return 'win'
+  }
+  return modelLaunchShapeMismatch(agentId, modelId, models) ? 'shape' : null
+}
+
+export interface ModelRecoveryCure {
+  cured: boolean
+  detail?: string
+}
+
+/** Verify a completed restart from the actual record written by the accepted launch path. */
+export function modelRecoveryCure(
+  reason: ModelRecoveryReason,
+  agentId: AgentId,
+  launchModel: string | undefined,
+  launchContextWindow: number | undefined,
+  models: readonly GatewayModel[]
+): ModelRecoveryCure {
+  if (models.length === 0) {
+    return { cured: false, detail: 'the current gateway catalogue is unavailable' }
+  }
+  const modelId = launchModel?.trim()
+  if (!modelId) return { cured: false, detail: 'the restarted session reported no launch model' }
+
+  if (modelAvailability(modelId, models).unavailable) {
+    return { cured: false, detail: `the restarted model ${modelId} is not in the current catalogue` }
+  }
+  if (reason === 'gone') return { cured: true }
+
+  if (reason === 'win') {
+    const currentWindow = modelContextWindow(modelId, models)
+    if (currentWindow === undefined) {
+      return { cured: false, detail: `the gateway reported no context window for ${modelId}` }
+    }
+    if (
+      typeof launchContextWindow !== 'number' ||
+      !Number.isFinite(launchContextWindow) ||
+      launchContextWindow <= 0
+    ) {
+      return { cured: false, detail: 'the restarted session reported no launch context window' }
+    }
+    return launchContextWindow === currentWindow
+      ? { cured: true }
+      : {
+          cured: false,
+          detail: `the restarted session still records ${launchContextWindow} tokens; the catalogue reports ${currentWindow}`
+        }
+  }
+
+  return modelLaunchShapeMismatch(agentId, modelId, models)
+    ? { cured: false, detail: `the restarted session still records the stale launch id ${modelId}` }
+    : { cured: true }
+}
+
+/** Per-session, per-record key so one node never spends a sibling's prompt. */
+export function modelRecoverySessionKey(
+  nodeId: string,
+  modelId: string,
+  reason: ModelRecoveryReason,
+  version: string | number
+): string {
+  return `model-recovery:${nodeId}:${modelId.trim()}:${reason}:${version}`
+}
+
+export { modelContextWindow } from './model-gateway'

--- a/src/shared/agents/model-gateway.test.ts
+++ b/src/shared/agents/model-gateway.test.ts
@@ -5,6 +5,7 @@ import {
   modelGatewayEnv,
   modelGatewayCredentialKind,
   modelGatewayRoutes,
+  modelContextWindow,
   modelsForAgent,
   parseGatewayModels,
   parseModelGatewayEnvReference,
@@ -443,5 +444,20 @@ describe('Claude gateway subagent routing', () => {
     expect(claudeSubagentEnvFor('codex', models)).toEqual({})
     expect(claudeSubagentModelFor([], 'vllm/zeta')).toBeUndefined()
     expect(tmuxUpdateEnvironmentLine()).toContain('CLAUDE_CODE_SUBAGENT_MODEL')
+  })
+})
+
+describe('modelContextWindow', () => {
+  const models = [{ id: 'vllm/GLM-5.3', contextWindow: 400_000 }]
+
+  it('matches either plain or [1m]-suffixed spelling', () => {
+    expect(modelContextWindow('vllm/GLM-5.3', models)).toBe(400_000)
+    expect(modelContextWindow('vllm/GLM-5.3[1m]', models)).toBe(400_000)
+  })
+
+  it('returns undefined for an absent model or invalid window', () => {
+    expect(modelContextWindow(undefined, models)).toBeUndefined()
+    expect(modelContextWindow('other', models)).toBeUndefined()
+    expect(modelContextWindow('bad', [{ id: 'bad', contextWindow: Number.NaN }])).toBeUndefined()
   })
 })

--- a/src/shared/agents/model-gateway.test.ts
+++ b/src/shared/agents/model-gateway.test.ts
@@ -33,6 +33,38 @@ describe('modelGatewayRoutes', () => {
     expect(modelGatewayRoutes('https://example.test/#fragment')).toBeNull()
     expect(modelGatewayRoutes('not a URL')).toBeNull()
   })
+
+  it('appends a supplied discovery path instead of the conventional /v1/models', () => {
+    expect(modelGatewayRoutes('https://bifrost.example.test', '/openai/v1/models')).toEqual({
+      discovery: 'https://bifrost.example.test/openai/v1/models',
+      openai: 'https://bifrost.example.test/openai/v1',
+      anthropic: 'https://bifrost.example.test/anthropic'
+    })
+  })
+
+  it('falls back to /v1/models when the discovery path is absent, empty, or unsafe', () => {
+    // Absent/empty = the conventional suffix. Unsafe values (full URLs — a caller-chosen host
+    // would be a credential-exfiltration oracle — query, fragment, traversal) degrade to the
+    // derived default, never to a fetch somewhere unvetted.
+    expect(modelGatewayRoutes('https://bifrost.example.test', undefined)?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+    expect(modelGatewayRoutes('https://bifrost.example.test', '')?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+    expect(modelGatewayRoutes('https://bifrost.example.test', 'https://evil.test/x')?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+    expect(modelGatewayRoutes('https://bifrost.example.test', '/../etc')?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+    expect(modelGatewayRoutes('https://bifrost.example.test', '/x?y=1')?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+    expect(modelGatewayRoutes('https://bifrost.example.test', '/x#f')?.discovery).toBe(
+      'https://bifrost.example.test/v1/models'
+    )
+  })
 })
 
 describe('parseGatewayModels', () => {

--- a/src/shared/agents/model-gateway.test.ts
+++ b/src/shared/agents/model-gateway.test.ts
@@ -11,6 +11,8 @@ import {
   resolveModelGatewayApiKey,
   withAgentModel,
   claudeAutocompactFor,
+  claudeSubagentEnvFor,
+  claudeSubagentModelFor,
   AUTOCOMPACT_THRESHOLD,
   AUTOCOMPACT_PCT_OVERRIDE,
   tmuxUpdateEnvironmentLine
@@ -416,5 +418,30 @@ describe('autocompact env keys lockstep', () => {
     for (const k of Object.keys(claudeAutocompactFor('claude', 'anthropic/claude-opus-5', models).env)) {
       expect(line).toContain(k)
     }
+  })
+})
+
+describe('Claude gateway subagent routing', () => {
+  const models = [
+    { id: 'vllm/zeta', contextWindow: 200_000 },
+    { id: 'anthropic/alpha' }
+  ]
+
+  it('prefers the configured default when the gateway lists it', () => {
+    expect(claudeSubagentModelFor(models, 'vllm/zeta')).toBe('vllm/zeta')
+  })
+
+  it('falls back deterministically when the default is absent or unlisted', () => {
+    expect(claudeSubagentModelFor(models, 'missing')).toBe('anthropic/alpha')
+    expect(claudeSubagentModelFor([...models].reverse())).toBe('anthropic/alpha')
+  })
+
+  it('routes independently of context metadata and only for a Claude-base agent', () => {
+    expect(claudeSubagentEnvFor('claude', models)).toEqual({
+      CLAUDE_CODE_SUBAGENT_MODEL: 'anthropic/alpha'
+    })
+    expect(claudeSubagentEnvFor('codex', models)).toEqual({})
+    expect(claudeSubagentModelFor([], 'vllm/zeta')).toBeUndefined()
+    expect(tmuxUpdateEnvironmentLine()).toContain('CLAUDE_CODE_SUBAGENT_MODEL')
   })
 })

--- a/src/shared/agents/model-gateway.test.ts
+++ b/src/shared/agents/model-gateway.test.ts
@@ -9,7 +9,11 @@ import {
   parseGatewayModels,
   parseModelGatewayEnvReference,
   resolveModelGatewayApiKey,
-  withAgentModel
+  withAgentModel,
+  claudeAutocompactFor,
+  AUTOCOMPACT_THRESHOLD,
+  AUTOCOMPACT_PCT_OVERRIDE,
+  tmuxUpdateEnvironmentLine
 } from './model-gateway'
 import {
   setCustomAgentBaseResolver,
@@ -272,5 +276,145 @@ describe('MODEL_GATEWAY_ENV_KEYS lockstep', () => {
     }
     expect(seen.size).toBeGreaterThan(0)
     for (const k of seen) expect(MODEL_GATEWAY_ENV_KEYS).toContain(k)
+  })
+})
+
+describe('claudeAutocompactFor', () => {
+  // A model above the threshold, one at exactly the threshold, and one below — sourced from
+  // discovery the way the spawn site resolves them.
+  const models = parseGatewayModels({
+    data: [
+      { id: 'anthropic/claude-opus-5', context_length: 1_000_000 },
+      { id: 'anthropic/claude-sonnet-5', context_length: 200_000 },
+      { id: 'anthropic/claude-haiku-5', context_length: 100_000 }
+    ]
+  })
+
+  it('appends [1m] + sets the autocompact env for a claude model whose window is above the threshold', () => {
+    const r = claudeAutocompactFor('claude', 'anthropic/claude-opus-5', models)
+    expect(r.modelId).toBe('anthropic/claude-opus-5[1m]')
+    expect(r.env).toEqual({
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: '1000000',
+      CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: AUTOCOMPACT_PCT_OVERRIDE
+    })
+  })
+
+  it('a window BETWEEN the threshold and 1M gets the env AND the suffix', () => {
+    // The env var does NOT drive the CLI's own meter (measured: Misc Bugs, 5.3 plain, env
+    // 400000, status line still 200k) — the [1m] suffix is the only lever Claude Code honors
+    // for the meter, so every above-threshold window carries it, mid-band included.
+    const mid = parseGatewayModels({
+      data: [{ id: 'vllm/GLM-5.3-Flash-NVFP4', context_length: 400_000 }]
+    })
+    const r = claudeAutocompactFor('claude', 'vllm/GLM-5.3-Flash-NVFP4', mid)
+    expect(r.modelId).toBe('vllm/GLM-5.3-Flash-NVFP4[1m]')
+    expect(r.env).toEqual({
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: '400000',
+      CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: AUTOCOMPACT_PCT_OVERRIDE
+    })
+  })
+
+  it('a suffixed mid-band record stays suffixed — the suffix is not re-stripped on re-launch', () => {
+    const mid = parseGatewayModels({
+      data: [{ id: 'vllm/GLM-5.2-NVFP4-MTP', context_length: 400_000 }]
+    })
+    const r = claudeAutocompactFor('claude', 'vllm/GLM-5.2-NVFP4-MTP[1m]', mid)
+    expect(r.modelId).toBe('vllm/GLM-5.2-NVFP4-MTP[1m]')
+    expect(r.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('400000')
+  })
+
+  it('does not double-append [1m] when the id already carries it', () => {
+    const withSuffix = parseGatewayModels({
+      data: [{ id: 'vllm/GLM-5.2-NVFP4-MTP[1m]', context_length: 1_000_000 }]
+    })
+    const r = claudeAutocompactFor('claude', 'vllm/GLM-5.2-NVFP4-MTP[1m]', withSuffix)
+    expect(r.modelId).toBe('vllm/GLM-5.2-NVFP4-MTP[1m]')
+    expect(r.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe('1000000')
+  })
+
+  it('sets neither env nor suffix at or below the threshold — never guesses a large window', () => {
+    // Exactly the threshold: not above it, so no autocompact.
+    expect(claudeAutocompactFor('claude', 'anthropic/claude-sonnet-5', models).env).toEqual({})
+    expect(claudeAutocompactFor('claude', 'anthropic/claude-sonnet-5', models).modelId).toBe(
+      'anthropic/claude-sonnet-5'
+    )
+    // Below the threshold.
+    expect(claudeAutocompactFor('claude', 'anthropic/claude-haiku-5', models).env).toEqual({})
+    expect(claudeAutocompactFor('claude', 'anthropic/claude-haiku-5', models).modelId).toBe(
+      'anthropic/claude-haiku-5'
+    )
+  })
+
+  it('strips a stale [1m] suffix when the discovered window is no longer large', () => {
+    expect(
+      claudeAutocompactFor('claude', 'anthropic/claude-sonnet-5[1m]', models)
+    ).toEqual({ modelId: 'anthropic/claude-sonnet-5', env: {} })
+  })
+
+  it('fails open for an unknown model or one with no reported window — no guess, no suffix', () => {
+    expect(claudeAutocompactFor('claude', 'anthropic/claude-future', models).env).toEqual({})
+    expect(claudeAutocompactFor('claude', 'anthropic/claude-future', models).modelId).toBe(
+      'anthropic/claude-future'
+    )
+    // A discovered model that reported no context_length.
+    const noWindow = parseGatewayModels({ data: [{ id: 'anthropic/claude-x' }] })
+    expect(claudeAutocompactFor('claude', 'anthropic/claude-x', noWindow).env).toEqual({})
+  })
+
+  it('PAIRING INVARIANT: every suffixed branch emits the env with it; the env never rides alone', () => {
+    // The two halves of the autocompact mechanism are ONE mechanism: the [1m] suffix lifts the
+    // CLI's own window ceiling; CLAUDE_CODE_AUTO_COMPACT_WINDOW pulls the compaction point back
+    // to the discovered size. A suffix without the env grows the context past the headroom the
+    // gateway can serve (the Misc Bugs report); an env without the suffix meters 200k while
+    // compaction fires at the bigger window. One call emits both — this pins that no branch can
+    // emit one without the other.
+    const above = parseGatewayModels({
+      data: [
+        { id: 'a', context_length: 400_000 },
+        { id: 'b', context_length: 1_000_000 }
+      ]
+    })
+    for (const m of above) {
+      const r = claudeAutocompactFor('claude', m.id, above)
+      expect(r.modelId?.endsWith('[1m]')).toBe(true)
+      expect(r.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBeTruthy()
+    }
+    // Inverse: the env implies the suffix — every branch emitting env is a suffixed branch.
+    for (const m of above) {
+      const r = claudeAutocompactFor('claude', m.id, above)
+      expect(!!r.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW && r.modelId?.endsWith('[1m]')).toBe(true)
+    }
+    // At and below the threshold: NEITHER half — never one alone.
+    const at = parseGatewayModels({ data: [{ id: 'c', context_length: 200_000 }] })
+    expect(claudeAutocompactFor('claude', 'c', at)).toEqual({ modelId: 'c', env: {} })
+  })
+
+  it('is a no-op for a non-claude agent — the env vars and [1m] convention are Claude Code own', () => {
+    for (const id of ['codex', 'copilot', 'gemini', 'grok', 'opencode'] as const) {
+      const r = claudeAutocompactFor(id, 'anthropic/claude-opus-5', models)
+      expect(r.env).toEqual({})
+      expect(r.modelId).toBe('anthropic/claude-opus-5')
+    }
+  })
+
+  it('returns the unchanged id (no --model) when there is no model at all', () => {
+    expect(claudeAutocompactFor('claude', undefined, models)).toEqual({ modelId: undefined, env: {} })
+  })
+
+  it('threshold is above the 200k default so an ordinary 200k model does NOT trigger it', () => {
+    expect(AUTOCOMPACT_THRESHOLD).toBe(200_000)
+  })
+})
+
+describe('autocompact env keys lockstep', () => {
+  it('the autocompact keys are in the tmux update-environment line so a re-attached client inherits them', () => {
+    const line = tmuxUpdateEnvironmentLine()
+    expect(line).toContain('CLAUDE_CODE_AUTO_COMPACT_WINDOW')
+    expect(line).toContain('CLAUDE_AUTOCOMPACT_PCT_OVERRIDE')
+    // And a large-context claude model actually emits those keys through the helper.
+    const models = parseGatewayModels({ data: [{ id: 'anthropic/claude-opus-5', context_length: 1_000_000 }] })
+    for (const k of Object.keys(claudeAutocompactFor('claude', 'anthropic/claude-opus-5', models).env)) {
+      expect(line).toContain(k)
+    }
   })
 })

--- a/src/shared/agents/model-gateway.ts
+++ b/src/shared/agents/model-gateway.ts
@@ -268,6 +268,11 @@ export const AUTOCOMPACT_ENV_KEYS = [
   'CLAUDE_AUTOCOMPACT_PCT_OVERRIDE'
 ] as const
 
+/** Claude Code routes its own subagents through this model. Keeping the key separate from the
+ *  autocompact keys makes routing independent of context-window metadata. */
+export const CLAUDE_CODE_SUBAGENT_MODEL_KEY = 'CLAUDE_CODE_SUBAGENT_MODEL'
+export const CLAUDE_SUBAGENT_ENV_KEYS = [CLAUDE_CODE_SUBAGENT_MODEL_KEY] as const
+
 /** tmux's own stock `update-environment` entries (tmux 3.4 defaults, measured via
  *  `show-options -g`). Assigning the option as a whole REPLACES the array, so the defaults must be
  *  restated or SSH agent forwarding et al. silently break. */
@@ -300,6 +305,7 @@ export function tmuxUpdateEnvironmentLine(extraNames: readonly string[] = []): s
       ...TMUX_STOCK_UPDATE_ENV,
       ...MODEL_GATEWAY_ENV_KEYS,
       ...AUTOCOMPACT_ENV_KEYS,
+      ...CLAUDE_SUBAGENT_ENV_KEYS,
       ...extraNames
     ])
   ]
@@ -467,4 +473,27 @@ export function claudeAutocompactFor(
       CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: AUTOCOMPACT_PCT_OVERRIDE
     }
   }
+}
+
+/** Choose only a model the current gateway catalogue says it serves. A configured default wins
+ *  when present; otherwise sort here so callers need not know how the catalogue was produced. */
+export function claudeSubagentModelFor(
+  models: readonly GatewayModel[],
+  defaultModel?: string
+): string | undefined {
+  const ids = [...new Set(modelsForAgent(models, 'claude').map((model) => model.id.trim()).filter(Boolean))]
+    .sort((left, right) => left.localeCompare(right))
+  const preferred = defaultModel?.trim()
+  return preferred && ids.includes(preferred) ? preferred : ids[0]
+}
+
+/** Build Claude's gateway subagent routing independently from large-context launch handling. */
+export function claudeSubagentEnvFor(
+  agentId: AgentId,
+  models: readonly GatewayModel[],
+  defaultModel?: string
+): Record<string, string> {
+  if (capabilityAgentId(agentId) !== 'claude') return {}
+  const model = claudeSubagentModelFor(models, defaultModel)
+  return model ? { [CLAUDE_CODE_SUBAGENT_MODEL_KEY]: model } : {}
 }

--- a/src/shared/agents/model-gateway.ts
+++ b/src/shared/agents/model-gateway.ts
@@ -497,3 +497,15 @@ export function claudeSubagentEnvFor(
   const model = claudeSubagentModelFor(models, defaultModel)
   return model ? { [CLAUDE_CODE_SUBAGENT_MODEL_KEY]: model } : {}
 }
+
+/** Current reported window for either plain or `[1m]` spelling of one model id. */
+export function modelContextWindow(
+  modelId: string | undefined,
+  models: readonly GatewayModel[]
+): number | undefined {
+  const id = modelId?.trim()
+  if (!id) return undefined
+  const base = id.replace(/\[1m\]$/, '')
+  const value = models.find((model) => model.id.replace(/\[1m\]$/, '') === base)?.contextWindow
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
+}

--- a/src/shared/agents/model-gateway.ts
+++ b/src/shared/agents/model-gateway.ts
@@ -70,6 +70,14 @@ export interface GatewayModel {
   id: string
   name?: string
   provider?: string
+  /** Maximum prompt context window in tokens, when the gateway reports one. The autocompact helper sizes
+   *  `CLAUDE_CODE_AUTO_COMPACT_WINDOW` off it for a claude-base agent. Absent ⇒ the env var is
+   *  omitted and the CLI falls back to its own default — never guessed (a percentage over a guessed
+   *  window is a wrong number presented as a fact). */
+  contextWindow?: number
+  /** Maximum output/completion tokens the model may produce, when reported. Retained as catalogue
+   *  metadata for consumers; absent stays absent, never guessed. */
+  maxOutputTokens?: number
 }
 
 export interface ModelDiscoveryResult {
@@ -154,6 +162,13 @@ export function modelGatewayRoutes(
   }
 }
 
+/** Accept only positive integer token limits; invalid or absent metadata stays unknown. */
+function coerceTokenLimit(value: unknown): number | undefined {
+  const n = typeof value === 'string' ? Number(value.trim()) : typeof value === 'number' ? value : NaN
+  if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) return undefined
+  return n
+}
+
 /** Parse OpenAI-compatible model-list responses, dropping unsafe/empty/duplicate ids. */
 export function parseGatewayModels(payload: unknown): GatewayModel[] {
   if (!payload || typeof payload !== 'object') return []
@@ -162,7 +177,17 @@ export function parseGatewayModels(payload: unknown): GatewayModel[] {
   const byId = new Map<string, GatewayModel>()
   for (const raw of data) {
     if (!raw || typeof raw !== 'object') continue
-    const row = raw as { id?: unknown; name?: unknown; provider?: unknown; owned_by?: unknown }
+    const row = raw as {
+      id?: unknown
+      name?: unknown
+      provider?: unknown
+      owned_by?: unknown
+      context_length?: unknown
+      max_context_length?: unknown
+      context_window?: unknown
+      max_output_tokens?: unknown
+      max_completion_tokens?: unknown
+    }
     const id = typeof row.id === 'string' ? row.id.trim() : ''
     if (!id || id.length > 500 || /[\u0000-\u001f\u007f]/.test(id)) continue
     const prefix = id.includes('/') ? id.slice(0, id.indexOf('/')) : ''
@@ -172,10 +197,22 @@ export function parseGatewayModels(payload: unknown): GatewayModel[] {
         : typeof row.owned_by === 'string'
           ? row.owned_by.trim()
           : ''
+    // Context window: gateways disagree on the field name. The OpenAI convention (`context_length`)
+    // and the `context_window` alias cover the providers Copilot BYOK targets; `max_context_length`
+    // is the max variant some report. The FIRST present, finite value wins (they are synonyms), and
+    // an absent one stays undefined so the env var is omitted rather than guessed.
+    const contextWindow =
+      coerceTokenLimit(row.context_length) ??
+      coerceTokenLimit(row.max_context_length) ??
+      coerceTokenLimit(row.context_window)
+    const maxOutputTokens =
+      coerceTokenLimit(row.max_output_tokens) ?? coerceTokenLimit(row.max_completion_tokens)
     byId.set(id, {
       id,
       ...(typeof row.name === 'string' && row.name.trim() ? { name: row.name.trim() } : {}),
-      ...(explicitProvider || prefix ? { provider: explicitProvider || prefix } : {})
+      ...(explicitProvider || prefix ? { provider: explicitProvider || prefix } : {}),
+      ...(contextWindow ? { contextWindow } : {}),
+      ...(maxOutputTokens ? { maxOutputTokens } : {})
     })
   }
   return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id))
@@ -187,9 +224,9 @@ export function parseGatewayModels(payload: unknown): GatewayModel[] {
  * provider here would hide supported modes. The capability is the only UI gate; custom agents
  * inherit it from their declared base harness.
  */
-export function modelsForAgent(models: GatewayModel[], agentId: AgentId): GatewayModel[] {
+export function modelsForAgent(models: readonly GatewayModel[], agentId: AgentId): GatewayModel[] {
   if (!canSwitchModel(agentId)) return []
-  return models
+  return [...models]
 }
 
 /**
@@ -215,6 +252,20 @@ export const MODEL_GATEWAY_ENV_KEYS = [
   'COPILOT_PROVIDER_MODEL_ID',
   'COPILOT_PROVIDER_WIRE_MODEL',
   'COPILOT_PROVIDER_WIRE_API'
+] as const
+
+/** Claude Code autocompact env vars, injected for a claude-base agent whose resolved gateway model
+ *  reports a context window above `AUTOCOMPACT_THRESHOLD`. These are Claude Code's OWN conventions:
+ *  `CLAUDE_CODE_AUTO_COMPACT_WINDOW` sizes the compaction window, `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`
+ *  sets the % threshold at which it fires. Listed alongside `MODEL_GATEWAY_ENV_KEYS` in the tmux
+ *  `update-environment` conf so a re-attached client inherits them (unset on a non-claude session ⇒
+ *  no effect, so including them in the shared conf is harmless). Sourced ONLY from discovery — never
+ *  guessed — by `claudeAutocompactFor` below. */
+export const AUTOCOMPACT_THRESHOLD = 200_000
+export const AUTOCOMPACT_PCT_OVERRIDE = '80'
+export const AUTOCOMPACT_ENV_KEYS = [
+  'CLAUDE_CODE_AUTO_COMPACT_WINDOW',
+  'CLAUDE_AUTOCOMPACT_PCT_OVERRIDE'
 ] as const
 
 /** tmux's own stock `update-environment` entries (tmux 3.4 defaults, measured via
@@ -244,7 +295,14 @@ const TMUX_STOCK_UPDATE_ENV = [
  *  Deduped so an overlap (e.g. ANTHROPIC_AUTH_TOKEN, in both the gateway list and the claude
  *  auth strip) cannot double an entry. */
 export function tmuxUpdateEnvironmentLine(extraNames: readonly string[] = []): string {
-  const names = [...new Set([...TMUX_STOCK_UPDATE_ENV, ...MODEL_GATEWAY_ENV_KEYS, ...extraNames])]
+  const names = [
+    ...new Set([
+      ...TMUX_STOCK_UPDATE_ENV,
+      ...MODEL_GATEWAY_ENV_KEYS,
+      ...AUTOCOMPACT_ENV_KEYS,
+      ...extraNames
+    ])
+  ]
   return `set -g update-environment "${names.join(' ')}"`
 }
 
@@ -328,4 +386,85 @@ export function withAgentModel(cmd: string, agentId: AgentId, model: string | un
   // provider-prefixed Bifrost id through Copilot's internal catalogue.
   if (capabilityAgentId(agentId) === 'copilot') return cmd
   return `${cmd} --model ${shellSingleQuote(value)}`
+}
+
+/**
+ * For a claude-base agent and its resolved model, return the `[1m]`-suffixed model id and the
+ * Claude Code autocompact env, sourced ONLY from the gateway's discovered model list.
+ *
+ * Claude Code sizes its autocompact window off the model id and fires compaction at a default %
+ * of that window. A gateway model whose real context window is large (e.g. a 1M model surfaced
+ * through a proxy as `vllm/GLM-5.2-NVFP4-MTP[1m]`) would otherwise still use the 200k default and
+ * compact a long session early. Two levers fix it, both Claude-Code-specific:
+ *
+ *  1. A `[1m]` suffix on the model id marks a LARGE window. Appended when the discovered window
+ *     is above `AUTOCOMPACT_THRESHOLD` (see the comment at the suffix below for what each lever
+ *     actually moves — the env var sizes compaction, the suffix is what the CLI's own meter
+ *     honors).
+ *  2. `CLAUDE_CODE_AUTO_COMPACT_WINDOW` (the window size) and `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`
+ *     (the % threshold) env vars, set to the discovered window and `AUTOCOMPACT_PCT_OVERRIDE`.
+ *
+ * Everything is sourced from discovery — never guessed. An unknown model, or one the gateway did
+ * not report a `contextWindow` for, yields NO env and NO suffix (fail open to the CLI's own
+ * behavior). A percentage over a guessed window is a wrong number presented as a fact, the same
+ * rule used throughout gateway model metadata. Non-claude agents get neither: the env
+ * var names and the `[1m]` convention are Claude Code's own and mean nothing to codex/copilot.
+ *
+ * `modelId` is the (possibly suffixed) id a caller should pass to `withAgentModel`; `env` is the
+ * map a spawn site merges into the session environment. The two come from ONE call so the suffix
+ * and the env can never disagree about whether this is a large-context session.
+ */
+export function claudeAutocompactFor(
+  agentId: AgentId,
+  model: string | undefined,
+  models: readonly GatewayModel[]
+): { modelId: string | undefined; env: Record<string, string> } {
+  // Only a claude-base harness. The env var names are Claude Code's; a codex/copilot node would
+  // silently ignore them, and appending [1m] to its --model would send an unknown id to that CLI.
+  if (capabilityAgentId(agentId) !== 'claude') return { modelId: model, env: {} }
+  const id = normalizedAgentModel(agentId, model)
+  if (!id) return { modelId: model, env: {} }
+  // The discovered model is the ONLY source of the window. A model not in the catalogue tells us
+  // nothing — ship no env and no suffix rather than a guess. Exact ids first; then the
+  // `[1m]`-stripped pair, because the SAME model is listed plain and suffixed depending on who
+  // stored it (`modelAvailability` already treats either spelling as available — judging the
+  // window exact-only here would let a suffixed catalogue spelling silently skip both the env
+  // and the shape-mismatch ask for a session launched plain).
+  const discovered = models.find((m) => m.id === id) ??
+    models.find((m) => m.id.replace(/\[1m\]$/, '') === id.replace(/\[1m\]$/, ''))
+  const window = discovered?.contextWindow
+  if (!window) return { modelId: id, env: {} }
+  if (window <= AUTOCOMPACT_THRESHOLD) {
+    return { modelId: id.replace(/\[1m\]$/, ''), env: {} }
+  }
+  // Append the [1m] marker for EVERY above-threshold window — restored 2026-08-31 after the
+  // mid-band "env only" rule measured as a regression: Misc Bugs (5.3 plain, env 400000) still
+  // metered 200k in its status line, so `CLAUDE_CODE_AUTO_COMPACT_WINDOW` does NOT drive the
+  // CLI's own meter, and the suffix is the only lever that resizes it. The env rides alongside
+  // to size the compaction point; the suffix carries the window to the meter. (A suffixed 5.2 in
+  // the field metered ~400k, so the suffix claims the window per model — it is not a fixed 1M
+  // escalation — which also means a mid-band identifier is safe to suffix.)
+  // Symmetric strip: a record whose window dropped below the threshold must NOT keep an old
+  // suffix — re-launching it would re-claim the large window.
+  //
+  // PAIRING INVARIANT (belt-and-suspenders, pinned by model-gateway.test.ts): every branch that
+  // emits a suffixed modelId MUST also emit the autocompact env, and the env is emitted ONLY on
+  // a suffixed branch. The two halves of the mechanism are one mechanism: the `[1m]` suffix lifts
+  // Claude Code's OWN window ceiling (it is what the CLI's status meter honors) and
+  // `CLAUDE_CODE_AUTO_COMPACT_WINDOW` pulls the compaction point back DOWN to the discovered
+  // size. A suffix without the env lets the context grow toward the ceiling with no autocompact
+  // headroom — past what the gateway can serve; an env without the suffix meters 200k while
+  // compaction reads the larger window — two windows disagreeing in one session. `pty-manager`
+  // asserts the invariant at the composed-env site (refuses the spawn loud) so a future caller
+  // that half-applies the pair is caught the day it ships.
+  const modelId = window > AUTOCOMPACT_THRESHOLD
+    ? (id.endsWith('[1m]') ? id : `${id}[1m]`)
+    : id.replace(/\[1m\]$/, '')
+  return {
+    modelId,
+    env: {
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: String(window),
+      CLAUDE_AUTOCOMPACT_PCT_OVERRIDE: AUTOCOMPACT_PCT_OVERRIDE
+    }
+  }
 }

--- a/src/shared/agents/model-gateway.ts
+++ b/src/shared/agents/model-gateway.ts
@@ -8,6 +8,28 @@ export interface ModelGatewaySettings {
   baseUrl: string
   /** Literal legacy key, `${env:VAR}` reference, or `MODEL_GATEWAY_SECRET_REF`. */
   apiKey: string
+  /** Path the discovery (Models API) request is sent to, appended to `baseUrl` — e.g.
+   *  `/openai/v1/models` for a gateway that serves its model catalogue under a protocol prefix.
+   *  Deliberately a PATH SUFFIX and never a full URL: discovery sends the resolved API key to the
+   *  target, and a caller-chosen host would turn the pre-save/relay flow into a credential-exfil-
+   *  tration oracle (the same reason `${env:VAR}` references resolve only for the saved baseUrl).
+   *  Empty/absent = the conventional derived `/v1/models` (see `modelGatewayRoutes`). */
+  discoveryPath?: string
+}
+
+/** Characters a discovery path may contain, minus URL structure that could change WHERE the
+ *  request goes: no query (`?`), fragment (`#`), dot-dot traversal, or second scheme. The value is
+ *  hand-editable settings.json AND caller-supplied over IPC, so it is re-validated at the point it
+ *  is appended to the root (the same rule as permission modes / model ids on a command line) — an
+ *  unrecognized value yields the derived default path, never a guessed one. */
+const GATEWAY_DISCOVERY_PATH = /^\/[A-Za-z0-9\-._~!$&'()*+,;=:@/]*$/
+
+/** A validated discovery path, or null when absent/unsafe (null ⇒ use the derived default). */
+export function sanitizedGatewayDiscoveryPath(path: string | undefined): string | null {
+  const value = path?.trim() ?? ''
+  if (!value) return null
+  if (value.length > 500 || value.includes('..') || !GATEWAY_DISCOVERY_PATH.test(value)) return null
+  return value.replace(/\/+$/, '') || null
 }
 
 /** Stored in settings.json when the literal credential lives in the shell's secret store. */
@@ -100,8 +122,18 @@ export function resolveModelGatewayApiKey(
  * the provider-specific paths are the Bifrost layout requested by the launch mapping. Only http(s)
  * URLs are accepted: this value is later handed to `fetch` and agent CLIs, and settings.json is
  * hand-editable. Invalid input degrades to null, never to a guessed endpoint.
+ *
+ * `discoveryPath` (optional, from the same `ModelGatewaySettings`) replaces the conventional
+ * `/v1/models` suffix when it is present and passes `sanitizedGatewayDiscoveryPath`. It changes
+ * only WHICH path on the saved root the catalogue is read from — never the host — so the
+ * credential trust gate upstream (references resolve only for the saved baseUrl) is unaffected.
+ * An unsafe value falls back to the derived default rather than sending a fetch somewhere the
+ * user did not vet.
  */
-export function modelGatewayRoutes(baseUrl: string): ModelGatewayRoutes | null {
+export function modelGatewayRoutes(
+  baseUrl: string,
+  discoveryPath?: string
+): ModelGatewayRoutes | null {
   const raw = baseUrl.trim().replace(/\/+$/, '')
   if (!raw) return null
   try {
@@ -111,8 +143,9 @@ export function modelGatewayRoutes(baseUrl: string): ModelGatewayRoutes | null {
     // The separate API-key field exists precisely so a secret never has to live there.
     if (parsed.username || parsed.password || parsed.search || parsed.hash) return null
     const root = parsed.toString().replace(/\/+$/, '')
+    const discoverySuffix = sanitizedGatewayDiscoveryPath(discoveryPath) ?? '/v1/models'
     return {
-      discovery: `${root}/v1/models`,
+      discovery: `${root}${discoverySuffix}`,
       openai: `${root}/openai/v1`,
       anthropic: `${root}/anthropic`
     }

--- a/src/shared/agents/vanilla-env.test.ts
+++ b/src/shared/agents/vanilla-env.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { vanillaEnvStripPattern, setCustomAgentBaseResolver } from './config'
+
+afterEach(() => setCustomAgentBaseResolver(null))
+
+describe('vanillaEnvStripPattern', () => {
+  it('claude strips ANTHROPIC_* + the OAuth token but keeps the config dir', () => {
+    const re = vanillaEnvStripPattern('claude')!
+    expect(re).not.toBeNull()
+    // Provider + inherited auth vars the gateway and a LaunchAgent export.
+    expect(re.test('ANTHROPIC_BASE_URL')).toBe(true)
+    expect(re.test('ANTHROPIC_AUTH_TOKEN')).toBe(true)
+    expect(re.test('ANTHROPIC_API_KEY')).toBe(true)
+    expect(re.test('CLAUDE_CODE_OAUTH_TOKEN')).toBe(true)
+    // The managed-account config dir is NOT a provider credential — stripping it would break
+    // account isolation, so the pattern must leave it alone.
+    expect(re.test('CLAUDE_CONFIG_DIR')).toBe(false)
+    // nodeterm's own code constants (not env the pane sets) are left alone.
+    expect(re.test('CLAUDE_HOOK_EVENTS')).toBe(false)
+  })
+
+  it('codex strips only the two known gateway vars', () => {
+    const re = vanillaEnvStripPattern('codex')!
+    expect(re.test('OPENAI_BASE_URL')).toBe(true)
+    expect(re.test('OPENAI_API_KEY')).toBe(true)
+    // Codex credentials live under CODEX_HOME (a config dir), not CODEX_* env — a broad strip is
+    // unverified, so unrelated OPENAI_* the user may set must survive.
+    expect(re.test('OPENAI_ORG_ID')).toBe(false)
+    expect(re.test('CODEX_HOME')).toBe(false)
+  })
+
+  it('copilot strips COPILOT_PROVIDER_* but keeps the home dir + hook constants', () => {
+    const re = vanillaEnvStripPattern('copilot')!
+    expect(re.test('COPILOT_PROVIDER_API_KEY')).toBe(true)
+    expect(re.test('COPILOT_PROVIDER_BASE_URL')).toBe(true)
+    expect(re.test('COPILOT_HOME')).toBe(false)
+    expect(re.test('COPILOT_HOOK_EVENTS')).toBe(false)
+  })
+
+  it('gemini/grok/opencode have no pattern (the action is hidden for them)', () => {
+    expect(vanillaEnvStripPattern('gemini')).toBeNull()
+    expect(vanillaEnvStripPattern('grok')).toBeNull()
+    expect(vanillaEnvStripPattern('opencode')).toBeNull()
+    // A plain custom agent with no base inherits nothing.
+    expect(vanillaEnvStripPattern('custom:plain')).toBeNull()
+  })
+
+  it('a custom agent inherits its base harness pattern', () => {
+    setCustomAgentBaseResolver((id) => (id === 'custom:proxy' ? 'claude' : undefined))
+    const re = vanillaEnvStripPattern('custom:proxy')!
+    expect(re.test('ANTHROPIC_BASE_URL')).toBe(true)
+    expect(re.test('CLAUDE_CONFIG_DIR')).toBe(false)
+  })
+
+  it('is cached: the same source compiles once', () => {
+    const a = vanillaEnvStripPattern('claude')
+    const b = vanillaEnvStripPattern('claude')
+    expect(a).toBe(b) // referentially identical — the cache returns the same compiled RegExp
+  })
+})

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -26,6 +26,8 @@ export const IPC = {
   /** Renderer → core: SIGTERM the non-shell foreground process group in this node's pane.
    *  Model switching uses this instead of typing an exit slash-command into an agent composer. */
   ptyTerminateForeground: 'pty:terminate-foreground',
+  /** Read-only post-respawn proof: does the expected agent own the foreground process group? */
+  ptyAgentProcess: 'pty:agent-process',
   ptyReadSessionName: 'pty:read-session-name',
   /** Shell → renderer: this MACHINE's pty-device pressure band changed (core/pty-pressure.ts).
    *  Payload: `PtyPressure` — `{ level, usage, ceiling }`. Sent on band CHANGES only, and re-sent

--- a/src/shared/model-respawn-trace.test.ts
+++ b/src/shared/model-respawn-trace.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { modelRespawnErrorKind, modelRespawnTrace } from './model-respawn-trace'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('modelRespawnTrace', () => {
+  it('emits one searchable line and omits undefined fields', () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+    modelRespawnTrace('restart.begin', { nodeId: 'node-1', attempt: 2, detail: undefined })
+    expect(info).toHaveBeenCalledOnce()
+    expect(info).toHaveBeenCalledWith(
+      '[model-respawn] restart.begin {"nodeId":"node-1","attempt":2}'
+    )
+  })
+})
+
+describe('modelRespawnErrorKind', () => {
+  it('reports only the error class', () => {
+    expect(modelRespawnErrorKind(new TypeError('secret provider response'))).toBe('TypeError')
+    expect(modelRespawnErrorKind('secret provider response')).toBe('string')
+  })
+})

--- a/src/shared/model-respawn-trace.ts
+++ b/src/shared/model-respawn-trace.ts
@@ -1,0 +1,26 @@
+/**
+ * One deliberately narrow trace stream for model-provider respawns.
+ *
+ * Callers may only supply scalar metadata that is safe to mirror into the desktop log. Never
+ * pass full commands/argv, environment values, credentials, gateway URLs, session ids, or raw
+ * errors here. A tmux `pane_current_command` process name is intentionally allowed: distinguishing
+ * an agent process from a shell is the lifecycle fact this trace exists to diagnose. Keeping the
+ * complete payload on one line also makes Electron's renderer console forwarding preserve every
+ * field in `nodeterm.log`.
+ */
+export type ModelRespawnTraceValue = string | number | boolean | null | undefined
+export type ModelRespawnTraceFields = Record<string, ModelRespawnTraceValue>
+
+export function modelRespawnTrace(event: string, fields: ModelRespawnTraceFields = {}): void {
+  const compact: Record<string, Exclude<ModelRespawnTraceValue, undefined>> = {}
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) compact[key] = value
+  }
+  console.info(`[model-respawn] ${event} ${JSON.stringify(compact)}`)
+}
+
+/** Error classification without leaking message text, URLs, commands, or provider responses. */
+export function modelRespawnErrorKind(error: unknown): string {
+  if (error instanceof Error) return error.name || 'Error'
+  return error === null ? 'null' : typeof error
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -18,6 +18,7 @@ import type {
   ModelGatewayCredentialStatus,
   ModelGatewaySettings
 } from './agents/model-gateway'
+import type { AgentPaneVerdict } from './agents/pane-owner-predicate'
 
 /**
  * The default provider behavior for a FRESH agent spawn — the three-way successor to the old
@@ -886,6 +887,17 @@ export type PtyLimitFixResult =
    *  renderer: nothing failed, so neither may raise an error toast. */
   | { ok: false; error: string; canceled?: boolean; busy?: boolean }
 
+/** Result of the exact-PID foreground stop used by agent restarts. */
+export type TerminateForegroundOutcome = 'terminated' | 'already-exited' | 'refused'
+
+/** A fresh kernel-backed process identity sample for a node's expected agent. */
+export interface AgentProcessProof {
+  verdict: AgentPaneVerdict
+  /** The tmux pane's root/login-shell PID, distinct from the agent process. */
+  shellPid?: number
+  agentPid?: number
+}
+
 export interface PtyApi {
   /** Starts a new PTY session; returns its sessionId and whether the session was freshly
    *  created (cold start) vs reattached to a still-running tmux session (warm). */
@@ -919,7 +931,7 @@ export interface PtyApi {
   /** Ends a node's persistent session so the SAME node id respawns in a new cwd ("move into
    *  worktree"). Same tmux kill as `destroy`, opposite intent: the node stays on the canvas, so
    *  co-viewers get `onRecycled` (restart + re-attach), never the permanent closed state. */
-  recycle(persistKey: string): void
+  recycle(persistKey: string): Promise<void>
   /** Suggest a terminal title from its recent output via the configured AI agent. */
   generateName(persistKey: string, cwd: string): Promise<GitResult>
   /** Suggest a group title from its member terminals' recent output via the configured AI agent. */
@@ -939,11 +951,13 @@ export interface PtyApi {
    *  node persistKey. null when it is unknown — no session, no tmux, or the query failed — which
    *  callers must read as "not observed", never as evidence of a particular command. */
   paneCommand(persistKey: string): Promise<string | null>
-  /** Terminate the foreground process group in a node's pane. Returns false when the pane/process
-   *  cannot be safely identified; it never kills the pane's login shell. When `expectedAgentId` is
-   *  given, the kill happens only if that harness actually owns the foreground group (argv-verified)
-   *  — so a stale menu can never SIGTERM vim or a build the user started in the pane. */
-  terminateForeground(persistKey: string, expectedAgentId?: string): Promise<boolean>
+  /** Terminate the exact argv-verified agent process group without killing the pane shell. */
+  terminateForeground(
+    persistKey: string,
+    expectedAgentId?: string
+  ): Promise<TerminateForegroundOutcome>
+  /** Read-only proof that the expected agent owns the foreground process group. */
+  agentProcess(persistKey: string, expectedAgentId: string): Promise<AgentProcessProof>
   /** The agent session's display name (`/rename` name, else auto name) read from the agent's own
    *  session store, resolved strictly by sessionId; null if unknown. Keeps a node title in sync with
    *  the `/resume` name (e.g. after resume) without cross-contaminating same-folder sessions.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -19,6 +19,25 @@ import type {
   ModelGatewaySettings
 } from './agents/model-gateway'
 
+/**
+ * The default provider behavior for a FRESH agent spawn — the three-way successor to the old
+ * `vanillaLaunchDefault` boolean. Read by `pty-manager`'s spawn-site strip gate and by the
+ * renderer's new-node creation (`addAgentNode`):
+ *  - `'gateway'`        — inject the model gateway env; the agent uses the CLI's OWN default model
+ *                         (no `--model`). Today's behavior for a gateway node with no per-node model.
+ *  - `'gateway-model'`  — inject the gateway env AND launch with the configured default gateway
+ *                         model (`settings.modelGatewayDefaultModel`), so a new canvas session
+ *                         opens on a chosen model without a per-node "Switch model" click.
+ *  - `'subscription'`   — strip the gateway + inherited provider env so the agent runs against its
+ *                         OWN default provider (Claude's subscription, Copilot's GitHub routing).
+ *                         The former `vanillaLaunchDefault: true`. Wins even when a default model is
+ *                         set (vanilla = no gateway at all, so the gateway model is moot).
+ *
+ * `vanillaLaunchDefault` is kept for one release as a migration MIRROR (an older build still honors
+ * the choice); `agentLaunchMode === 'subscription'` ⇒ `vanillaLaunchDefault = true`, else `false`.
+ */
+export type AgentLaunchMode = 'gateway' | 'gateway-model' | 'subscription'
+
 /** Profile-switch replacement intent. The trusted core validates and re-resolves it before teardown. */
 export interface PtyRecycleTarget {
   profileId: string
@@ -1524,6 +1543,10 @@ export interface Settings {
   customAgents: CustomAgent[]
   /** One gateway root + non-secret credential reference used by model-switch-capable harnesses. */
   modelGateway: ModelGatewaySettings
+  /** The default gateway model id (from discovery) applied to a fresh canvas agent spawn when
+   *  `agentLaunchMode === 'gateway-model'`. A separate field from `modelGateway` (it is NOT a
+   *  credential). Absent/empty = no default ⇒ `'gateway-model'` behaves like `'gateway'`. */
+  modelGatewayDefaultModel?: string
   /** Per-builtin-agent launch command overrides (Settings → Agents → Launch commands). The value
    *  replaces the bare CLI name everywhere a launch line is built — new sessions, cold-restore
    *  relaunches and in-place restarts, with the usual flags (`--resume`, `--permission-mode`, the
@@ -1576,6 +1599,9 @@ export interface Settings {
    *  `CLAUDE_CONFIG_DIR` (account isolation survives). See `vanillaEnvStripPattern`.
    */
   vanillaLaunchDefault: boolean
+  /** The default provider behavior for a fresh agent spawn (the three-way successor to
+   *  `vanillaLaunchDefault`). See `AgentLaunchMode`. Default `'gateway'` = today's behavior. */
+  agentLaunchMode: AgentLaunchMode
   /** "Eco": exit the agent CLI of a session that has been idle AND offscreen for
    *  `agentHibernationIdleMinutes`, reclaiming its RAM; the conversation is resumed automatically
    *  when the node is viewed again. Default OFF — opt-in, because it stops a real process.
@@ -1743,6 +1769,9 @@ export const DEFAULT_SETTINGS: Settings = {
   soundVolume: 0.5,
   customAgents: [],
   modelGateway: { baseUrl: '', apiKey: '' },
+  // No default gateway model until the user picks one in Settings → Model gateway. Absent ⇒
+  // `'gateway-model'` behaves like `'gateway'` (no --model on a fresh spawn).
+  modelGatewayDefaultModel: undefined,
   agentLaunchCommands: {},
   claudeAccounts: [],
   codexAccounts: [],
@@ -1765,6 +1794,9 @@ export const DEFAULT_SETTINGS: Settings = {
   // Opt-in: strips the gateway/inherited provider env on every fresh launch so agents run against
   // their own default provider. Off by default — changes which provider every agent node uses.
   vanillaLaunchDefault: false,
+  // The three-way successor to the boolean above. `'gateway'` = inject gateway env, CLI default
+  // model (today's behavior). `vanillaLaunchDefault` is now its migration mirror.
+  agentLaunchMode: 'gateway',
   // Opt-in: hibernation exits a live CLI, so nobody gets it without asking. The 30-minute floor
   // is deliberately long — shorter windows exit sessions the user is between turns on.
   agentHibernationEnabled: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -385,6 +385,10 @@ export interface CanvasNodeState {
   agentId?: AgentId
   /** Model selected for this agent node through the shared model gateway. */
   agentModel?: string
+  /** Exact model id emitted by the launch assembler; may include an internal `[1m]` marker. */
+  agentLaunchModel?: string
+  /** Context window baked into this session's launch environment, when discovery knew it. */
+  agentLaunchContextWindow?: number
   /**
    * One-shot "Restart on subscription" flag: when set, the next `transport.create` strips gateway +
    * inherited provider env (per `vanillaEnvStripPattern`) so the agent resumes against its own

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -106,6 +106,14 @@ export interface PtyCreateOptions {
   agentId?: AgentId
   /** Per-node model override. Applied through the node's base harness on launch/cold restore. */
   agentModel?: string
+  /**
+   * One-shot: spawn (or re-spawn after a recycle) with gateway + inherited provider env stripped
+   * so the agent runs against its OWN default provider (Claude's subscription, Copilot's GitHub
+   * routing) instead of the configured gateway/inherited override. The strip set is per-agent
+   * (`vanillaEnvStripPattern`); `CLAUDE_CONFIG_DIR` is deliberately kept (account isolation
+   * survives). Cleared after the spawn resolves so a later ordinary Restart re-applies the gateway.
+   */
+  clearEnv?: boolean
   /** Managed Claude account: inject CLAUDE_CONFIG_DIR for this account into the session env. */
   accountId?: string
   /**
@@ -357,6 +365,13 @@ export interface CanvasNodeState {
   agentId?: AgentId
   /** Model selected for this agent node through the shared model gateway. */
   agentModel?: string
+  /**
+   * One-shot "Restart on subscription" flag: when set, the next `transport.create` strips gateway +
+   * inherited provider env (per `vanillaEnvStripPattern`) so the agent resumes against its own
+   * default provider. Set by the clear-env recycle action, cleared after the spawn resolves so an
+   * ordinary Restart re-applies the gateway. See `PtyCreateOptions.clearEnv`.
+   */
+  clearEnv?: boolean
   /** Set while this node is armed but not yet launched — see PendingLaunch. */
   pendingLaunch?: PendingLaunch
   /**
@@ -1552,6 +1567,15 @@ export interface Settings {
    *  driver runs in `default`). Overridable per project via Project.defaultPermissionMode.
    *  `auto` is version-gated: CLIs below 2.1.71 reject the value, so it degrades to no flag. */
   claudePermissionMode: AgentPermissionMode
+  /**
+   *  When on, EVERY fresh agent launch spawns with gateway + inherited provider env stripped, so the
+   *  agent runs against its OWN default provider (Claude's subscription, Copilot's GitHub routing)
+   *  instead of a configured gateway/inherited override. The per-node one-shot `data.clearEnv`
+   *  (cleared after its single recycle) is the per-node action; this is its global counterpart.
+   *  Default OFF — opt-in, because it changes which provider every agent node uses. Does NOT strip
+   *  `CLAUDE_CONFIG_DIR` (account isolation survives). See `vanillaEnvStripPattern`.
+   */
+  vanillaLaunchDefault: boolean
   /** "Eco": exit the agent CLI of a session that has been idle AND offscreen for
    *  `agentHibernationIdleMinutes`, reclaiming its RAM; the conversation is resumed automatically
    *  when the node is viewed again. Default OFF — opt-in, because it stops a real process.
@@ -1738,6 +1762,9 @@ export const DEFAULT_SETTINGS: Settings = {
   // Sessions start in auto mode out of the box. Existing users pick this up on hydrate
   // (settings hydrate merges over DEFAULT_SETTINGS) — a deliberate behavior change.
   claudePermissionMode: 'auto',
+  // Opt-in: strips the gateway/inherited provider env on every fresh launch so agents run against
+  // their own default provider. Off by default — changes which provider every agent node uses.
+  vanillaLaunchDefault: false,
   // Opt-in: hibernation exits a live CLI, so nobody gets it without asking. The 30-minute floor
   // is deliberately long — shorter windows exit sessions the user is between turns on.
   agentHibernationEnabled: false,


### PR DESCRIPTION
Sessions affected by a removed gateway model, changed context window, or outdated launch flags are now collected into one recovery dialog. Each row retains progress, a concrete refusal or failure reason, and Retry when needed.

Recovery refreshes discovery once on focus using the current settings. Evaluating an empty or failed catalogue does not start another request. A restart counts as repaired only when the actual saved launch record satisfies the current catalogue; an uncured restart remains actionable and does not suppress the next recovery prompt.

Prerequisites: https://github.com/eneskirca/nodeterm/pull/725. This draft targets `main`; its GitHub diff includes prerequisite commits until those changes land. [Review this change alone](https://github.com/dkattan/nodeterm/compare/1a17a6234ee4479a40eb50c2b44cf542bd79acc5...98d95809212e6f1a5cc85e2f6ff677b1dbea138e).

Replaces https://github.com/dkattan/nodeterm/pull/11. Split from https://github.com/eneskirca/nodeterm/pull/715.

Prior branch validation: 311 focused tests plus 49 Canvas wiring tests, typecheck, and production build passed. The combined local macOS full suite retained failures reproduced on unchanged main and intermittent real-tmux timeouts. This upstream draft now runs the repository’s PR checks against `main`.
