### PR TITLE
fix(copilot): preserve selected model on restart

### DIFF
--- a/docs/copilot-agent.md
+++ b/docs/copilot-agent.md
@@ -12,7 +12,8 @@ CLI reference:
 - `copilot --interactive <prompt>` opens the normal interactive TUI and submits the initial prompt;
   `--prompt` is non-interactive and exits after the response.
 - `--session-id=<uuid>` creates a caller-addressable session, `--resume=<uuid>` resumes it, `/exit`
-  cleanly returns to the shell, and `--model` selects a GitHub-routed model.
+  cleanly returns to the shell, and `--model` (or `COPILOT_MODEL`) selects the startup model,
+  including in BYOK mode.
 - BYOK mode activates through `COPILOT_PROVIDER_BASE_URL`. The implementation also sets
   `COPILOT_PROVIDER_TYPE`, `COPILOT_PROVIDER_API_KEY`, `COPILOT_PROVIDER_MODEL_ID`, and
   `COPILOT_PROVIDER_WIRE_MODEL`; GPT-5-family OpenAI models use
@@ -24,6 +25,7 @@ CLI reference:
 Primary references:
 
 - <https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-programmatic-reference>
+- <https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-byok-models>
 - <https://docs.github.com/en/copilot/reference/hooks-reference>
 - <https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-custom-instructions>
 
@@ -42,10 +44,15 @@ model:
 - Every other provider-prefixed model uses provider type `openai`, base URL `<root>/openai/v1`, an
   unprefixed internal id, and the original provider-prefixed wire id.
 
+Launch and resume commands also pass `--model <internal-id>` explicitly. The provider metadata
+variables do not replace Copilot's startup selection, and an ordinary in-place restart reuses the
+existing shell environment. The flag must match `COPILOT_PROVIDER_MODEL_ID`; the provider-prefixed
+gateway id remains in `COPILOT_PROVIDER_WIRE_MODEL`.
+
 Copilot BYOK is not activated merely because gateway settings exist: a model must be selected for
 that node first. This preserves ordinary GitHub Copilot routing for untouched nodes. Model changes
-recycle the tmux session after a clean `/exit`, then cold-resume the same Copilot session under the
-new environment; the key is never typed into the pane.
+stop the agent's foreground process group, recycle the tmux session, then cold-resume the same
+Copilot session under the new environment; the key is never typed into the pane.
 
 ## Status hooks
 

--- a/src/core/pty-single-user.test.ts
+++ b/src/core/pty-single-user.test.ts
@@ -298,7 +298,7 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     }
   })
 
