### PR TITLE
chore(release): v0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-terminal",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "engines": {
     "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   },


### PR DESCRIPTION
Version bump 0.3.4 → 0.3.5 for the v0.3.5 release — 265 commits since v0.3.4 (canvas UI sweep, shared Codex daemon spine, trigger phases, grok parity, cold-restore fixes, monaco/dep bumps and the rest of the wave). The v0.3.5 tag will be pushed onto this bump commit once it lands on main, triggering the mac sign+notarize / linux / win release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BK7rDFLNonxfXeCpfrroGN