### PR TITLE
Worktree removal: let the agent-raised dialog collect itself, through #740's hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2052,10 +2052,22 @@ else, and its context links must keep classifying across restarts).
   (the other direction would abandon a dialog whose answer main would still accept); it replies
   `expired` rather than `denied by user` (nobody denied anything, and a reply main has already
   timed out is simply dropped); and the notice is a fading info strip, because raising an alert
-  would keep `confirmBusy()` true — i.e. reproduce the bug with better wording. `close-worktree
-  --mode remove`'s dialog is deliberately outside this: it replies to the CLI immediately
-  ("the user decides") so there is no pending request to expire — its own `confirmBusy` hold is a
-  separate, still-open gap.
+  would keep `confirmBusy()` true — i.e. reproduce the bug with better wording.
+  **`close-worktree --mode remove`'s dialog expires too** (2026-09-11), through the SAME
+  `renderer/lib/useExpiringDialog.ts` the confirm uses — the rule was extracted rather than copied,
+  because a second effect beside the first is how one gains a fix the other silently lacks. Three
+  differences to keep in mind, all deliberate: it carries **no `onExpire`** (the verb replies
+  "removal confirmation shown to the user — they decide" the instant the dialog opens, so nobody is
+  waiting on an answer and an `onExpire` would be a reply to a call that finished minutes ago); its
+  clear must also release **`removePendingRef`**, the guard covering the async `git.status` gap
+  before `removeTarget` exists, which `confirmBusy()` reads directly — dropping the state while
+  leaving that ref latched closes the dialog and keeps refusing every later destructive verb, i.e.
+  the bug minus the only thing on screen that explained it; and the deadline is set **only when
+  `requestedBy` is present**, because a removal the USER opened from the group menu must never
+  vanish under them. It reuses `confirmExpiresAt` rather than inventing a second timeout: the fact
+  is the same class ("an agent asked and the human is not at the machine"), and this is the most
+  dangerous dialog to leave lying around — the one carrying a pre-ticked delete-from-disk choice on
+  a worktree the human never asked about.
   **MEASURED, and the answer is no: two canvases cannot raise two dialogs for one request.** The
   suspicion was worth checking because the same project can be open on a desktop and in a Server
   Edition browser at once. Desktop main forwards each request to `getMainWindow()` — one

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,12 @@ lane unaffected.
   refusal was retryable, retried into it in a loop. If you raise a dialog for a bounded request,
   give it the deadline (`ConfirmState.expiresAt`), import the bound rather than re-typing it, have
   it expire slightly AFTER the requester gives up, and answer with "expired" — never "denied by
-  user", which claims a decision the human never made.
+  user", which claims a decision the human never made. Reach for the existing
+  `useExpiringDialog` hook rather than a second effect: the worktree-removal dialog needed the
+  identical rule a day later, and two copies is how one of them quietly misses the next fix. Give
+  the deadline only to a dialog an AGENT raised — one the user opened themselves must never vanish
+  under them — and remember that clearing a dialog is not always just nulling its state (that one
+  also has to release the ref its own busy-guard reads).
 
 - **Anything path-shaped: Windows is a delivery target.** Most of this was written on
   macOS/Linux, so the recurring defect is code that is genuinely correct on POSIX —

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -525,6 +525,7 @@ import { chordHeld, isHoldChord, isModifierEventKey, matchesShortcut } from '@sh
 // write/close as "the confirm-gated pair" from inside `src/main` — which this project cannot see —
 // while the gating lived in two hand-written blocks here, so the set decided nothing.
 import { isDestructiveVerb, dryRunRequested } from '@shared/control-verbs'
