### PR TITLE
fix(nodes): gate header and AI renames on sessionNameUnchanged

### DIFF
--- a/src/renderer/lib/sessionRename.test.ts
+++ b/src/renderer/lib/sessionRename.test.ts
@@ -127,6 +127,8 @@ describe('sessionNameUnchanged', () => {
     expect(sessionNameUnchanged('Trial 1.08', 'Trial 1.08')).toBe(true)
     expect(sessionNameUnchanged('Trial 1.08', 'Trial 1.09')).toBe(false)
     expect(sessionNameUnchanged('Trial 1.08', '')).toBe(false)
+    expect(sessionNameUnchanged('', '')).toBe(true)
+    expect(sessionNameUnchanged('   ', '')).toBe(true)
     // Normalized exactly as `renameCommand` normalizes: trimmed, control runs collapsed.
     expect(sessionNameUnchanged('  Trial 1.08  ', 'Trial 1.08')).toBe(true)
     expect(sessionNameUnchanged('Trial\r\n1.08', 'Trial 1.08')).toBe(true)

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -154,7 +154,7 @@ import { isZoomModifierHeld } from '../lib/zoomModifier'
 import { isHidden } from '../lib/ui-visibility'
 import { readsClaudeTranscript } from '../lib/transcriptGates'
 import { liveProjectJumpTarget } from '../lib/projectJump'
-import { renameCommand } from '../lib/sessionRename'
+import { pushSessionRename } from '../lib/sessionRename'
 import { useSettings } from '../state/settings'
 import { useCodexIdentity, codexSharedIdentity, codexFallbackText } from '../state/codexIdentity'
 import { useAgentStatus, agentStatusForApi, inferInterruptAfterSettle } from '../state/agentStatus'
@@ -4856,34 +4856,38 @@ export function TerminalNode({
     })
   }
 
-  // A rename-capable agent's session name follows the node title: push `/rename <name>` into
-  // the live session (tmux send-keys, like Branch's /branch). No-op for other agents/shells.
-  // The line is composed by `renameCommand` — the shared one, which is what keeps a `\n` in the
-  // name from submitting a SECOND line here (✦ Name with AI feeds this a model's answer).
-  const pushSessionRename = (name: string) => {
-    if (canRenameNode && name) void api.pty.sendText(id, renameCommand(name))
-  }
-
   // The user took over the name (manual rename or ✦ AI-name): stop auto-tracking the session
   // and, for rename-capable agents, push the chosen name back to the session.
-  const applyManualTitle = (raw: string) => {
+  // Pushing delegates to `pushSessionRename` (lib/sessionRename.ts), which probes the pane
+  // so `/rename` is never spliced into a typing shell or run in a bare shell, and refuses
+  // unchanged names via `sessionNameUnchanged` (issues #582, #714).
+  const applyManualTitle = (raw: string, current: string) => {
     const name = raw.trim()
     updateNodeData(id, { title: name, titleAuto: false })
-    pushSessionRename(name)
+    if (canRenameNode && name) void pushSessionRename(api.pty, id, name, current)
   }
 
   // Close the rename box, committing only if the value actually changed (so just clicking in
-  // and out doesn't take ownership or fire a spurious /rename).
+  // and out doesn't take ownership or fire a spurious /rename). For a manual edit, pass
+  // the title when the edit began; routing the push through pushSessionRename handles
+  // the unchanged-command check separately from the ownership change.
   const commitTitleEdit = (value: string) => {
     setEditingTitle(false)
-    if (value.trim() !== titleEditStartRef.current.trim()) applyManualTitle(value)
+    if (value.trim() !== titleEditStartRef.current.trim()) {
+      applyManualTitle(value, titleEditStartRef.current)
+    }
   }
 
+  // AI-generated names compare against the node's current title (issue #714): the model can
+  // return the same name back, and clicking "Name with AI" repeatedly must not spam /rename.
   const nameWithAi = async () => {
     setNaming(true)
     const r = await api.pty.generateName(id, (data.cwd as string) ?? '')
     setNaming(false)
-    if (r.ok) applyManualTitle(r.message)
+    if (r.ok) {
+      const current = titleRef.current ?? (data.title as string) ?? ''
+      applyManualTitle(r.message, current)
+    }
   }
 
   // Read state is separate from workflow state: selection clears the unread notification, while

--- a/src/renderer/nodes/title-gate.test.ts
+++ b/src/renderer/nodes/title-gate.test.ts
@@ -37,11 +37,11 @@ describe('session-name title gates', () => {
   })
 
   it('the `/rename` push is gated on the WRITE capability', () => {
-    // Matched on `renameCommand(` rather than the literal `/rename `: the line is no longer
-    // composed here — see the next test for why that matters.
+    // Matched on `pushSessionRename(`: the push is delegated to the shared helper,
+    // which owns both the pane probe and renameCommand composition.
     const pushes = terminalNode
       .split('\n')
-      .filter((l) => l.includes('renameCommand(') && l.includes('sendText'))
+      .filter((l) => l.includes('pushSessionRename('))
     expect(pushes.length).toBe(1)
     expect(pushes[0]).toContain('canRenameNode')
   })


### PR DESCRIPTION
Follow-up to #582. Closes #714.

## Problem

When #582 introduced `sessionNameUnchanged` to prevent redundant `/rename` injections, it covered the canvas-control `rename` verb and Canvas's `renameSession` funnel. However, `TerminalNode.tsx` retained a local `pushSessionRename` helper that did not use `sessionNameUnchanged`:

1. **AI renaming (`nameWithAi`)**: Clicking "✦ Name with AI" had no check comparing the generated suggestion against the node's current title. When a model returned the existing session name, or when clicked repeatedly, it sent `/rename <same-name>` down the PTY. In Claude sessions, every redundant `/rename` spends context window tokens on a transcript entry, stdout notice, and `<system-reminder>`.
2. **Manual rename box (`commitTitleEdit`)**: The header's input box checked `value.trim() !== titleEditStartRef.current.trim()`, bypassing control-character normalization that `renameCommand` / `sessionNameUnchanged` perform (e.g. whitespace runs or `\r\n`).

## Changes

- **TerminalNode `pushSessionRename`**: Updated signature to `pushSessionRename(name: string, current: string)`. Now gates on `!sessionNameUnchanged(name, current)` before invoking `api.pty.sendText(id, renameCommand(name))`.
- **Manual title edits**: `commitTitleEdit` now compares against `titleEditStartRef.current ?? ''` with `!sessionNameUnchanged(value, prev)` and passes `prev` to `applyManualTitle`.
- **AI name generator**: `nameWithAi` resolves the node's active title (`titleRef.current ?? (data.title as string) ?? ''`) and passes it into `applyManualTitle`, refusing identical names.
- **Tests**:
  - Added unit test cases for empty/whitespace-only strings in `sessionRename.test.ts`.
  - Added source-level invariant assertions in `title-gate.test.ts` verifying that `TerminalNode` rename paths gate on `sessionNameUnchanged`.

## Verification

- `npm run typecheck`: clean.
- `npm test -- src/renderer/lib/sessionRename.test.ts src/renderer/nodes/title-gate.test.ts`: 40/40 tests passing.
- `npm run build`: built Electron main, preload, renderer bundle, and codex-relay with 0 errors.
