### PR TITLE
fix(test): normalize path separators in the machineName guard's exemption lookup

### DIFF
--- a/src/renderer/lib/machineName.guard.test.ts
+++ b/src/renderer/lib/machineName.guard.test.ts
@@ -14,7 +14,20 @@ import { describe, expect, it } from 'vitest'
  * COMMENTS ARE NOT SCANNED. They are not shown to anyone, they carry real history ("a Mac→SSH
  * node"), and rewriting them would bury the actual copy change in noise.
  */
+const REPO_ROOT = join(__dirname, '..', '..', '..')
 const ROOTS = ['src/renderer', 'src/shared']
+
+/**
+ * Guard comparisons use one separator regardless of the host running Vitest.
+ *
+ * `relative()` answers in the HOST's separator, while the exemption keys below are written with
+ * POSIX slashes — so on Windows `ALLOWED.has(rel)` missed every entry, the exempt files were
+ * scanned after all, and the suite failed on copy that is correct (issue #746). Same rule, same
+ * helper shape, as `fs-atomic.guard.test.ts` and `localStore.guard.test.ts`.
+ */
+function normalizedSourcePath(value: string): string {
+  return value.replace(/\\/g, '/')
+}
 
 /** Files where naming a Mac is the CORRECT answer, each with the reason it is exempt. */
 const ALLOWED = new Map<string, string>([
@@ -57,8 +70,8 @@ describe('no user-visible copy calls this machine a Mac', () => {
   it('finds none outside the documented exemptions', () => {
     const offenders: string[] = []
     for (const root of ROOTS) {
-      for (const file of sourceFiles(join(process.cwd(), root))) {
-        const rel = relative(process.cwd(), file)
+      for (const file of sourceFiles(join(REPO_ROOT, root))) {
+        const rel = normalizedSourcePath(relative(REPO_ROOT, file))
         if (ALLOWED.has(rel)) continue
         readFileSync(file, 'utf8')
           .split('\n')
@@ -75,8 +88,37 @@ describe('no user-visible copy calls this machine a Mac', () => {
 
   it('keeps the exemption list honest — every entry still exists and still says Mac', () => {
     for (const [rel, why] of ALLOWED) {
-      const src = readFileSync(join(process.cwd(), rel), 'utf8')
+      const src = readFileSync(join(REPO_ROOT, rel), 'utf8')
       expect(BANNED.test(src), `${rel} no longer needs its exemption (${why})`).toBe(true)
+    }
+  })
+
+  it('every exemption actually matches a file the scan walked', () => {
+    // The assertion above reads each exempt file by PATH, so it passes even when the scan's own
+    // lookup never matched it — which is exactly how the Windows separator bug hid: the exempt
+    // files were scanned and reported as offenders while this test stayed green. Comparing against
+    // the scan's OWN keys is what makes a key that stops matching fail HERE, naming the exemption,
+    // instead of failing above and naming innocent copy.
+    const scanned = new Set(
+      ROOTS.flatMap((root) => sourceFiles(join(REPO_ROOT, root))).map((file) =>
+        normalizedSourcePath(relative(REPO_ROOT, file))
+      )
+    )
+    for (const rel of ALLOWED.keys()) {
+      expect(scanned.has(rel), `${rel} is exempt but the scan never produced that key`).toBe(true)
+    }
+  })
+
+  it('normalizes exemption keys on both POSIX and Windows-shaped paths', () => {
+    expect(normalizedSourcePath('src/renderer/lib/machineName.ts')).toBe(
+      'src/renderer/lib/machineName.ts'
+    )
+    expect(normalizedSourcePath(String.raw`src\renderer\lib\machineName.ts`)).toBe(
+      'src/renderer/lib/machineName.ts'
+    )
+    // A Windows-shaped path must reach the SAME exemption the POSIX one does.
+    for (const rel of ALLOWED.keys()) {
+      expect(ALLOWED.has(normalizedSourcePath(rel.replace(/\//g, '\\')))).toBe(true)
     }
   })
 })


### PR DESCRIPTION
## What was wrong

`src/renderer/lib/machineName.guard.test.ts` built its scan key with `relative()` — which answers in the **host's** separator — and looked it up in an exemption map written with POSIX slashes. On Windows every key missed, so the three exempt files were scanned after all and the suite failed on copy that is **correct**: the macOS-only notch step in `OnboardingFlow.tsx` and the `kern.tty.ptmx_max` banner in `PtyPressureBanner.tsx`.

@Abhirup0 diagnosed it exactly, including the fix, and quoted the rule it breaks — CONTRIBUTING.md: *"Normalize BOTH sides of a path comparison, through one function."*

## The sweep

The brief was to check whether any other guard test compares paths the same way. Result:

| guard test | path comparison | status |
|---|---|---|
| `core/fs-atomic.guard.test.ts` | `normalizedSourcePath(relative(...))` | already normalized |
| `renderer/lib/localStore.guard.test.ts` | `normalizedSourcePath(relative(...))` | already normalized |
| `core/stream-epipe.guard.test.ts` | `.replace(/\\/g, '/')` | already normalized |
| `core/tmux-socket-isolation.guard.test.ts` | `.replace(/\\/g, '/')` (incl. self-exclusion) | already normalized |
| `shared/line-endings.guard.test.ts` | `file === __filename`, both platform-native | safe |
| `NodeColorSwatches` / `nodeterm-events` / `browser-control-route` | `relative()` for the offender MESSAGE only | not a lookup |
| **`renderer/lib/machineName.guard.test.ts`** | raw `relative()` into `ALLOWED.has()` | **the bug** |

One unnormalized lookup, now using the same helper shape as its two siblings.

## Beyond the reported one-liner

- **Scan root.** `process.cwd()` → a `__dirname`-derived `REPO_ROOT`, so the exemption keys no longer depend on which directory Vitest was started from.
- **A new assertion, because the existing honesty test could not see this.** `keeps the exemption list honest` reads each exempt file **by path** (`join(root, rel)`, which normalizes) — so it stayed green on Windows while the scan's lookup was missing every entry. That is exactly how this hid. The new test compares the exemption keys against the keys the scan **actually produced**.

## Mutation check

Simulating a Windows host by making `relative()` answer with backslashes:

- **fix present** → 4/4 pass.
- **fix removed** → the reported failure reproduces byte-for-byte (same two offenders), *and* the new test fails with `src/renderer/lib/machineName.ts is exempt but the scan never produced that key`. The old honesty test passes in both — confirming it was blind to this class.

So the guard now fails by naming the *exemption*, not innocent copy.

## Verification

- `npx vitest run` over all six guard suites — 29/29 pass.
- `npm run typecheck` clean.

## Device checklist

- [ ] Run `npm test -- src/renderer/lib/machineName.guard.test.ts` on a real **Windows** host and confirm 4/4 green (this is the platform the bug is on; CI's `windows-latest` job covers it too).
- [ ] Confirm the guard still catches a real offender: add `this Mac` to any non-exempt renderer file and confirm the first test goes red.

Fixes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
