### PR TITLE
test(renderer): normalize path separators in the machineName guard on Windows

### DIFF
--- a/src/renderer/lib/machineName.guard.test.ts
+++ b/src/renderer/lib/machineName.guard.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, statSync } from 'fs'
-import { join, relative } from 'path'
+import { join, relative, sep } from 'path'
 import { describe, expect, it } from 'vitest'
 
 /**
@@ -58,7 +58,8 @@ describe('no user-visible copy calls this machine a Mac', () => {
     const offenders: string[] = []
     for (const root of ROOTS) {
       for (const file of sourceFiles(join(process.cwd(), root))) {
-        const rel = relative(process.cwd(), file)
+        // ALLOWED is keyed with forward slashes; on Windows `relative` returns backslashes.
+        const rel = relative(process.cwd(), file).split(sep).join('/')
         if (ALLOWED.has(rel)) continue
         readFileSync(file, 'utf8')
           .split('\n')


### PR DESCRIPTION
Fixes #746

## Summary

`machineName.guard.test.ts` looks up each scanned file in `ALLOWED`, whose keys are written with forward slashes, but `relative(process.cwd(), file)` returns backslashes on Windows. The exemptions therefore never matched there, the guard scanned `OnboardingFlow.tsx` and `PtyPressureBanner.tsx`, and it reported their documented macOS copy as offenders.

The relative path is now split on `path.sep` and re-joined with `/` before the lookup, so the same keys work on every platform. The reported offender paths use the normalized form too, which keeps the failure output identical across platforms.

## Verification

`npx vitest run src/renderer/lib/machineName.guard.test.ts` passes on macOS (the normalization is a no-op there). I could not run it on Windows; the change only touches how the lookup key is built, and `split(sep).join('/')` produces exactly the `ALLOWED` keys from the report's `src\renderer\…` paths.
