### PR TITLE
fix(canvas): frame a maximized node against the rectangle maximize placed it in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3190,6 +3190,23 @@ the Settings section and ShortcutsPanel start disagreeing about what a chord mea
   losing the centre. The free-rect solve (`solveFitFrame` / `solveFitPadding`) stays where it earns
   its keep: `fitAll`, which fits EVERY node and would otherwise tuck them under the dock.
   Unknowable size or no pane ⇒ the camera **stands still**.
+  **ONE exception, and it is not a walk-back of that rule (issue #743): a MAXIMIZED node**
+  (`isMaximized` — `data.premaxRect`, the flag `maximizeNodeToRect` writes and
+  `restoreMaximizedNode` clears) is framed against the same rectangle `maximizeTargetRect` placed
+  it in, by passing `measurePinnedInsets(box)` to `viewportForRect`. The trade-off above rests on
+  ONE number — how much of the node ends up behind the panel — and for a maximized node that
+  number is set by the PANEL rather than the node, **by construction**: maximize sized it to be
+  *exactly* the free area, so centring it in the wider pane buries half the inset less the margin.
+  Measured by the reporter on a signed v0.3.5 build with the sidebar pinned: an ordinary node lost
+  33px, the maximized one 137px, and the camera drifted by `322 / 2 = 161` px on every "go to
+  another node and back". Because the node is that rectangle minus two margins, centring it in the
+  free area reproduces maximize's own origin (`marginPx + insets.left`) exactly — which is what
+  makes this a fix rather than a second opinion about placement. It applies to BOTH zoom branches
+  (the rectangle question is the same one; splitting it would be two rectangles again, which is
+  the bug), and with no pinned panel `insets` is zero and the whole thing is a mathematical no-op.
+  A pane narrower than the panels over it falls back to the whole pane rather than solving against
+  a negative width. `measurePinnedInsets` reads the DOM, so it is asked only for a node that can
+  use the answer.
   `settings.focusZoomToNode` (Behavior, default ON) is the escape hatch for the rescale: off, the
   camera keeps the zoom `getZoom()` reports and only pans, and that zoom is passed through
   **unclamped** — it is one the canvas is already displaying, and re-clamping it to the framing

--- a/src/renderer/canvas/Canvas.tsx
+++ b/src/renderer/canvas/Canvas.tsx
@@ -291,13 +291,14 @@ import {
 } from '../lib/projectOpen'
 import {
   absolutePosition,
+  isMaximized,
   isMeasured,
   nodeFitRect,
   viewportForRect,
   type FocusableNode
 } from '../lib/nodeFocus'
 import { NODE_MAXIMIZE_MARGIN_PX, maximizeTargetRect } from '../lib/nodeMaximize'
-import { measurePinnedInsets, type ScreenInsets } from '../lib/pinnedInsets'
+import { NO_INSETS, measurePinnedInsets, type ScreenInsets } from '../lib/pinnedInsets'
 import { ZONE_GUTTER_PX, ZONES, zoneTargetRect, type ZoneId } from '../lib/nodeZones'
 import {
   recordBreadcrumb,
@@ -6904,7 +6905,11 @@ export function Canvas() {
       // `focusZoomToNode` off: keep the zoom the user settled on and only pan — the node still
       // lands in the middle, only the rescale is dropped.
       const keepZoom = useSettings.getState().settings.focusZoomToNode ? undefined : getZoom()
-      const viewport = viewportForRect(rect, box.width, box.height, keepZoom)
+      // A MAXIMIZED node is framed against the rectangle its own placement used (issue #743);
+      // everything else is centred in the whole pane, as it always was. `measurePinnedInsets`
+      // reads the DOM, so it is asked only for the node that can use the answer.
+      const insets = isMaximized(node) ? measurePinnedInsets(box) : NO_INSETS
+      const viewport = viewportForRect(rect, box.width, box.height, keepZoom, insets)
       if (viewport) void setViewport(viewport, { duration: 300 })
     },
     [setViewport, getInternalNode, getZoom]

--- a/src/renderer/canvas/canvas-wiring.test.tsx
+++ b/src/renderer/canvas/canvas-wiring.test.tsx
@@ -178,9 +178,21 @@ describe('breadcrumb wiring the CLAUDE.md bullet calls load-bearing', () => {
       CANVAS_SRC.indexOf('const frameNode = useCallback'),
       CANVAS_SRC.indexOf('const goToNode = useCallback')
     )
-    expect(frame).toContain('viewportForRect(rect, box.width, box.height, keepZoom)')
+    expect(frame).toContain('viewportForRect(rect, box.width, box.height, keepZoom, insets)')
     expect(frame).not.toContain('solveFitFrame')
     expect(frame).toContain('settings.focusZoomToNode ? undefined : getZoom()')
+  })
+
+  it('insets that framing ONLY for a maximized node (issue #743)', () => {
+    // The trade-off above is about how much of the node ends up behind the panel, and for a
+    // maximized node that number is set by the PANEL, not the node: it is exactly as wide as the
+    // free area, so centring it in the wider pane buries half the inset less the margin. Keying
+    // on anything looser would walk back the whole-pane rule for ordinary nodes.
+    const frame = CANVAS_SRC.slice(
+      CANVAS_SRC.indexOf('const frameNode = useCallback'),
+      CANVAS_SRC.indexOf('const goToNode = useCallback')
+    )
+    expect(frame).toContain('const insets = isMaximized(node) ? measurePinnedInsets(box) : NO_INSETS')
   })
 
   it('the resume card slot is spent only on a card that can render, and only when opted in', () => {

--- a/src/renderer/lib/nodeFocus.test.ts
+++ b/src/renderer/lib/nodeFocus.test.ts
@@ -3,11 +3,13 @@ import { getViewportForBounds } from '@xyflow/system'
 import {
   FIT_NODE_OPTIONS,
   absolutePosition,
+  isMaximized,
   isMeasured,
   nodeFitRect,
   viewportForRect
 } from './nodeFocus'
 import type { FocusableNode } from './nodeFocus'
+import { NODE_MAXIMIZE_MARGIN_PX } from './nodeMaximize'
 
 const term = (over: Partial<FocusableNode> = {}): FocusableNode => ({
   id: 'n1',
@@ -190,5 +192,82 @@ describe('isMeasured', () => {
     expect(isMeasured({ measured: { width: 600 } })).toBe(false)
     expect(isMeasured({ measured: { width: 0, height: 0 } })).toBe(false)
     expect(isMeasured(undefined)).toBe(false)
+  })
+})
+
+describe('viewportForRect — the maximized exception (issue #743)', () => {
+  /**
+   * The reporter's controlled measurement, reproduced as arithmetic. macOS, signed v0.3.5,
+   * `focusZoomToNode` OFF (so the zoom is held and cannot confound it), sessions sidebar pinned,
+   * one node, maximized. Only the CAMERA moved across "go to another node and back": the node's
+   * position, size and the zoom were byte-identical before and after.
+   */
+  const PANE_W = 1710
+  const ZOOM = 0.7345
+  const INSETS = { left: 322, right: 0 }
+  const rect = { x: -68.9, y: 0, width: 1824, height: 1261 }
+  /** Where the node's left edge lands on screen for a given viewport. */
+  const leftEdge = (vp: { x: number }) => vp.x + rect.x * ZOOM
+
+  it('reproduces the reported drift when the framing ignores the pinned inset', () => {
+    // 1824 × 0.7345 = 1339.8 rendered px; (1710 - 1339.8) / 2 = 185.1 — centred in the WHOLE pane,
+    // exactly as measured. Maximize had put it at 346.0, so the camera moved 160.9 px, which is
+    // 322 / 2: half the left inset, what centring a free-area-wide object in the full pane gives.
+    const vp = viewportForRect(rect, PANE_W, 900, ZOOM)!
+    expect(leftEdge(vp)).toBeCloseTo(185.1, 0)
+    expect(leftEdge(viewportForRect(rect, PANE_W, 900, ZOOM, INSETS)!) - leftEdge(vp)).toBeCloseTo(
+      160.9,
+      0
+    )
+  })
+
+  it('frames a maximized node exactly where maximizeTargetRect placed it', () => {
+    // maximize's own origin is `marginPx + insets.left` = 24 + 322 = 346. The node is the free
+    // area minus two margins, so centring it in the free area reproduces that origin — which is
+    // the property that makes this a fix rather than a different opinion about where to put it.
+    const vp = viewportForRect(rect, PANE_W, 900, ZOOM, INSETS)!
+    expect(leftEdge(vp)).toBeCloseTo(NODE_MAXIMIZE_MARGIN_PX + INSETS.left, 0)
+    // 136.9 px of the node sat behind the sidebar before; none does now.
+    expect(leftEdge(vp)).toBeGreaterThanOrEqual(INSETS.left)
+  })
+
+  it('is a mathematical no-op when no panel is pinned', () => {
+    const bare = viewportForRect(rect, PANE_W, 900, ZOOM)!
+    const zero = viewportForRect(rect, PANE_W, 900, ZOOM, { left: 0, right: 0 })!
+    expect(zero).toEqual(bare)
+    expect(viewportForRect(rect, PANE_W, 900, undefined, { left: 0, right: 0 })).toEqual(
+      viewportForRect(rect, PANE_W, 900)
+    )
+  })
+
+  it('insets the zoom-to-fit path too, without changing the unpinned answer', () => {
+    // `focusZoomToNode` ON rescales as well. The rectangle question is the same one, so the
+    // maximized node is fitted INSIDE the free area rather than the pane — its whole width is
+    // clear of the panel, where centring in the pane left part of it underneath.
+    const fitted = viewportForRect(rect, PANE_W, 900, undefined, INSETS)!
+    expect(fitted.x + rect.x * fitted.zoom).toBeGreaterThanOrEqual(INSETS.left)
+    expect(fitted.x + (rect.x + rect.width) * fitted.zoom).toBeLessThanOrEqual(PANE_W)
+  })
+
+  it('falls back to the whole pane when the panels are wider than it', () => {
+    // Not a rectangle anything can be centred in — solving against a negative width would put the
+    // camera somewhere arbitrary. Standing on the old answer is the honest degrade.
+    const narrow = viewportForRect(rect, 300, 900, ZOOM, { left: 322, right: 0 })!
+    expect(narrow).toEqual(viewportForRect(rect, 300, 900, ZOOM))
+  })
+
+  it('refuses a container it cannot size, insets or not', () => {
+    expect(viewportForRect(rect, 0, 0, ZOOM, INSETS)).toBeNull()
+    expect(viewportForRect(rect, PANE_W, 900, 0, INSETS)).toBeNull()
+  })
+})
+
+describe('isMaximized', () => {
+  it('keys on premaxRect — the flag maximize itself writes and restore clears', () => {
+    expect(isMaximized({ data: { premaxRect: { x: 0, y: 0, width: 10, height: 10 } } })).toBe(true)
+    expect(isMaximized({ data: {} })).toBe(false)
+    expect(isMaximized({})).toBe(false)
+    expect(isMaximized(null)).toBe(false)
+    expect(isMaximized(undefined)).toBe(false)
   })
 })

--- a/src/renderer/lib/nodeFocus.ts
+++ b/src/renderer/lib/nodeFocus.ts
@@ -1,5 +1,7 @@
 import { getViewportForBounds, type Rect, type Viewport } from '@xyflow/system'
 
+import { NO_INSETS, type ScreenInsets } from './pinnedInsets'
+
 /**
  * "Zoom to this node" geometry, computed without React Flow's `fitView`.
  *
@@ -33,6 +35,26 @@ export interface FocusableNode {
   height?: number | null
   measured?: { width?: number | null; height?: number | null }
   style?: { width?: number | string | null; height?: number | string | null }
+}
+
+/**
+ * Is this node currently MAXIMIZED — i.e. was it placed against the chrome-free rectangle rather
+ * than dropped somewhere by hand?
+ *
+ * `premaxRect` is the maximize MODE flag (`maximizeNodeToRect` writes it, `restoreMaximizedNode`
+ * clears it), which is what makes it the right key here: it is exactly the set of nodes whose
+ * position was chosen by `maximizeTargetRect`, and the fix below is about framing a node against
+ * the rectangle its own placement used.
+ *
+ * It survives things that make the node no longer free-area-sized — a manual resize, a window
+ * resize (maximize deliberately does not re-fit on those) — and that is acceptable in both
+ * directions: with no pinned panel the inset is zero and this decision is a no-op, and with one
+ * the worst case is a node framed clear of a panel it was already meant to clear. Unpinning the
+ * panel needs no special case at all: `fitMaximizedToUsableArea` re-fits every maximized node
+ * whenever the insets change, so the flag and the geometry re-converge on their own.
+ */
+export function isMaximized(node: { data?: { premaxRect?: unknown } } | null | undefined): boolean {
+  return !!node?.data?.premaxRect
 }
 
 /** Zoom/padding for framing a single node, shared by both framing paths here so the whole-pane
@@ -93,13 +115,24 @@ export function nodeFitRect(node: FocusableNode, all: readonly FocusableNode[]):
  * The viewport that frames `rect` in a `containerWidth × containerHeight` pane, with the same
  * padding/zoom clamp `fitView` would have applied. Null when the container has no size yet.
  *
- * **Centred in the pane, and nothing else.** Framing a focused node against the chrome-free
- * rectangle instead — centred in it, or centred in the pane and then nudged clear of it — was tried
- * twice and is wrong both ways: the sessions sidebar is a 300px OVERLAY, so either rule pushes the
- * node right by most of its width, and "go to node" stops putting the node where the eye is. The
- * couple of dozen pixels of a node that end up behind the sidebar cost far less than that. The
- * free-rect solve stays where it earns its keep, in `fitAll`, which fits EVERY node and would
- * otherwise tuck them under the dock.
+ * **Centred in the pane, and nothing else — `insets` default to none.** Framing a focused node
+ * against the chrome-free rectangle instead — centred in it, or centred in the pane and then
+ * nudged clear of it — was tried twice and is wrong both ways: the sessions sidebar is a 300px
+ * OVERLAY, so either rule pushes the node right by most of its width, and "go to node" stops
+ * putting the node where the eye is. The couple of dozen pixels of a node that end up behind the
+ * sidebar cost far less than that. The free-rect solve stays where it earns its keep, in `fitAll`,
+ * which fits EVERY node and would otherwise tuck them under the dock.
+ *
+ * **The MAXIMIZED exception (issue #743), and why it is not a walk-back of that trade-off.** The
+ * trade-off above rests on one number: how much of the node ends up behind the panel. For an
+ * ordinary node that is a couple of dozen pixels (33px, measured by the reporter). For a maximized
+ * one the premise inverts by CONSTRUCTION, not by degree: `maximizeTargetRect` sized the node to
+ * be *exactly* as wide as the free area, so centring it in the wider pane buries half the inset
+ * less the margin — 137px in the reported layout, and it scales with the PANEL, not with the node.
+ * It cannot come out as a few dozen pixels. So a maximized node is framed against the same
+ * rectangle its own placement used, which — since the node is that rectangle minus two margins —
+ * reproduces exactly where maximize put it. Everything else still centres in the whole pane,
+ * because `insets` is `NO_INSETS` unless the caller says otherwise.
  *
  * `zoom` keeps the camera at a scale the caller already has (`settings.focusZoomToNode` off): the
  * node is centred exactly as it would be, at that zoom, so "go to" stays a pan. It is passed
@@ -110,25 +143,32 @@ export function viewportForRect(
   rect: Rect,
   containerWidth: number,
   containerHeight: number,
-  zoom?: number
+  zoom?: number,
+  insets: ScreenInsets = NO_INSETS
 ): Viewport | null {
   if (!(containerWidth > 0) || !(containerHeight > 0)) return null
+  // A pane narrower than the panels covering it is not a rectangle anything can be centred in —
+  // fall back to the whole pane rather than solving against a negative width.
+  const freeWidth = containerWidth - insets.left - insets.right
+  const originX = freeWidth > 0 ? insets.left : 0
+  const width = freeWidth > 0 ? freeWidth : containerWidth
   if (zoom !== undefined) {
     if (!(zoom > 0)) return null
     return {
-      x: containerWidth / 2 - (rect.x + rect.width / 2) * zoom,
+      x: originX + width / 2 - (rect.x + rect.width / 2) * zoom,
       y: containerHeight / 2 - (rect.y + rect.height / 2) * zoom,
       zoom
     }
   }
-  return getViewportForBounds(
+  const fitted = getViewportForBounds(
     rect,
-    containerWidth,
+    width,
     containerHeight,
     FIT_NODE_OPTIONS.minZoom,
     FIT_NODE_OPTIONS.maxZoom,
     FIT_NODE_OPTIONS.padding
   )
+  return originX ? { ...fitted, x: fitted.x + originX } : fitted
 }
 
 /** Whether React Flow already knows this node's on-screen size — i.e. whether `fitView` will


### PR DESCRIPTION
## What was wrong

Maximize a node with the sessions sidebar pinned, go to another node in the sidebar, come back: the node is now partly behind the sidebar. The node has not moved — the camera has.

@ezwep measured it on a signed **v0.3.5** build with `focusZoomToNode` **off** (so the zoom is held and cannot confound it) and read the numbers out of `workspace.json` and the project's `.nodeterm/project.json`: only `viewport.x` changed, by `-160.89`, leaving `136.9px` of the node under a `322px` sidebar. `322 / 2 = 161`.

Two subsystems, two rectangles, one node:

- `maximizeTargetRect` insets by the pinned panels — `originX = marginPx + insets.left`.
- `frameNode` handed `viewportForRect` `wrap.getBoundingClientRect()` — the whole pane, no insets.

## Why this does not walk back the existing trade-off

`nodeFocus.ts` argues, and still argues, that an ordinary focused node belongs centred in the **whole pane**: the sidebar is a 300px overlay, framing against the free rect pushes the node right by most of its width, and the couple of dozen pixels lost behind the panel is the cheaper cost. That was reported wrong twice before and reverted twice.

That trade-off rests on **one number**, and the reporter measured it for both cases: an ordinary node loses **33px**, a maximized one **137px**. The difference is not degree, it is construction — maximize sized the node to be *exactly* the free area, so centring it in the wider pane buries half the inset less the margin, and it scales with the **panel**, not the node. It cannot come out as a few dozen pixels.

So `viewportForRect` gains an optional `insets` (default `NO_INSETS`), and `frameNode` passes the measured insets **only** when `isMaximized(node)`. Ordinary framing is byte-identical.

The property that makes this a fix rather than a second opinion: the node is that rectangle minus two margins, so centring it in the free area reproduces maximize's own origin. `322 + (1388 - 1339.8) / 2 = 346.1` against maximize's `24 + 322 = 346`.

## The three open questions, answered

- **Scope** — `frameNode`, so both callers (`goToNode` and the breadcrumb `stepAndFrame`). It is the single framing implementation, and a second copy is the drift this fixes. **Both zoom branches**, deliberately: the rectangle question is the same one, and splitting it would be two rectangles again. You flagged `focusZoomToNode` **on** as a separate decision — I took it, because with the setting on a maximized node is still centred in the pane and still lands partly under the panel; the fitted node now sits wholly clear of it, pinned by its own test.
- **What counts as maximized** — `data.premaxRect`: the flag `maximizeNodeToRect` writes and `restoreMaximizedNode` clears, i.e. exactly the set of nodes `maximizeTargetRect` placed. Your three staleness cases: a **manual resize** and a **window resize** leave the flag standing, and in both the worst case is a node framed clear of a panel it was already meant to clear (with no pinned panel the inset is zero and the decision is a no-op). **Unpinning** needs no special case at all — `fitMaximizedToUsableArea` already re-fits every maximized node whenever the insets change, so flag and geometry re-converge on their own.
- **Which rectangle** — recomputed from the live layout, never the stored rect. It is the current pane and the current panels that decide where the camera can see; the stored rect is about where the NODE is.

A pane narrower than the panels covering it falls back to the whole pane rather than solving against a negative width.

## Verification

Your measurement is reproduced as arithmetic in `nodeFocus.test.ts` — 1710px pane, 0.7345 zoom, 322px inset, node at `x = -68.9` — asserting `185.1` before, `160.9` of drift, and `346` (maximize's own origin) after. Plus the no-op case, the zoom-to-fit case, the degenerate pane and the nulls.

Mutation-checked both directions:

- **ignore the insets** → the reported drift reproduces (`expected +0 to be close to 160.9`, `expected 185.1 to be close to 346`).
- **apply them to EVERY node** → the wiring test that pins the maximized-only key goes red, so the whole-pane rule for ordinary nodes cannot be quietly widened later.

`npm run typecheck` clean. `src/renderer/canvas` + `src/renderer/lib`: 1878 pass, 2 fail — both `directionalFocus.test.ts` and `keyContext.test.ts`, which assert against installed `node_modules` dist files and fail identically on clean `origin/main` (verified by stashing).

CLAUDE.md's "Go to node" section records the exception and why it is not a reversal of the whole-pane rule.

## Device checklist

- [ ] macOS, sidebar pinned, `focusZoomToNode` **off**: maximize a node, go to another node, come back — the node lands where maximize put it, fully clear of the sidebar.
- [ ] Same with `focusZoomToNode` **on** — the fitted node is wholly clear of the sidebar (this is the behaviour change beyond the reported case).
- [ ] **Ordinary** (non-maximized) node with the sidebar pinned — still centred in the whole pane, ~33px behind it, exactly as before.
- [ ] No pinned panel at all — identical to the current build in both settings.
- [ ] Explorer drawer pinned instead (a RIGHT-edge inset), and both pinned at once.
- [ ] Breadcrumb `Cmd+[` / `Cmd+]` onto a maximized node takes the same framing.
- [ ] Unpin the sidebar while a node is maximized, then go-to it — the re-fit has already resized it and the framing is the no-op.

Fixes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8UuYDwCXGs18f625TaWKL
