### PR TITLE
feat(tabbar): tabs that read as tabs, with an options button on every one

### DIFF
--- a/src/renderer/components/TabBar.test.tsx
+++ b/src/renderer/components/TabBar.test.tsx
@@ -264,3 +264,57 @@ describe('TabBar drag-reorder', () => {
     expect(onReorder).toHaveBeenCalledWith('p1', null)
   })
 })
+
+describe('TabBar options button', () => {
+  let root: Root
+  let host: HTMLElement
+
+  beforeEach(async () => {
+    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = NoopResizeObserver
+    Element.prototype.scrollIntoView = (): void => {}
+    ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {}
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    useProjects.setState({
+      projects: [project(), project({ id: 'p2', name: 'Beta' })],
+      activeProjectId: 'p1'
+    })
+    root = createRoot(host)
+    await act(async () => {
+      root.render(
+        <TabBar
+          onSwitch={vi.fn()}
+          onReconnect={vi.fn()}
+          onReorder={vi.fn()}
+          onOpenWelcome={vi.fn()}
+          onRename={vi.fn()}
+          onSetFolder={vi.fn()}
+          onCloseProject={vi.fn()}
+          onRemoteAccess={vi.fn()}
+          onSetDefaultAccount={vi.fn()}
+          onSetDefaultPermissionMode={vi.fn()}
+          onOpenProjectSettings={vi.fn()}
+        />
+      )
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    useProjects.setState({ projects: [], activeProjectId: '' })
+  })
+
+  it('sits on every tab, so the menu is reachable without activating it first', () => {
+    expect(host.querySelectorAll('.tab__caret').length).toBe(2)
+  })
+
+  it('opens the menu for the tab it belongs to, active or not', async () => {
+    const inactive = host.querySelectorAll<HTMLButtonElement>('.tab__caret')[1]
+    await act(async () => {
+      inactive.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(document.querySelector('.tab-menu')).not.toBeNull()
+  })
+})

--- a/src/renderer/components/TabBar.test.tsx
+++ b/src/renderer/components/TabBar.test.tsx
@@ -116,7 +116,6 @@ describe('TabBar caret menu', () => {
     expect(document.querySelector('.tab-menu')).toBeNull()
   })
 })
-
 describe('TabBar New-project pin', () => {
   let root: Root
   let host: HTMLElement
@@ -175,5 +174,93 @@ describe('TabBar New-project pin', () => {
       host.querySelector<HTMLButtonElement>('.tab__add')!.click()
     })
     expect(onOpenWelcome).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('TabBar drag-reorder', () => {
+  let root: Root
+  let host: HTMLElement
+  let onReorder: ReturnType<typeof vi.fn<(dragged: string, before: string | null) => void>>
+
+  // jsdom has no DragEvent, and React reads `dataTransfer` in onDragStart. One shared stub is
+  // enough: nothing here inspects what was put on it.
+  const drag = async (el: Element, type: string): Promise<void> => {
+    const e = new Event(type, { bubbles: true, cancelable: true })
+    Object.defineProperty(e, 'dataTransfer', { value: { effectAllowed: '', setData: (): void => {} } })
+    await act(async () => {
+      el.dispatchEvent(e)
+    })
+  }
+
+  const tabs = (): Element[] => Array.from(host.querySelectorAll('.tab'))
+
+  beforeEach(async () => {
+    const { TabBar, useProjects } = await load()
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    useProjects.setState({
+      projects: [
+        project(),
+        project({ id: 'p2', name: 'Beta', cwd: '/repo/beta' }),
+        project({ id: 'p3', name: 'Gamma', cwd: '/repo/gamma' })
+      ],
+      activeProjectId: 'p1'
+    })
+    onReorder = vi.fn<(dragged: string, before: string | null) => void>()
+    root = createRoot(host)
+    await act(async () => {
+      root.render(
+        <TabBar
+          onSwitch={vi.fn()}
+          onReconnect={vi.fn()}
+          onReorder={onReorder}
+          onOpenWelcome={vi.fn()}
+          onRename={vi.fn()}
+          onSetFolder={vi.fn()}
+          onCloseProject={vi.fn()}
+          onRemoteAccess={vi.fn()}
+          onSetDefaultAccount={vi.fn()}
+          onSetDefaultPermissionMode={vi.fn()}
+          onOpenProjectSettings={vi.fn()}
+        />
+      )
+    })
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    useProjects.setState({ projects: [], activeProjectId: '' })
+  })
+
+  it('drops a tab before the one it was released on', async () => {
+    const [first, , third] = tabs()
+    await drag(third, 'dragstart')
+    await drag(first, 'dragover')
+    await drag(first, 'drop')
+    expect(onReorder).toHaveBeenCalledWith('p3', 'p1')
+  })
+
+  it('marks the hovered tab so the insertion line has something to hang on', async () => {
+    const [first, , third] = tabs()
+    await drag(third, 'dragstart')
+    await drag(first, 'dragover')
+    expect(first.classList.contains('is-drop-before')).toBe(true)
+  })
+
+  it('shows an insertion line for the end zone, which has no tab to hang one off', async () => {
+    const [first] = tabs()
+    await drag(first, 'dragstart')
+    expect(host.querySelector('.tab__dropline')).toBeNull()
+    await drag(host.querySelector('.tabbar__tabs')!, 'dragover')
+    expect(host.querySelector('.tab__dropline')).not.toBeNull()
+  })
+
+  it('drops at the end when released on the strip itself', async () => {
+    const [first] = tabs()
+    await drag(first, 'dragstart')
+    await drag(host.querySelector('.tabbar__tabs')!, 'dragover')
+    await drag(host.querySelector('.tabbar__tabs')!, 'drop')
+    expect(onReorder).toHaveBeenCalledWith('p1', null)
   })
 })

--- a/src/renderer/components/TabBar.test.tsx
+++ b/src/renderer/components/TabBar.test.tsx
@@ -230,7 +230,6 @@ describe('TabBar drag-reorder', () => {
   afterEach(() => {
     act(() => root.unmount())
     host.remove()
-    useProjects.setState({ projects: [], activeProjectId: '' })
   })
 
   it('drops a tab before the one it was released on', async () => {
@@ -270,9 +269,7 @@ describe('TabBar options button', () => {
   let host: HTMLElement
 
   beforeEach(async () => {
-    ;(globalThis as { ResizeObserver?: unknown }).ResizeObserver = NoopResizeObserver
-    Element.prototype.scrollIntoView = (): void => {}
-    ;(window as unknown as { nodeTerminal: any }).nodeTerminal = {}
+    const { TabBar, useProjects } = await load()
     host = document.createElement('div')
     document.body.appendChild(host)
     useProjects.setState({
@@ -302,7 +299,6 @@ describe('TabBar options button', () => {
   afterEach(() => {
     act(() => root.unmount())
     host.remove()
-    useProjects.setState({ projects: [], activeProjectId: '' })
   })
 
   it('sits on every tab, so the menu is reachable without activating it first', () => {

--- a/src/renderer/components/TabBar.test.tsx
+++ b/src/renderer/components/TabBar.test.tsx
@@ -115,6 +115,28 @@ describe('TabBar caret menu', () => {
     // …and the menu closes behind it, like every other action in this menu.
     expect(document.querySelector('.tab-menu')).toBeNull()
   })
+
+  it('closes on a press anywhere outside it, including the bar the menu hangs from', async () => {
+    // The dismiss backdrop is below the bar so a click on another tab still switches projects,
+    // which leaves the bar itself unable to close the menu without this.
+    expect(document.querySelector('.tab-menu')).not.toBeNull()
+    await act(async () => {
+      host
+        .querySelector('.tabbar')!
+        .dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    })
+    expect(document.querySelector('.tab-menu')).toBeNull()
+  })
+
+  it('leaves the caret to its own toggle, so pressing it while open does not reopen the menu', async () => {
+    const caret = host.querySelector<HTMLButtonElement>('.tab__caret')!
+    await act(async () => {
+      caret.dispatchEvent(new Event('pointerdown', { bubbles: true }))
+    })
+    expect(document.querySelector('.tab-menu')).not.toBeNull()
+    await click(caret)
+    expect(document.querySelector('.tab-menu')).toBeNull()
+  })
 })
 describe('TabBar New-project pin', () => {
   let root: Root

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -369,6 +369,8 @@ export function TabBar({
                 )}
 
                 {active && editingId !== p.id && (
+                  // On the ACTIVE tab only: the toggle says which view you are looking at, and
+                  // on an inactive tab it would flip a project's view without taking you there.
                   // The title was a hardcoded `(⌘⇧B)` — mac glyphs shown to Linux/Windows users
                   // (a pre-existing bug: it was never even hintLabel-wrapped), and stale after a
                   // remap. `commandTooltip` fixes both and drops the chord entirely when the
@@ -379,6 +381,7 @@ export function TabBar({
                       kanbanActive ? 'Canvas view' : 'Kanban view',
                       'view.kanbanToggle'
                     )}
+                    aria-label={kanbanActive ? 'Canvas view' : 'Kanban view'}
                     onClick={(e) => {
                       e.stopPropagation() // a tab click switches projects, this only flips the view
                       const vm = useViewMode.getState()

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -12,7 +12,7 @@ import { sessionCount, sessionForProject, useProjectSession } from '../session/s
 import { tabClickAction } from '../session/relay-tab'
 import { useMenuFlip } from '../ui/useMenuFlip'
 import { commandTooltip } from '../lib/keybindingOverrides'
-import { IconCanvasView, IconChevronDown, IconKanban, IconPlus } from './icons'
+import { IconCanvasView, IconKanban, IconMoreVertical, IconPlus } from './icons'
 import { ProjectGlyph } from './ProjectGlyph'
 import {
   ALL_PERMISSION_MODES,
@@ -400,17 +400,18 @@ export function TabBar({
                     {kanbanActive ? <IconCanvasView /> : <IconKanban />}
                   </button>
                 )}
-                {active && editingId !== p.id && (
+                {editingId !== p.id && (
                   <button
                     className="tab__caret"
                     title="Project options"
+                    aria-label="Project options"
                     onClick={(e) => {
                       e.stopPropagation()
                       if (menuId === p.id) closeMenu()
                       else openMenu(p.id, e.currentTarget)
                     }}
                   >
-                    <IconChevronDown />
+                    <IconMoreVertical />
                   </button>
                 )}
               </div>

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -212,6 +212,23 @@ export function TabBar({
       ?.scrollIntoView({ behavior: 'smooth', inline: 'nearest', block: 'nearest' })
   }, [activeId, projects.length])
 
+  // The backdrop deliberately sits BELOW the bar, so a click on another tab switches to it in one
+  // go instead of being swallowed as a dismiss — which leaves the bar itself (its empty stretch,
+  // the brand, the +) unable to close the menu. This covers exactly that gap, and it closes
+  // WITHOUT consuming the event, so the click still lands wherever it was aimed.
+  useEffect(() => {
+    if (!menuId) return
+    const onDown = (e: PointerEvent): void => {
+      const el = e.target as HTMLElement | null
+      // The caret owns its own toggle; closing here first would let its click re-open the menu.
+      if (el?.closest('.tab-menu, .tab__caret')) return
+      closeMenu()
+    }
+    document.addEventListener('pointerdown', onDown, true)
+    return () => document.removeEventListener('pointerdown', onDown, true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [menuId])
+
   return (
     <>
       {(menuId || editingId) && (

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -416,6 +416,12 @@ export function TabBar({
               </div>
             )
           })}
+          {/* The end-of-strip drop zone (`dropId === ''`) had no marker at all — every other target
+              draws its line as the `::before` of the tab it lands in front of, and "after the last
+              one" has no such tab. It lives INSIDE the scroller so it lands after the last tab
+              rather than at the window edge. Rendered only mid-drag, and its negative margins
+              cancel its own width so appearing costs no layout shift. */}
+          {dragId && dropId === '' && <span className="tab__dropline" aria-hidden />}
           </div>
           <button
             type="button"

--- a/src/renderer/components/TabBar.tsx
+++ b/src/renderer/components/TabBar.tsx
@@ -368,54 +368,58 @@ export function TabBar({
                   </span>
                 )}
 
-                {active && editingId !== p.id && (
-                  // On the ACTIVE tab only: the toggle says which view you are looking at, and
-                  // on an inactive tab it would flip a project's view without taking you there.
-                  // The title was a hardcoded `(⌘⇧B)` — mac glyphs shown to Linux/Windows users
-                  // (a pre-existing bug: it was never even hintLabel-wrapped), and stale after a
-                  // remap. `commandTooltip` fixes both and drops the chord entirely when the
-                  // command is unbound.
-                  <button
-                    className="tab__board-toggle"
-                    title={commandTooltip(
-                      kanbanActive ? 'Canvas view' : 'Kanban view',
-                      'view.kanbanToggle'
-                    )}
-                    aria-label={kanbanActive ? 'Canvas view' : 'Kanban view'}
-                    onClick={(e) => {
-                      e.stopPropagation() // a tab click switches projects, this only flips the view
-                      const vm = useViewMode.getState()
-                      const settings = useSettings.getState().settings
-                      const omni = isOmniKanbanEnabled(settings)
-                      const asDefault = settings.omniKanbanAsDefault === true
-                      // Closing: global overlay is exclusive — any board toggle while it's open closes it.
-                      if (vm.globalKanban) {
-                        vm.toggleGlobalKanban()
-                        return
-                      }
-                      if (omni && asDefault) {
-                        vm.toggleGlobalKanban()
-                      } else {
-                        vm.toggle(p.id)
-                      }
-                    }}
-                  >
-                    {kanbanActive ? <IconCanvasView /> : <IconKanban />}
-                  </button>
-                )}
                 {editingId !== p.id && (
-                  <button
-                    className="tab__caret"
-                    title="Project options"
-                    aria-label="Project options"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      if (menuId === p.id) closeMenu()
-                      else openMenu(p.id, e.currentTarget)
-                    }}
-                  >
-                    <IconMoreVertical />
-                  </button>
+                  // The actions are one cluster with its own rhythm, not two more items in the
+                  // tab's label row: they sit a hair apart from each other and further from the
+                  // name than the name's own parts sit from one another.
+                  <span className="tab__actions">
+                    {active && (
+                      // On the ACTIVE tab only: the toggle says which view you are looking at, and
+                      // on an inactive tab it would flip a project's view without taking you
+                      // there. The chord comes from `commandTooltip`, so a remap or an unbound
+                      // command is not advertised as a chord that no longer works.
+                      <button
+                        className="tab__board-toggle"
+                        title={commandTooltip(
+                          kanbanActive ? 'Canvas view' : 'Kanban view',
+                          'view.kanbanToggle'
+                        )}
+                        aria-label={kanbanActive ? 'Canvas view' : 'Kanban view'}
+                        onClick={(e) => {
+                          e.stopPropagation() // a tab click switches projects, this flips the view
+                          const vm = useViewMode.getState()
+                          const settings = useSettings.getState().settings
+                          const omni = isOmniKanbanEnabled(settings)
+                          const asDefault = settings.omniKanbanAsDefault === true
+                          // Closing: the global overlay is exclusive, so any board toggle while
+                          // it is open closes it.
+                          if (vm.globalKanban) {
+                            vm.toggleGlobalKanban()
+                            return
+                          }
+                          if (omni && asDefault) {
+                            vm.toggleGlobalKanban()
+                          } else {
+                            vm.toggle(p.id)
+                          }
+                        }}
+                      >
+                        {kanbanActive ? <IconCanvasView /> : <IconKanban />}
+                      </button>
+                    )}
+                    <button
+                      className="tab__caret"
+                      title="Project options"
+                      aria-label="Project options"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        if (menuId === p.id) closeMenu()
+                        else openMenu(p.id, e.currentTarget)
+                      }}
+                    >
+                      <IconMoreVertical />
+                    </button>
+                  </span>
                 )}
               </div>
             )

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -416,6 +416,16 @@ export const IconMore = () => (
   </svg>
 )
 
+/** Vertical ellipsis: the per-row overflow menu, where a horizontal one would read as a separator
+ *  between the label beside it and what follows. */
+export const IconMoreVertical = () => (
+  <svg {...S} fill="currentColor" stroke="none">
+    <circle cx="12" cy="5.5" r="1.6" />
+    <circle cx="12" cy="12" r="1.6" />
+    <circle cx="12" cy="18.5" r="1.6" />
+  </svg>
+)
+
 /** Bare checkmark. IconCircleCheck is the badged variant and means something else: a completed
  *  thing, not a selected one. */
 export const IconCheck = () => (

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -276,6 +276,9 @@ body,
 .tabbar__projects {
   display: flex;
   align-items: stretch;
+  /* The bar centers its items, so without this the wrapper is only as tall as its content and the
+     tabs stretch to THAT — they have to reach the bar's own top and bottom to read as tabs. */
+  align-self: stretch;
   gap: 4px;
   flex: 1;
   /* Load-bearing (issue #375): a flex item's min-width defaults to `auto`, which resolves against
@@ -446,6 +449,15 @@ body,
   outline: none;
 }
 
+/* The two tab actions read as one cluster: a hair between them, and a wider step from the name
+   than the 7px the tab's own parts (dot, name, badge) sit apart. */
+.tab__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  margin-left: 3px;
+}
+
 .tab__board-toggle,
 .tab__caret {
   display: inline-flex;
@@ -456,7 +468,13 @@ body,
   color: currentColor;
   cursor: pointer;
   line-height: 1;
-  padding: 2px;
+  /* A fixed box, not padding around the glyph: these two sit side by side and their glyphs fill
+     very different amounts of a 14px square — the board's bars run edge to edge, the three dots
+     stand alone in the middle — so a padded box would give them hover plates of two widths and
+     read as two kinds of control. */
+  width: 22px;
+  height: 22px;
+  padding: 0;
   border-radius: 5px;
   /* Reachable on every tab, not only the active one, so it is never hidden: an affordance that
      appears on hover cannot be found by someone who does not already know it is there. */
@@ -486,8 +504,8 @@ body,
   /* Load-bearing: without this a squeezed bar shrinks the 28px + instead of scrolling the tabs. */
   flex-shrink: 0;
   /* Its own breathing room now the strip runs at `gap: 0` — "+" is a separate action, not the
-     next tab in the row. */
-  margin-left: 8px;
+     next tab in the row. Small: it belongs to the strip it ends, not to the empty bar beside it. */
+  margin-left: 2px;
   width: 28px;
   height: 28px;
   background: transparent;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -453,7 +453,9 @@ body,
   line-height: 1;
   padding: 2px 2px;
   border-radius: 4px;
-  opacity: 0;
+  /* Reachable on every tab, not only the active one, so it is never hidden: an affordance that
+     appears on hover cannot be found by someone who does not already know it is there. */
+  opacity: 0.45;
 }
 
 .tab:hover .tab__caret {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -309,7 +309,9 @@ body,
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 0 14px;
+  /* Asymmetric on purpose: the right edge ends in the options button, whose three dots are a far
+     narrower glyph than the name on the left, so an equal padding reads as a gap there. */
+  padding: 0 10px 0 14px;
   color: var(--muted);
   font-size: 13px;
   /* One weight for every tab: a heavier active tab shifts the whole strip's metrics as you switch,
@@ -444,6 +446,7 @@ body,
   outline: none;
 }
 
+.tab__board-toggle,
 .tab__caret {
   display: inline-flex;
   align-items: center;
@@ -461,12 +464,14 @@ body,
   transition: background 0.12s ease, opacity 0.12s ease;
 }
 
+.tab:hover .tab__board-toggle,
 .tab:hover .tab__caret {
   opacity: 0.7;
 }
 
 /* Same answer a node's header buttons give (`.term-node__refresh` and friends): a tinted plate
    under the glyph, not just a brighter glyph. */
+.tab__board-toggle:hover,
 .tab__caret:hover {
   background: rgba(var(--tint-rgb), 0.1);
   color: var(--text);
@@ -1878,6 +1883,7 @@ body,
 /* Icon sizing for the boxes that are smaller than the shared 16px glyph. The icon set is one
    family on one viewBox (see icons.tsx); where a button is tight, the BUTTON scales it down
    rather than the icon carrying a second size of its own. */
+.tab__board-toggle svg,
 .tab__caret svg,
 .sessmem-row__kill svg,
 .welcome__recent-del svg {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -289,7 +289,9 @@ body,
 .tabbar__tabs {
   display: flex;
   align-items: stretch;
-  gap: 2px;
+  /* No gap: the active tab's side hairlines ARE the seams, and a strip of bar showing between two
+     tabs reads as a segmented control again — the thing this replaced. */
+  gap: 0;
   align-self: stretch;
   padding: 0;
   overflow-x: auto;
@@ -334,12 +336,21 @@ body,
 /* The two side hairlines that cut the tab out of the bar, drawn as an inset shadow so they cost
    no layout. Sides ONLY: a top edge would draw a lid on a shape whose whole point is that it is
    open into the canvas below. Load-bearing in LIGHT, where `--canvas-bg` and `--panel` are one
-   value apart and the fill alone would be invisible — hence in both themes, not just that one. */
+   value apart and the fill alone would be invisible — hence in both themes, not just that one.
+
+   FOUR shadows, not two, so these edges render as the SAME colour as `.tabbar::after`. `--border`
+   is an alpha (0.1 dark / 0.14 light), and the bar's separator composites it over `--panel` while
+   these edges sit over `--canvas-bg` — which in dark is #000 against #282828, so the identical
+   token painted two grades darker. A box-shadow list paints first-on-top, so the `--panel` pair
+   is listed LAST to sit behind as an opaque ground and the `--border` pair lands on it exactly as
+   it does on the bar. Cheaper than a resolved token, which would have to restate the alpha per
+   theme and drift from `--border` the first time one of them is tuned. */
 .tab.active::after {
   content: '';
   position: absolute;
   inset: 0;
-  box-shadow: inset 1px 0 0 var(--border), inset -1px 0 0 var(--border);
+  box-shadow: inset 1px 0 0 var(--border), inset -1px 0 0 var(--border),
+    inset 1px 0 0 var(--panel), inset -1px 0 0 var(--panel);
   pointer-events: none;
 }
 
@@ -458,9 +469,11 @@ body,
   align-items: center;
   justify-content: center;
   align-self: center;
-  /* Load-bearing once the pill no longer has flex:1: without this a squeezed bar
-     shrinks the 28px + instead of scrolling the tabs. */
+  /* Load-bearing: without this a squeezed bar shrinks the 28px + instead of scrolling the tabs. */
   flex-shrink: 0;
+  /* Its own breathing room now the strip runs at `gap: 0` — "+" is a separate action, not the
+     next tab in the row. */
+  margin-left: 8px;
   width: 28px;
   height: 28px;
   background: transparent;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -308,9 +308,6 @@ body,
   align-items: center;
   gap: 7px;
   padding: 0 14px;
-  /* Full height of the bar, with only the TOP corners rounded — the bottom edge is where the tab
-     meets its own content. */
-  border-radius: 10px 10px 0 0;
   color: var(--muted);
   font-size: 13px;
   cursor: pointer;
@@ -334,16 +331,15 @@ body,
   z-index: 1;
 }
 
-/* A hairline around the tab's three outer edges, drawn as an inset shadow so it costs no layout
-   and cannot round differently from the fill. Load-bearing in LIGHT, where `--canvas-bg` and
-   `--panel` are one value apart and the fill alone would be invisible. */
+/* The two side hairlines that cut the tab out of the bar, drawn as an inset shadow so they cost
+   no layout. Sides ONLY: a top edge would draw a lid on a shape whose whole point is that it is
+   open into the canvas below. Load-bearing in LIGHT, where `--canvas-bg` and `--panel` are one
+   value apart and the fill alone would be invisible — hence in both themes, not just that one. */
 .tab.active::after {
   content: '';
   position: absolute;
   inset: 0;
-  border-radius: inherit;
-  box-shadow: inset 0 1px 0 var(--border), inset 1px 0 0 var(--border),
-    inset -1px 0 0 var(--border);
+  box-shadow: inset 1px 0 0 var(--border), inset -1px 0 0 var(--border);
   pointer-events: none;
 }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -312,6 +312,9 @@ body,
   padding: 0 14px;
   color: var(--muted);
   font-size: 13px;
+  /* One weight for every tab: a heavier active tab shifts the whole strip's metrics as you switch,
+     and the fill already says which one is active. */
+  font-weight: 500;
   cursor: pointer;
   white-space: nowrap;
 }
@@ -324,9 +327,8 @@ body,
 .tab.active {
   /* THE tab look: the active tab is a hole in the bar showing the canvas behind it. */
   background: var(--canvas-bg);
-  font-weight: 600;
-  /* Neutral, never the project colour: the fill and the weight say which tab is active and
-     `.tab__dot` says which project it is, so tinting the label would say the same thing twice. */
+  /* Neutral, never the project colour: the fill alone says which tab is active and `.tab__dot`
+     says which project it is, so tinting the label would say the same thing twice. */
   color: var(--text);
   /* Above `.tabbar::after`, so the tab's own bottom pixel replaces the separator line and the
      fill runs uninterrupted into the canvas. */
@@ -451,18 +453,23 @@ body,
   color: currentColor;
   cursor: pointer;
   line-height: 1;
-  padding: 2px 2px;
-  border-radius: 4px;
+  padding: 2px;
+  border-radius: 5px;
   /* Reachable on every tab, not only the active one, so it is never hidden: an affordance that
      appears on hover cannot be found by someone who does not already know it is there. */
   opacity: 0.45;
+  transition: background 0.12s ease, opacity 0.12s ease;
 }
 
 .tab:hover .tab__caret {
   opacity: 0.7;
 }
 
+/* Same answer a node's header buttons give (`.term-node__refresh` and friends): a tinted plate
+   under the glyph, not just a brighter glyph. */
 .tab__caret:hover {
+  background: rgba(var(--tint-rgb), 0.1);
+  color: var(--text);
   opacity: 1;
 }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -211,7 +211,6 @@ body,
   height: var(--tabbar-h);
   padding: 0 12px;
   background: var(--panel);
-  border-bottom: 1px solid var(--border);
   /* Above the canvas and the menu backdrop so tabs/inputs stay interactive. */
   z-index: 30;
   flex-shrink: 0;
@@ -225,6 +224,23 @@ body,
    pushing the logo in by 86px and taking the same 86px off the tab strip (issue #564). */
 :root[data-window-chrome='inset'] .tabbar {
   padding-left: 86px;
+}
+
+/* The separator between the bar and the canvas, as a pseudo-element rather than the bar's own
+   `border-bottom`: the ACTIVE tab has to break that line to read as a tab whose body IS the
+   canvas. It is z-index:auto, so the active tab's `z-index: 1` paints over the 1px it covers,
+   and the line still runs under every inactive tab and the bar's empty stretch. In light the two
+   surfaces are almost the same value (`--panel` #f3efe7 vs `--canvas-bg` #f4efe6), so this line
+   plus the active tab's own outline is the whole separation there. */
+.tabbar::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background: var(--border);
+  pointer-events: none;
 }
 
 /* Interactive elements inside the bar must not drag the window. */
@@ -255,29 +271,27 @@ body,
   letter-spacing: 0.2px;
 }
 
-/* Tabs as a single rounded pill of segments. The + is a sibling in `.tabbar__projects`
-   so it cannot scroll away with the tabs (issue #375). The wrapper is flex:1 and is
-   NOT in the no-drag list — it is the remaining title-bar drag region. Do not put
-   flex:1 on the pill itself: that inflates an empty capsule for every 2-tab window. */
+/* The + is a sibling of the strip so it cannot scroll away with the tabs (issue #375). The
+   wrapper is flex:1 and is NOT in the no-drag list — it is the remaining title-bar drag region. */
 .tabbar__projects {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   gap: 4px;
   flex: 1;
   /* Load-bearing (issue #375): a flex item's min-width defaults to `auto`, which resolves against
-     the pill's full content width — so with many tabs the wrapper refuses to shrink and shoves
+     the strip's full content width — so with many tabs the wrapper refuses to shrink and shoves
      the + past the window edge. Measured: 1280 px / 12 projects, + at x=1382 without this. */
   min-width: 0;
 }
+
+/* Browser-style tabs: the strip is the bar's floor, each tab runs its FULL height and the active
+   one is filled with the canvas colour so its body continues into the page below. */
 .tabbar__tabs {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   gap: 2px;
-  height: 34px;
-  padding: 3px;
-  background: rgba(var(--tint-rgb), 0.05);
-  border: 1px solid var(--border);
-  border-radius: 17px;
+  align-self: stretch;
+  padding: 0;
   overflow-x: auto;
   /* Scrollable but without the native scrollbar (foreign-looking in a title-bar tab strip);
      trackpad swipe / wheel still scroll, and the active tab is scrolled into view. */
@@ -293,22 +307,44 @@ body,
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 0 12px;
-  height: 100%;
-  border-radius: 14px;
+  padding: 0 14px;
+  /* Full height of the bar, with only the TOP corners rounded — the bottom edge is where the tab
+     meets its own content. */
+  border-radius: 10px 10px 0 0;
   color: var(--muted);
   font-size: 13px;
   cursor: pointer;
   white-space: nowrap;
 }
 
-.tab:hover {
+.tab:not(.active):hover {
   background: rgba(var(--tint-rgb), 0.05);
+  color: var(--text);
 }
 
 .tab.active {
-  background: rgba(var(--tint-rgb), 0.09);
+  /* THE tab look: the active tab is a hole in the bar showing the canvas behind it. */
+  background: var(--canvas-bg);
   font-weight: 600;
+  /* Neutral, never the project colour: the fill and the weight say which tab is active and
+     `.tab__dot` says which project it is, so tinting the label would say the same thing twice. */
+  color: var(--text);
+  /* Above `.tabbar::after`, so the tab's own bottom pixel replaces the separator line and the
+     fill runs uninterrupted into the canvas. */
+  z-index: 1;
+}
+
+/* A hairline around the tab's three outer edges, drawn as an inset shadow so it costs no layout
+   and cannot round differently from the fill. Load-bearing in LIGHT, where `--canvas-bg` and
+   `--panel` are one value apart and the fill alone would be invisible. */
+.tab.active::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 1px 0 var(--border), inset 1px 0 0 var(--border),
+    inset -1px 0 0 var(--border);
+  pointer-events: none;
 }
 
 /* In the all-projects board the highlighted tab follows the selected swimlane, not necessarily
@@ -397,22 +433,6 @@ body,
   padding: 2px 6px;
   width: 120px;
   outline: none;
-}
-
-.tab__board-toggle {
-  display: inline-flex;
-  align-items: center;
-  background: transparent;
-  border: none;
-  color: currentColor;
-  cursor: pointer;
-  line-height: 1;
-  padding: 2px 2px;
-  border-radius: 4px;
-  opacity: 0.55;
-}
-.tab__board-toggle:hover {
-  opacity: 1;
 }
 
 .tab__caret {
@@ -7778,7 +7798,7 @@ button.group-node__setup:disabled {
 .ss-rowdrop.is-drop-before::before { content: ''; position: absolute; top: -1px; left: 6px; right: 6px; height: 2px; border-radius: 1px; background: var(--accent); pointer-events: none; }
 /* Project reorder: vertical insertion line before the tab / horizontal line above the
    sidebar project header the dragged project will land before */
-.tab.is-drop-before::before { content: ''; position: absolute; left: -3px; top: 4px; bottom: 4px; width: 2px; border-radius: 1px; background: var(--accent); pointer-events: none; }
+.tab.is-drop-before::before { content: ''; position: absolute; left: -3px; top: 8px; bottom: 8px; width: 2px; border-radius: 1px; background: var(--accent); pointer-events: none; }
 .ss-group { position: relative; }
 .ss-group.is-drop-before::before { content: ''; position: absolute; top: -1px; left: 6px; right: 6px; height: 2px; border-radius: 1px; background: var(--accent); pointer-events: none; z-index: 1; }
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7807,7 +7807,25 @@ button.group-node__setup:disabled {
 .ss-rowdrop.is-drop-before::before { content: ''; position: absolute; top: -1px; left: 6px; right: 6px; height: 2px; border-radius: 1px; background: var(--accent); pointer-events: none; }
 /* Project reorder: vertical insertion line before the tab / horizontal line above the
    sidebar project header the dragged project will land before */
-.tab.is-drop-before::before { content: ''; position: absolute; left: -3px; top: 8px; bottom: 8px; width: 2px; border-radius: 1px; background: var(--accent); pointer-events: none; }
+/* The insertion line, drawn INSIDE the tab it lands in front of. Two things it must not do:
+   hang outside the tab (at `left: -3px` the first tab's line fell outside `.tabbar__tabs`, which
+   is `overflow-x: auto` and clipped it — so the leftmost drop target showed nothing), and sit
+   under the ACTIVE tab, whose `z-index: 1` swallowed it whenever the target was the tab right
+   after it. Hence `left: 0` and z-index 2. */
+.tab.is-drop-before::before { content: ''; position: absolute; left: 0; top: 8px; bottom: 8px; width: 2px; border-radius: 1px; background: var(--accent); pointer-events: none; z-index: 2; }
+
+/* The same line for "after the last tab", which has no tab to hang off. A real flex item rather
+   than a pseudo-element: the strip scrolls, and an absolutely positioned marker on a scroll
+   container drifts away from the end it is marking. The -1px side margins cancel its 2px width,
+   so the tabs do not shift when it appears. */
+.tab__dropline {
+  flex: 0 0 2px;
+  align-self: stretch;
+  margin: 8px -1px;
+  border-radius: 1px;
+  background: var(--accent);
+  pointer-events: none;
+}
 .ss-group { position: relative; }
 .ss-group.is-drop-before::before { content: ''; position: absolute; top: -1px; left: 6px; right: 6px; height: 2px; border-radius: 1px; background: var(--accent); pointer-events: none; z-index: 1; }
 


### PR DESCRIPTION
The project tabs now read as tabs. The strip was a 34px segmented pill floating inside the 44px bar, which read as a control sitting on a surface rather than as the surface's own edge. Tabs now run the full height of the bar, and the active one is filled with `--canvas-bg` so its body continues into the canvas below it. Every tab also gets its options button, so reaching another project's menu no longer means switching to it first.

![The project tab strip: a full-height active tab open into the canvas, an options button on every tab](https://dropoff.sh/p/eqsiu67arri.png)

## What changed, and why

**The active tab is a hole in the bar.** To let it break the separator between bar and canvas, that line moves off `.tabbar`'s `border-bottom` onto a `z-index: auto` `::after` that the raised tab paints over. In the light theme `--panel` and `--canvas-bg` are one value apart, so the active tab carries an inset hairline on its two sides. Those hairlines rendered two grades darker than the bar's own rule, because `--border` is an alpha and the bar composites it over `--panel` while the tab edges sit over `--canvas-bg` (#000 in dark). A second shadow pair in `--panel`, listed last so it paints behind, gives them the same ground and the same rendered colour. The top hairline is gone: a lid on a shape whose point is that it opens into the canvas.

**Tabs touch.** `gap: 0`, since the hairlines are the seams and a strip of bar between two tabs read as a segmented control again. The `+` keeps an 8px margin so it stays a separate action rather than the next tab in a gapless row, and it moves 6px closer to the strip it ends.

**One font weight.** The active tab was 600 against 400 elsewhere, so switching projects reflowed the whole strip. 500 for every tab keeps the metrics still. The fill already says which tab is active, and the label stays neutral rather than the project colour, which was barely legible as 13px type on a near-black strip for a dark blue or deep red project.

**The options button is on every tab.** It used to render only for the active tab, at opacity 0 until hovered, so nothing on screen said the menu existed. It now shows on every tab at a resting opacity and brightens on hover, with a tinted plate under the glyph the way a node's header buttons do. The glyph is a vertical ellipsis. A chevron reads as "expand this", and a horizontal ellipsis beside the tab name reads as a separator. Opening the menu on an inactive tab does not switch to it.

**The two tab actions are one pair.** The view toggle and the options button share one recipe (plate on hover, 14px glyph, the same opacities) and sit in a `.tab__actions` cluster with a fixed 22px square each. The board glyph runs its bars edge to edge while the three dots stand alone in the middle, so padding around each glyph gave them hover plates of two different widths. The toggle also carries an aria-label, and a comment records why it renders on the active tab only: on an inactive tab it would flip that project's view without taking you there.

**The menu closes on a press anywhere outside it.** Its dismiss backdrop sits below the bar on purpose (z 25 against the bar's 30) so a click on another tab switches in one go instead of being swallowed. That left the bar itself, its empty stretch, the brand and the `+` with no way to close the menu. A capture-phase `pointerdown` listener covers that gap without consuming the event; the caret is excluded because it owns its own toggle.

**The drop line is visible again at both ends.** Reordering worked but stopped saying where the tab would land. The line hung at `left: -3px`, which the scrolling `.tabbar__tabs` clipped for the first tab; with `gap: 0` it sat on the seam the active tab's `z-index: 1` painted over; and the end-of-strip zone never had a marker, since every other target draws its line as the `::before` of the tab it lands in front of. Now `left: 0`, `z-index: 2`, and a `.tab__dropline` flex item whose -1px side margins cancel its width so nothing shifts when it appears.

## Tests

`TabBar.test.tsx` gains drag-reorder tests (drop on a tab, drop at the end, both markers), tests for the options button on inactive tabs and for the outside-press dismiss. Two older suites in that file had been written against module-scope imports the file no longer has and are moved onto the per-test `load()`.

## Verified

Typecheck and the TabBar suite pass. I built the branch and drove it with Playwright on macOS: three projects, all three tabs measure 44px against a 44px bar, all three at weight 500, an options button on each, opening the menu on an inactive tab leaves the active tab where it was, and a press on the empty bar closes it. Not verified on a real device: the light theme (the hairline reasoning is from the CSS, screenshots were dark only), Windows and Linux, and the Server Edition, though nothing here touches a bridge or IPC.