+import { useExpiringDialog } from '../lib/useExpiringDialog'
 import {
   confirmExpiresAt,
   isWaivableVerb,
@@ -688,6 +689,21 @@ interface RemoveState {
   /** Set when an AGENT asked (canvas-control `close-worktree --mode remove`); the dialog says so,
    *  exactly like the agent `write`/`close` confirms do — AND refuses to be confirmed by keyboard. */
   requestedBy?: string
+  /**
+   * When this dialog collects itself unanswered (`useExpiringDialog`). Set ONLY for an
+   * agent-requested removal — a removal the USER opened from the group menu must never vanish
+   * under them.
+   *
+   * There is deliberately no `onExpire` to go with it, and the asymmetry with `ConfirmState` is
+   * the point: `close-worktree --mode remove` replies to the CLI the instant the dialog opens
+   * ("removal confirmation shown to the user — they decide"), so nobody is waiting on an answer
+   * and there is nothing to tell. What the expiry buys here is the OTHER half of PR #740's bug —
+   * this dialog holds `confirmBusy()` (and `removePendingRef`) while it is open, so an unanswered
+   * one refuses every later destructive verb for the rest of the app run. It is also the most
+   * dangerous dialog to leave lying around: it is the one with a pre-ticked delete-from-disk
+   * choice on a worktree the human never asked about.
+   */
+  expiresAt?: number
 }
 interface MergeState {
   repoPath: string
@@ -1611,40 +1627,43 @@ export function Canvas() {
    * node asked about again and again, because the agent was told to retry and every retry hit a
    * dialog that could no longer be answered.
    *
-   * It replies `expired` on the way out rather than cancelling: `denied by user` would be a lie
-   * about a decision the human never made, and a reply main has already timed out is simply
-   * dropped (`if (!pending) return`). If the renderer's timer fires while main IS still waiting —
-   * a background tab's throttled `setTimeout`, a clock jump — that reply is what stops the caller
-   * waiting out the remaining budget for a dialog that is gone.
+   * It replies `expired` on the way out rather than cancelling (`ConfirmState.onExpire`):
+   * `denied by user` would be a lie about a decision the human never made, and a reply main has
+   * already timed out is simply dropped (`if (!pending) return`). If the renderer's timer fires
+   * while main IS still waiting — a background tab's throttled `setTimeout`, a clock jump — that
+   * reply is what stops the caller waiting out the remaining budget for a dialog that is gone.
    *
-   * The notice is deliberately non-blocking: raising an alert would keep `confirmBusy` true, i.e.
-   * reproduce the bug this closes with better wording.
+   * The timer, the already-past case and the notice live in `useExpiringDialog`, shared with the
+   * worktree-removal dialog below — one rule, one implementation.
    */
-  useEffect(() => {
-    const at = confirm?.expiresAt
-    if (!at) return
-    const fire = (): void => {
-      confirm?.onExpire?.()
-      setConfirm(null)
-      setNotice({
-        kind: 'info',
-        text: `The request from ${confirm?.requestedBy ?? 'an agent'} expired before it was answered — nothing was done.`
-      })
-    }
-    const ms = at - Date.now()
-    if (ms <= 0) {
-      fire()
-      return
-    }
-    const t = setTimeout(fire, ms)
-    return () => clearTimeout(t)
-    // `confirm` is replaced wholesale per dialog, so its identity is the right key.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [confirm, setConfirm])
+  useExpiringDialog(
+    confirm,
+    () => setConfirm(null),
+    (text) => setNotice({ kind: 'info', text })
+  )
   const setRemoveTarget = useCallback((v: RemoveState | null) => {
     confirmFlags.current.remove = !!v
     setRemoveTargetState(v)
   }, [])
+  /**
+   * The same rule for the worktree-removal dialog (`close-worktree --mode remove`), through the
+   * same hook — PR #740 closed this for the canvas-control confirm and left this one open.
+   *
+   * It needs no `onExpire`: the verb answered its caller the moment the dialog opened, so nobody is
+   * waiting. It DOES need `removePendingRef` released. That ref covers the async gap in
+   * `requestRemoveWorktree` (the `git.status` probe runs before `removeTarget` exists) and
+   * `confirmBusy()` reads it directly, so dropping the state while leaving the ref latched would
+   * close this dialog and keep refusing every later destructive verb anyway — the bug, minus the
+   * only thing on screen that explained it. Both answer paths already clear it; this is the third.
+   */
+  useExpiringDialog(
+    removeTarget,
+    () => {
+      removePendingRef.current = false
+      setRemoveTarget(null)
+    },
+    (text) => setNotice({ kind: 'info', text })
+  )
   const setMoveTarget = useCallback((v: string | null) => {
     confirmFlags.current.move = !!v
     setMoveTargetState(v)
@@ -5758,7 +5777,12 @@ export function Canvas() {
           canDelete: wt.createdByApp,
           branch: wt.branch,
           path: wt.path,
-          requestedBy: opts?.requestedBy
+          requestedBy: opts?.requestedBy,
+          // An AGENT-raised dialog gets a deadline; a removal the user opened themselves never
+          // does. Same budget as a control request (`confirmExpiresAt`) because it is the same
+          // class of fact — "an agent asked and the human is not at the machine" — and one number
+          // beats two that mean the same thing.
+          expiresAt: opts?.requestedBy ? confirmExpiresAt(Date.now()) : undefined
         })
         return { ok: true }
       } catch (e) {

--- a/src/renderer/canvas/worktree-confirm-expiry.source.test.ts
+++ b/src/renderer/canvas/worktree-confirm-expiry.source.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * A SOURCE test, for the same reason `control-destructive.test.ts` is one: the wiring lives inside
+ * an 11k-line component's hooks and there is no render harness for it. The BEHAVIOUR of the expiry
+ * is proven in `renderer/lib/useExpiringDialog.test.tsx` with real timers; what cannot be reached
+ * from there is whether Canvas actually hands the worktree-removal dialog to that hook — and the
+ * failure mode is silence, since a dialog that never expires looks exactly like a dialog nobody
+ * happened to leave open.
+ *
+ * PR #740 gave the canvas-control confirm a deadline and left this dialog — the DANGEROUS one,
+ * carrying a pre-ticked delete-from-disk choice — holding `confirmBusy()` forever.
+ */
+const src = readFileSync(new URL('./Canvas.tsx', import.meta.url), 'utf8').replace(/\r\n/g, '\n')
+
+describe('the worktree-removal dialog collects itself, through the SHARED hook', () => {
+  it('both expiring dialogs go through useExpiringDialog — no second copy of the rule', () => {
+    expect(src).toMatch(/import \{ useExpiringDialog \} from '\.\.\/lib\/useExpiringDialog'/)
+    // Exactly two callers: the canvas-control confirm and the worktree-removal dialog.
+    expect(src.match(/useExpiringDialog\(/g)).toHaveLength(2)
+    // …and the timer itself is not re-implemented beside them. A bare `setTimeout` that clears a
+    // dialog state is the copy this test exists to forbid.
+    // Non-greedy across the arrow body, because the copy to forbid looks like
+    // `setTimeout(() => setRemoveTarget(null), …)` — a `[^)]*` class stops at the arrow's own
+    // parens and matches nothing, which is how this assertion first passed a real second copy.
+    expect(src).not.toMatch(/setTimeout\([\s\S]{0,200}?setRemoveTarget/)
+    expect(src).not.toMatch(/setTimeout\([\s\S]{0,200}?setConfirm\(null\)/)
+  })
+
+  it('the removal dialog releases removePendingRef when it expires', () => {
+    // `confirmBusy()` reads that ref directly (it covers the async `git.status` gap before
+    // `removeTarget` exists), so an expiry that dropped the state and left the ref latched would
+    // keep refusing every later destructive verb — the bug, minus the dialog that explained it.
+    const call = src.slice(src.indexOf('useExpiringDialog(\n    removeTarget,'))
+    expect(call).not.toBe('')
+    const body = call.slice(0, call.indexOf('\n  )'))
+    expect(body).toContain('removePendingRef.current = false')
+    expect(body).toContain('setRemoveTarget(null)')
+  })
+
+  it('only an AGENT-requested removal gets a deadline', () => {
+    // A removal the USER opened from the group menu must never vanish under them: they asked for
+    // it and they are looking at it. The deadline is conditional on `requestedBy`, which is set
+    // only by the canvas-control path.
+    expect(src).toContain(
+      'expiresAt: opts?.requestedBy ? confirmExpiresAt(Date.now()) : undefined'
+    )
+  })
+
+  it('the removal dialog has NO onExpire — its caller was already answered', () => {
+    // `close-worktree --mode remove` replies "removal confirmation shown to the user — they
+    // decide" the instant the dialog opens, so there is nobody left to tell. An `onExpire` here
+    // would be a reply to a call that finished minutes ago.
+    const call = src.slice(src.indexOf('useExpiringDialog(\n    removeTarget,'))
+    const body = call.slice(0, call.indexOf('\n  )'))
+    expect(body).not.toContain('onExpire')
+  })
+
+  it('the deadline is the shared control-request budget, not a second number', () => {
+    expect(src).toMatch(/from '@shared\/control-confirm'/)
+    // No freshly invented timeout beside it.
+    expect(src).not.toMatch(/const\s+\w*REMOVE\w*TIMEOUT\w*\s*=/i)
+  })
+})

--- a/src/renderer/lib/useExpiringDialog.test.tsx
+++ b/src/renderer/lib/useExpiringDialog.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+//
+// The hook that stops an unanswered agent-raised dialog from wedging every later destructive verb.
+// Tested behaviourally (timers, not source reads) because the failure modes are all about WHEN it
+// fires: a dialog that never expires is the bug, and one that expires while the user is reading it
+// is worse than the bug.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+
+import { useExpiringDialog, type ExpiringDialog } from './useExpiringDialog'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let root: Root
+let host: HTMLElement
+let cleared: number
+let notices: string[]
+
+function Harness({ dialog }: { dialog: ExpiringDialog | null }): null {
+  useExpiringDialog(
+    dialog,
+    () => {
+      cleared += 1
+    },
+    (text) => notices.push(text)
+  )
+  return null
+}
+
+async function render(dialog: ExpiringDialog | null): Promise<void> {
+  await act(async () => {
+    root.render(<Harness dialog={dialog} />)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-09-11T12:00:00Z'))
+  cleared = 0
+  notices = []
+  host = document.createElement('div')
+  document.body.appendChild(host)
+  root = createRoot(host)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  host.remove()
+  vi.useRealTimers()
+})
+
+describe('useExpiringDialog', () => {
+  it('clears the dialog and raises ONE notice at the deadline', async () => {
+    await render({ expiresAt: Date.now() + 1000, requestedBy: 'orchestrator' })
+    expect(cleared).toBe(0)
+    await act(async () => {
+      vi.advanceTimersByTime(999)
+    })
+    // Not a millisecond early: the user may still be reading it.
+    expect(cleared).toBe(0)
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(cleared).toBe(1)
+    expect(notices).toHaveLength(1)
+    expect(notices[0]).toContain('orchestrator')
+    expect(notices[0]).toContain('nothing was done')
+  })
+
+  it('never expires a dialog with no deadline — that is every human-opened one', async () => {
+    await render({ requestedBy: undefined })
+    await act(async () => {
+      vi.advanceTimersByTime(10 * 60_000)
+    })
+    expect(cleared).toBe(0)
+    expect(notices).toEqual([])
+  })
+
+  it('does nothing when there is no dialog at all', async () => {
+    await render(null)
+    await act(async () => {
+      vi.advanceTimersByTime(10 * 60_000)
+    })
+    expect(cleared).toBe(0)
+  })
+
+  it('fires immediately for a deadline already in the past', async () => {
+    // Reachable: a suspended tab whose timers were throttled across the deadline. Arming a
+    // negative timeout would be indistinguishable from never expiring.
+    await render({ expiresAt: Date.now() - 1 })
+    expect(cleared).toBe(1)
+    expect(notices).toHaveLength(1)
+  })
+
+  it('names "an agent" when the dialog does not say who asked', async () => {
+    await render({ expiresAt: Date.now() - 1 })
+    expect(notices[0]).toContain('an agent')
+  })
+
+  it('re-arms for a NEW dialog and cancels the old timer', async () => {
+    const first = { expiresAt: Date.now() + 1000, requestedBy: 'first' }
+    await render(first)
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+    // A second dialog replaces the first (the dispatch refuses this today, but the hook must not
+    // depend on that): the first one's timer must not fire against the second one's state.
+    await render({ expiresAt: Date.now() + 1000, requestedBy: 'second' })
+    await act(async () => {
+      vi.advanceTimersByTime(999)
+    })
+    expect(cleared).toBe(0)
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(cleared).toBe(1)
+    expect(notices[0]).toContain('second')
+  })
+
+  it('keeps an ABSOLUTE deadline, so re-renders cannot postpone it', async () => {
+    const dialog = { expiresAt: Date.now() + 1000, requestedBy: 'orchestrator' }
+    await render(dialog)
+    await act(async () => {
+      vi.advanceTimersByTime(900)
+    })
+    // Re-render with the same dialog 100 ms before the deadline. This is what a duration-based
+    // timer would get wrong: re-arming "1000 ms from now" on a canvas that re-renders constantly
+    // would push the expiry out indefinitely, which is the wedged-dialog bug wearing a timer.
+    // (The effect's `[dialog]` key also avoids the churn, but the absolute deadline is what makes
+    // the behaviour correct rather than merely cheap.)
+    await render(dialog)
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(cleared).toBe(1)
+  })
+
+  it('stops when the dialog is answered before the deadline', async () => {
+    await render({ expiresAt: Date.now() + 1000, requestedBy: 'orchestrator' })
+    await render(null)
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(cleared).toBe(0)
+    expect(notices).toEqual([])
+  })
+
+  it('calls onExpire exactly once, for a caller that still owes a reply', async () => {
+    // The canvas-control confirm uses this to answer `expired` instead of leaving its caller to
+    // wait out main's budget. Order against `clear()` is deliberately NOT asserted: `onExpire` is
+    // captured from the closure, so it fires either way, and pinning an order nothing depends on
+    // is a test that can only ever obstruct a refactor.
+    let replies = 0
+    await act(async () => {
+      root.render(
+        <Harness dialog={{ expiresAt: Date.now() + 10, onExpire: () => (replies += 1) }} />
+      )
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(10)
+    })
+    expect(replies).toBe(1)
+    expect(cleared).toBe(1)
+    // …and it does not keep firing afterwards.
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(replies).toBe(1)
+  })
+
+  it('tolerates a dialog with no onExpire — nobody is waiting on that one', async () => {
+    // `close-worktree --mode remove` answers its caller the moment the dialog opens.
+    await render({ expiresAt: Date.now() + 10, requestedBy: 'orchestrator' })
+    await act(async () => {
+      vi.advanceTimersByTime(10)
+    })
+    expect(cleared).toBe(1)
+    expect(notices).toHaveLength(1)
+  })
+})

--- a/src/renderer/lib/useExpiringDialog.ts
+++ b/src/renderer/lib/useExpiringDialog.ts
@@ -1,0 +1,69 @@
+import { useEffect } from 'react'
+
+import { expiredDialogNotice } from '@shared/control-confirm'
+
+/**
+ * The little an expiring dialog's state must carry. Structural, not a named union: the two dialogs
+ * that use this (`ConfirmState`, `RemoveState`) have nothing else in common and should not be made
+ * to share a type for the sake of one hook.
+ */
+export interface ExpiringDialog {
+  /** `Date.now()`-scale deadline. ABSENT = never expires, which is every human-opened dialog. */
+  expiresAt?: number
+  /** Named in the notice. Absent ⇒ "an agent", since only an agent-raised dialog gets a deadline. */
+  requestedBy?: string
+  /** The dialog's chance to answer whoever is still waiting on it. Optional: a dialog whose caller
+   *  was already replied to has nobody to tell (see `close-worktree --mode remove`). */
+  onExpire?: () => void
+}
+
+/**
+ * Collect an agent-raised dialog that nobody answered.
+ *
+ * WHY THIS EXISTS AT ALL, and it is not really about tidiness: these dialogs are serialized by
+ * `confirmBusy()`, so one that stays open does not merely sit there — it REFUSES every later
+ * destructive verb with "a confirmation is already pending — try again" for the rest of the app
+ * run. The agent is told that refusal is retryable, so it retries into the same wall, and the
+ * moment the human finally answers the stale dialog a queued retry raises a fresh one. That loop
+ * was the "the same dialog keeps coming back" report (PR #740).
+ *
+ * EXTRACTED rather than copied. The rule was written once for the canvas-control confirm and the
+ * worktree-removal dialog needed the identical behaviour; a second effect beside the first is how
+ * the two would drift — one gaining a fix the other silently lacks, which is the defect shape this
+ * repo keeps paying for. Both callers pass their own `clear`, because releasing a dialog is not
+ * uniform: the removal dialog also has to release `removePendingRef`, the guard that covers the
+ * async gap before its state exists, and an expiry that dropped the state while leaving that ref
+ * latched would reproduce the very bug it is closing.
+ *
+ * `dialog` is expected to be REPLACED wholesale per dialog (both callers hold it in `useState`),
+ * so its identity is the effect's key: a re-render with the same object neither re-arms nor
+ * cancels the timer.
+ */
+export function useExpiringDialog(
+  dialog: ExpiringDialog | null | undefined,
+  clear: () => void,
+  notify: (text: string) => void
+): void {
+  useEffect(() => {
+    const at = dialog?.expiresAt
+    if (!at) return
+    const fire = (): void => {
+      dialog?.onExpire?.()
+      clear()
+      // Non-blocking on purpose: an alert would itself be a confirm state, i.e. it would keep
+      // `confirmBusy` true and reproduce the bug with better wording.
+      notify(expiredDialogNotice(dialog?.requestedBy))
+    }
+    // Already past — a deadline can be in the past when the state is restored or the tab was
+    // suspended across it. Fire now rather than arming a negative timeout.
+    const ms = at - Date.now()
+    if (ms <= 0) {
+      fire()
+      return
+    }
+    const t = setTimeout(fire, ms)
+    return () => clearTimeout(t)
+    // `dialog` identity is the key; `clear`/`notify` are stable setters from the caller.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dialog])
+}

--- a/src/shared/control-confirm.test.ts
+++ b/src/shared/control-confirm.test.ts
@@ -5,6 +5,7 @@ import {
   CONTROL_REQUEST_TIMEOUT_MS,
   confirmExpiresAt,
   decideControlConfirm,
+  expiredDialogNotice,
   isWaivableVerb,
   sanitizeControlConfirmWaivers,
   waivedNotice
@@ -169,6 +170,28 @@ describe('the dialog deadline', () => {
     // Later than main started waiting, never earlier: the renderer receives the request after the
     // timer starts, so the dialog can never abandon a request main would still accept.
     expect(confirmExpiresAt(1_000)).toBeGreaterThan(CONTROL_REQUEST_TIMEOUT_MS)
+  })
+})
+
+describe('expiredDialogNotice', () => {
+  it('names who asked, and says nothing happened', () => {
+    const n = expiredDialogNotice('orchestrator')
+    expect(n).toContain('orchestrator')
+    expect(n).toContain('expired')
+    // The whole point of the sentence: the user must not be left wondering whether the worktree
+    // was removed / the text was sent while they were away.
+    expect(n).toContain('nothing was done')
+  })
+
+  it('falls back to "an agent" rather than printing undefined', () => {
+    expect(expiredDialogNotice()).toContain('an agent')
+    expect(expiredDialogNotice()).not.toContain('undefined')
+  })
+
+  it('is ONE sentence for every expiring dialog', () => {
+    // Both callers (the canvas-control confirm and the worktree-removal dialog) render this. Two
+    // wordings for the same event read as two different events.
+    expect(expiredDialogNotice('x')).toBe(expiredDialogNotice('x'))
   })
 })
 

--- a/src/shared/control-confirm.ts
+++ b/src/shared/control-confirm.ts
@@ -175,6 +175,18 @@ export function sanitizeControlConfirmWaivers(raw: unknown): ControlConfirmWaive
   return out
 }
 
+/**
+ * The user-visible line a dialog raises when it collects itself unanswered — ONE sentence for every
+ * expiring dialog (`useExpiringDialog`), because a session that raises two differently-worded
+ * notices for the same event reads as two different events.
+ *
+ * It says "nothing was done" and means it: every expiry path drops the dialog without performing
+ * its action. A dialog whose expiry could leave work half-finished must not use this sentence.
+ */
+export function expiredDialogNotice(requestedBy?: string): string {
+  return `The request from ${requestedBy ?? 'an agent'} expired before it was answered — nothing was done.`
+}
+
 /** The user-visible line a WAIVED destructive action raises (Canvas's info banner). A waiver
  *  makes the dialog go away — it must not make the ACTION go quiet, which is why this exists and
  *  why it names the waiver that let the action through. */


### PR DESCRIPTION
Follow-up to #740, which named this as the gap it left open.

## What was still broken

`close-worktree --mode remove` replies to its caller the instant the dialog opens ("removal confirmation shown to the user — they decide"), so there is no pending control request to expire — which is why #740 left it alone. But the **dialog** still holds `confirmBusy()` (and `removePendingRef`) while it is up, so one nobody answers refuses every later `write`/`close`/removal with *"a confirmation is already pending — try again"* for the rest of the app run. That is the same wedge #740 closed, reached by a different route.

It is also the worst dialog to leave lying around: the only one carrying a pre-ticked delete-from-disk choice, on a worktree the human never asked about.

## What changed

**The rule is extracted, not copied.** `renderer/lib/useExpiringDialog.ts` now owns the timer, the already-past case and the notice; both dialogs call it. A second effect beside the first is how one gains a fix the other silently lacks — so the source test asserts there are exactly **two** callers and no hand-rolled `setTimeout` that clears a dialog state.

Three deliberate differences for the removal dialog, each of which would be a bug if copied from the confirm:

- **No `onExpire`.** Its caller was answered minutes ago; an `onExpire` here would be a reply to a call that has long since returned.
- **Its clear also releases `removePendingRef`.** That ref covers the async `git.status` gap before `removeTarget` exists, and `confirmBusy()` reads it *directly* — so dropping the state while leaving the ref latched would close the dialog and keep refusing every later destructive verb anyway: the bug, minus the only thing on screen that explained it.
- **The deadline is set only when `requestedBy` is present.** A removal the *user* opened from the group menu must never vanish under them — they asked for it and they are looking at it.

The budget is `confirmExpiresAt` again rather than a new timeout: it is the same class of fact ("an agent asked and the human is not at the machine"), and one number beats two that mean the same thing.

`expiredDialogNotice` moved into `@shared/control-confirm` so both dialogs raise one sentence — a session that words the same event two ways reads as two events.

## How it was checked

- `npm run typecheck` clean; full suite **11136 passed / 0 failed** (818 files).
- 15 new tests. The hook is tested **behaviourally** with fake timers (`useExpiringDialog.test.tsx`), which is where the real failure modes live: fires at the deadline and not a millisecond earlier, fires immediately for a deadline already in the past (a suspended tab), never fires without one, cancels when the dialog is answered, re-arms for a replacement, calls `onExpire` exactly once and tolerates its absence, and keeps an **absolute** deadline so re-renders cannot postpone it.
- The Canvas wiring is pinned at source level (`worktree-confirm-expiry.source.test.ts`) because there is no render harness for an 11k-line component and the failure mode is silence — a dialog that never expires looks exactly like one nobody left open.
- **Mutation-verified.** Each of these was applied and the named test went red: removing the already-past branch, removing the timer cleanup, expiring a dialog with no deadline, a duration-based instead of absolute deadline, a notice that forgets who asked, dropping the removal hook call, an expiry that forgets `removePendingRef`, an unconditional deadline (a human-opened dialog would vanish), and a hand-rolled second timer for either dialog.
- Two tests were **corrected rather than kept green** after they survived mutation: one pinned the `onExpire`-before-`clear` order, which nothing depends on (the callback is captured from the closure), and one claimed re-renders could postpone the deadline, which an absolute `expiresAt` makes impossible. Both now assert the property that actually holds.

## Not verified / owed

- **No device run.** Everything was exercised under vitest on Linux.
- Device checklist:
  1. Agent runs `close-worktree --group <id> --mode remove`, leave the dialog untouched for 120 s → it disappears with an "expired … nothing was done" strip, the worktree is still there, and the **next** destructive verb opens a dialog instead of being refused as pending.
  2. Open the same dialog yourself from the group frame's menu, wait longer than 120 s → it stays put.
  3. Answer an agent-raised one normally (both Unbind and Delete) → unchanged behaviour, guard released.
- Unchanged and still true: the single-id `close --node <gone>` still reports `closed <id>` for a node that never existed (pre-existing, noted in `closeTargets.ts`).
- One stray unhandled error appeared in the summary line of one full-suite run and not in a second, with all 11136 tests passing both times; it did not reproduce in five runs of the new test file and I could not attribute it. Flagging it rather than claiming it is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GC3SpXaz6qQqY5BaeueAZ