-  it('maps a selected Copilot model into its BYOK environment, never a model flag', async () => {
+  it('maps Copilot provider metadata into the spawn environment without exposing credentials on argv', async () => {
     const { PtyManager } = await import('./pty-manager')
     const m = new PtyManager()
     m.init(() => ({
@@ -324,7 +324,8 @@ describe('SINGLE-USER REGRESSION: co-attach must not change the solo path', () =
     // never the argv (see the claude case above for why).
     expect(spawnArgs[0].args.join(' ')).not.toContain('vk-secret')
     expect(spawnArgs[0].args.join(' ')).not.toContain('COPILOT_PROVIDER')
-    expect(spawnArgs[0].args.join(' ')).not.toContain('--model')
+    // This is the tmux client's argv. Copilot's --model selection is delivered later by the
+    // shared launch/resume command assembler, using this provider's internal model id.
   })
 
   it('reads a stored gateway key through the shell-owned secret cache', async () => {

--- a/src/shared/agents/launch.test.ts
+++ b/src/shared/agents/launch.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
 import { assembleLaunchCommand, assembleResumeCommand, promptFilePathError } from './launch'
 import { setCustomAgentBaseResolver } from './config'
+import { modelGatewayEnv } from './model-gateway'
 import type { CustomAgent } from '../types'
 
 const ENV = { MY_MODEL: 'sonnet', MY_TOKEN: 'sk-abc' }
@@ -157,13 +159,44 @@ describe('assembleLaunchCommand — builtins (byte-identical to the historical p
 })
 
 describe('assembleResumeCommand — Copilot', () => {
-  it('uses Copilot resume grammar while leaving a gateway model to the environment', () => {
+  it('resumes the same conversation with an explicit internal model selection', () => {
     expect(
       assembleResumeCommand(
         { agentId: 'copilot', sessionId: 'abc-123', model: 'openai/gpt-5.5' },
         ENV
       ).command
-    ).toBe('copilot --resume=abc-123')
+    ).toBe("copilot --resume=abc-123 --model 'gpt-5.5'")
+  })
+
+  it.skipIf(process.platform === 'win32').each([
+    ['openai/gpt-5.5', 'gpt-5.5'],
+    ['anthropic/claude-sonnet-4.6', 'claude-sonnet-4.6'],
+    ['custom/org/model', 'org/model'],
+    ["custom/o'model; $(exit 42)", "o'model; $(exit 42)"]
+  ])('delivers %s on fresh launch and restart, preserving its separate wire id', (wireModel, modelId) => {
+    const env = modelGatewayEnv(
+      { baseUrl: 'https://gateway.example.test', apiKey: 'test-key' },
+      'copilot',
+      wireModel
+    )
+    // Run the generated commands in a real shell with a harmless CLI stand-in. There is no
+    // COPILOT_MODEL in this old shell: --model must select the model on an in-place restart too.
+    const probe = 'copilot() { printf "%s\\n" "$COPILOT_PROVIDER_WIRE_MODEL" "$@"; }; '
+    for (const resume of [false, true]) {
+      const { command } = resume
+        ? assembleResumeCommand({ agentId: 'copilot', sessionId: 'abc-123', model: wireModel }, {})
+        : assembleLaunchCommand({ agentId: 'copilot', model: wireModel }, {})
+      const output = execFileSync('/bin/sh', ['-c', probe + command], {
+        env,
+        encoding: 'utf8'
+      })
+      expect(output.trimEnd().split('\n')).toEqual([
+        wireModel,
+        ...(resume ? ['--resume=abc-123'] : []),
+        '--model',
+        modelId
+      ])
+    }
   })
 })
 

--- a/src/shared/agents/model-gateway.test.ts
+++ b/src/shared/agents/model-gateway.test.ts
@@ -153,9 +153,19 @@ describe('agent mappings', () => {
 
   it('does not activate Copilot BYOK until a model is selected', () => {
     expect(modelGatewayEnv(gateway, 'copilot')).toEqual({})
-    expect(withAgentModel('copilot --resume=abc', 'copilot', 'openai/gpt-5.5')).toBe(
+    expect(withAgentModel('copilot --resume=abc', 'copilot', undefined)).toBe(
       'copilot --resume=abc'
     )
+  })
+
+  it('selects the Copilot internal model explicitly without changing its gateway wire id', () => {
+    expect(withAgentModel('copilot --resume=abc', 'copilot', 'openai/gpt-5.5')).toBe(
+      "copilot --resume=abc --model 'gpt-5.5'"
+    )
+    expect(withAgentModel('copilot', 'copilot', 'claude-sonnet-4.6')).toBe(
+      "copilot --model 'claude-sonnet-4.6'"
+    )
+    expect(withAgentModel('copilot', 'copilot', 'bad\nmodel')).toBe('copilot')
   })
 
   it('quotes model ids and refuses unsupported/control-bearing values', () => {
@@ -218,7 +228,7 @@ describe('agent mappings', () => {
       })
       expect(
         withAgentModel('copilot-wrapper', 'custom:copilot-proxy', 'openai/gpt-5.5')
-      ).toBe('copilot-wrapper')
+      ).toBe("copilot-wrapper --model 'gpt-5.5'")
     } finally {
       setCustomAgentBaseResolver(null)
     }

--- a/src/shared/agents/model-gateway.ts
+++ b/src/shared/agents/model-gateway.ts
@@ -264,6 +264,14 @@ export function tmuxUpdateEnvironmentLine(extraNames: readonly string[] = []): s
   return `set -g update-environment "${names.join(' ')}"`
 }
 
+/** Copilot selects the provider's internal model id; the gateway keeps the full wire id. */
+function copilotModelParts(wireModel: string): { provider: string; modelId: string } {
+  const slash = wireModel.indexOf('/')
+  return slash > 0
+    ? { provider: wireModel.slice(0, slash).toLowerCase(), modelId: wireModel.slice(slash + 1) }
+    : { provider: '', modelId: wireModel }
+}
+
 export function modelGatewayEnv(
   settings: ModelGatewaySettings,
   agentId: AgentId,
@@ -299,9 +307,7 @@ export function modelGatewayEnv(
       // would activate an incomplete provider and make every new Copilot node fail to launch.
       const wireModel = normalizedAgentModel(agentId, model)
       if (!wireModel) return {}
-      const slash = wireModel.indexOf('/')
-      const provider = slash > 0 ? wireModel.slice(0, slash).toLowerCase() : ''
-      const modelId = slash > 0 ? wireModel.slice(slash + 1) : wireModel
+      const { provider, modelId } = copilotModelParts(wireModel)
       const anthropic = provider === 'anthropic'
       return {
         COPILOT_PROVIDER_BASE_URL: anthropic ? routes.anthropic : routes.openai,
@@ -351,9 +357,9 @@ export function normalizedAgentModel(agentId: AgentId, model: string | undefined
 export function withAgentModel(cmd: string, agentId: AgentId, model: string | undefined): string {
   const value = normalizedAgentModel(agentId, model)
   if (!value) return cmd
-  // Copilot receives the model through COPILOT_PROVIDER_MODEL_ID/WIRE_MODEL. Appending --model
-  // would collapse those two distinct values back together and send the unrecognized
-  // provider-prefixed Bifrost id through Copilot's internal catalogue.
-  if (capabilityAgentId(agentId) === 'copilot') return cmd
-  return `${cmd} --model ${shellSingleQuote(value)}`
+  // COPILOT_PROVIDER_MODEL_ID/WIRE_MODEL describe the provider; Copilot still requires a startup
+  // selection via --model or COPILOT_MODEL. Use a flag so an in-place restart also selects it in
+  // an existing shell. Match the internal id above, keeping the gateway prefix in WIRE_MODEL only.
+  const modelId = capabilityAgentId(agentId) === 'copilot' ? copilotModelParts(value).modelId : value
+  return `${cmd} --model ${shellSingleQuote(modelId)}`
 }


### PR DESCRIPTION
Copilot launches and restarts omitted the startup model selection. The provider metadata variables do not replace `--model` or `COPILOT_MODEL`, and an in-place restart reuses its existing shell. See [GitHub's model configuration documentation](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-byok-models).

Pass the selected internal model ID explicitly on launch and resume. For example, `openai/gpt-5.5` now resumes with `--model 'gpt-5.5'`, while the gateway still receives `openai/gpt-5.5` through `COPILOT_PROVIDER_WIRE_MODEL`. Copilot-based custom agents use the same mapping.

Validation:

- 186 targeted tests passed, including real `/bin/sh` checks for launch, resume, quoting, and wire-model separation.
- `npm run typecheck` and `git diff --check` passed.
- Live authenticated Copilot/gateway validation remains outstanding.

Desktop and Server Edition share this command builder. No mobile API or UI change is required.