### PR TITLE
fix(delivery): use Escape to clear prompt line on Windows shells (#710)

### DIFF
--- a/src/core/session-host-launch-ledger.test.ts
+++ b/src/core/session-host-launch-ledger.test.ts
@@ -28,7 +28,7 @@ class FakePty {
   write(data: string): void {
     this.writes.push(data)
     this.onWrite?.(data)
-    if (this.echoWrites && data !== '\r' && data !== '\x15') this.emitData(data)
+    if (this.echoWrites && data !== '\r' && data !== '\x15' && data !== '\x1b') this.emitData(data)
   }
 
   emitData(data: string): void {

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -109,10 +109,9 @@ import {
 import {
   cleanEcho,
   deliverCommand,
-  KILL_LINE,
-  WINDOWS_KILL_LINE,
   type DeliveryIo
 } from '../terminal/command-delivery'
+import { terminalKillLine } from '../terminal/terminal-kill-line'
 import {
   RESUME_MISS_WINDOW_MS,
   detectsResumeMiss,
@@ -1565,10 +1564,14 @@ export function TerminalNode({
     !remoteSession &&
     (data.cwd as string | undefined) !== parentWtPath
   const getTerminalKillLine = (): string => {
-    const isWindows =
-      (corePlatformRef.current === 'win32' || (isWindowsPlatform() && session.source === 'local')) &&
-      !remoteSession
-    return isWindows ? WINDOWS_KILL_LINE : KILL_LINE
+    return terminalKillLine({
+      source: session.source,
+      browserRuntime: isBrowserRuntime(),
+      viewerWindows: isWindowsPlatform(),
+      corePlatform: corePlatformRef.current,
+      remoteSession,
+      shell: data.shell || useSettings.getState().settings.defaultShell || undefined
+    })
   }
   const status = useAgentStatus((s) => s.byId[id])
   /**

--- a/src/renderer/nodes/TerminalNode.tsx
+++ b/src/renderer/nodes/TerminalNode.tsx
@@ -106,7 +106,13 @@ import {
   validCellSize,
   type Vec2
 } from '../lib/glyphGridNode'
-import { cleanEcho, deliverCommand, KILL_LINE, type DeliveryIo } from '../terminal/command-delivery'
+import {
+  cleanEcho,
+  deliverCommand,
+  KILL_LINE,
+  WINDOWS_KILL_LINE,
+  type DeliveryIo
+} from '../terminal/command-delivery'
 import {
   RESUME_MISS_WINDOW_MS,
   detectsResumeMiss,
@@ -1558,6 +1564,12 @@ export function TerminalNode({
     !parentWtStale &&
     !remoteSession &&
     (data.cwd as string | undefined) !== parentWtPath
+  const getTerminalKillLine = (): string => {
+    const isWindows =
+      (corePlatformRef.current === 'win32' || (isWindowsPlatform() && session.source === 'local')) &&
+      !remoteSession
+    return isWindows ? WINDOWS_KILL_LINE : KILL_LINE
+  }
   const status = useAgentStatus((s) => s.byId[id])
   /**
    * Which Claude account this node is ACTUALLY on. `data.accountId` is what nodeterm launched
@@ -3325,7 +3337,8 @@ export function TerminalNode({
                   if (outcome === 'line-too-long') {
                     setCo(termKey, { launchTooLongBytes: lineBytes(cmd) })
                   }
-                }
+                },
+                { killLine: getTerminalKillLine() }
               )
             )
           })
@@ -3719,6 +3732,7 @@ export function TerminalNode({
           // An unusable session id leaves this undefined and performRestartResume refuses the
           // restart on its own `resumeCommand` gate — nothing is written either way.
           command,
+          killLine: getTerminalKillLine(),
           // Session-scoped (`api`, not the global preload), like readScrollback above: a relay
           // tab's pane lives on the host, and only its own api can see it.
           paneCommand: () => api.pty.paneCommand(id),
@@ -3860,12 +3874,14 @@ export function TerminalNode({
         // reason; the wake half owes the same. Deliberately HERE and not inside
         // `performResumePhase`: that function's output is pinned byte-for-byte by Task 8's tests,
         // and the restart path (which just cleared the line itself) must not clear it twice.
-        restartIo.write(KILL_LINE)
+        const killLine = getTerminalKillLine()
+        restartIo.write(killLine)
         return performResumePhase({
           agentId,
           sessionId: agentSessionId,
           io: restartIo,
           command,
+          killLine,
           isLive: restartTarget,
           onDelivery: (cancel) => {
             if (life.dead) cancel()

--- a/src/renderer/terminal/agent-restart.test.ts
+++ b/src/renderer/terminal/agent-restart.test.ts
@@ -683,6 +683,29 @@ describe('performResumePhase', () => {
     expect(written.join('')).toContain('claude --resume sid-1 --permission-mode plan')
   })
 
+  it('forwards custom killLine to deliverCommand on verification retry', async () => {
+    const written: string[] = []
+    const io = {
+      write(d: string) {
+        written.push(d)
+      },
+      onData() {
+        return () => {}
+      }
+    }
+    const p = performResumePhase({
+      agentId: 'claude',
+      sessionId: 'sid-1',
+      io,
+      killLine: '\x1b'
+    })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(written).toContain('\x1b')
+    expect(written).not.toContain('\x15')
+    await vi.advanceTimersByTimeAsync(10000)
+    await p
+  })
+
   it('keeps the bare command as the gate even when the caller overrides it', async () => {
     const { written, io } = fakeIo()
     expect(

--- a/src/renderer/terminal/agent-restart.ts
+++ b/src/renderer/terminal/agent-restart.ts
@@ -273,6 +273,7 @@ export async function performResumePhase(d: {
   command?: string
   /** Backstop for the resume delivery; see RESTART_DELIVERY_TIMEOUT_MS. */
   deliveryTimeoutMs?: number
+  killLine?: string
   /**
    * Handed `deliverCommand`'s cancel the moment a delivery starts — and only then. The delivery
    * outlives this promise (it runs on its own echo-verify timers), so its lifetime belongs to
@@ -319,7 +320,12 @@ export async function performResumePhase(d: {
       // Two statements on purpose: `d.onDelivery?.(deliverCommand(…))` short-circuits the ARGUMENT
       // too when no callback was passed — nothing would be delivered and this promise would never
       // settle.
-      const cancelDelivery = deliverCommand(d.io, cmd, settle)
+      const cancelDelivery = deliverCommand(
+        d.io,
+        cmd,
+        settle,
+        d.killLine !== undefined ? { killLine: d.killLine } : undefined
+      )
       started = true
       d.onDelivery?.(cancelDelivery)
     } catch (e) {
@@ -360,6 +366,7 @@ export async function performRestartResume(d: {
   pollMs?: number
   /** Backstop for the resume delivery; see RESTART_DELIVERY_TIMEOUT_MS. */
   deliveryTimeoutMs?: number
+  killLine?: string
   /** Handed `deliverCommand`'s cancel as the delivery starts; see `performResumePhase`. */
   onDelivery?: (cancel: () => void) => void
   /**
@@ -388,6 +395,7 @@ export async function performRestartResume(d: {
     io: d.io,
     command: d.command,
     deliveryTimeoutMs: d.deliveryTimeoutMs,
+    killLine: d.killLine,
     onDelivery: d.onDelivery,
     isLive: d.isLive
   })

--- a/src/renderer/terminal/agent-restart.ts
+++ b/src/renderer/terminal/agent-restart.ts
@@ -205,7 +205,10 @@ export async function performExitPhase(d: {
   // what command-delivery.ts already relies on for its rewrites. Each agent added to that table
   // inherits this assumption; only a device check retires it, per agent. If a TUI binds Ctrl-U to
   // something else this becomes one stray keystroke before the exit command — no worse than
-  // today's blind write. Belongs in the manual test matrix.
+  // CRITICAL LOAD-BEARING SPLIT: This line-clear writes into a pane owned by an AGENT TUI, not
+  // a shell. A lone Escape (\x1b) into a live agent is the user-interrupt gesture (cancels turns/thinking),
+  // whereas \x15 is the safe line-clear attempt. Keep \x15 here even on Windows; WINDOWS_KILL_LINE
+  // (\x1b) is strictly for shell panes (command delivery retry and hibernation wake).
   d.io.write(KILL_LINE)
   // opencode's TUI does not submit when text and CR arrive in the same input burst
   // (batched-input handling). Measured on 1.18.18-1.18.25, Linux, tmux, isolated socket:

--- a/src/renderer/terminal/command-delivery.test.ts
+++ b/src/renderer/terminal/command-delivery.test.ts
@@ -3,6 +3,7 @@ import {
   DELIVERY_ATTEMPTS,
   KILL_LINE,
   VERIFY_TIMEOUT_MS,
+  WINDOWS_KILL_LINE,
   cleanEcho,
   deliverCommand,
   echoedIntact
@@ -121,6 +122,25 @@ describe('deliverCommand', () => {
     // attempt 1..N writes, N-1 kill-lines between them, final bare Enter.
     expect(f.writes.filter((w) => w === CMD)).toHaveLength(DELIVERY_ATTEMPTS)
     expect(f.writes.filter((w) => w === '\x15')).toHaveLength(DELIVERY_ATTEMPTS - 1)
+    expect(f.writes[f.writes.length - 1]).toBe('\r')
+  })
+
+  it('uses custom killLine (WINDOWS_KILL_LINE) when provided in options', () => {
+    const f = fakeIo()
+    deliverCommand(f.io, CMD, undefined, { killLine: WINDOWS_KILL_LINE })
+    f.emit(CMD.slice(0, 30))
+    vi.advanceTimersByTime(VERIFY_TIMEOUT_MS)
+    expect(f.writes).toEqual([CMD, WINDOWS_KILL_LINE, CMD])
+    f.emit(CMD)
+    expect(f.writes).toEqual([CMD, WINDOWS_KILL_LINE, CMD, '\r'])
+  })
+
+  it('fails open with WINDOWS_KILL_LINE between retries when echo never arrives', () => {
+    const f = fakeIo()
+    deliverCommand(f.io, CMD, undefined, { killLine: WINDOWS_KILL_LINE })
+    for (let i = 0; i < DELIVERY_ATTEMPTS; i++) vi.advanceTimersByTime(VERIFY_TIMEOUT_MS)
+    expect(f.writes.filter((w) => w === CMD)).toHaveLength(DELIVERY_ATTEMPTS)
+    expect(f.writes.filter((w) => w === WINDOWS_KILL_LINE)).toHaveLength(DELIVERY_ATTEMPTS - 1)
     expect(f.writes[f.writes.length - 1]).toBe('\r')
   })
 
@@ -287,5 +307,18 @@ describe('a launch line longer than the tty can carry (issue #706)', () => {
     f.emit(LONG)
     expect(outcome).toBe('submitted')
     expect(f.writes).toContain('\r')
+  })
+
+  it('clears line with WINDOWS_KILL_LINE on line-too-long when configured', () => {
+    const f = fakeIo()
+    let outcome: string | undefined
+    deliverCommand(f.io, LONG, (o) => (outcome = o), { killLine: WINDOWS_KILL_LINE })
+    for (let i = 0; i < DELIVERY_ATTEMPTS; i++) {
+      f.emit(truncatedEcho(LONG))
+      vi.advanceTimersByTime(VERIFY_TIMEOUT_MS)
+    }
+    expect(outcome).toBe('line-too-long')
+    expect(f.writes).not.toContain('\r')
+    expect(f.writes[f.writes.length - 1]).toBe(WINDOWS_KILL_LINE)
   })
 })

--- a/src/renderer/terminal/command-delivery.test.ts
+++ b/src/renderer/terminal/command-delivery.test.ts
@@ -58,6 +58,11 @@ describe('cleanEcho', () => {
     const noisy = '\x1b[1;32mprompt\x1b[0m \x1b]0;title\x07ec' + '\r\n' + 'ho text\x1b[K'
     expect(cleanEcho(noisy)).toBe('prompt echo text')
   })
+
+  it('strips PSReadLine CSI erase sequences (e.g. \\x1b[9X)', () => {
+    const psreadlineErase = '\x1b[18X' + CMD
+    expect(cleanEcho(psreadlineErase)).toBe(CMD)
+  })
 })
 
 describe('echoedIntact', () => {

--- a/src/renderer/terminal/command-delivery.ts
+++ b/src/renderer/terminal/command-delivery.ts
@@ -18,9 +18,13 @@ import { fitsLaunchLine } from '@shared/canonical-line'
 
 export const VERIFY_TIMEOUT_MS = 2000
 export const DELIVERY_ATTEMPTS = 3
-/** Ctrl-U — clear the pending input line before a rewrite. Exported because the in-place restart
- *  choreography clears the line the same way before typing its exit command (agent-restart.ts). */
 export const KILL_LINE = '\x15'
+/** Escape — clear the pending input line in Windows shells (PowerShell, cmd.exe). */
+export const WINDOWS_KILL_LINE = '\x1b'
+
+export interface DeliverCommandOptions {
+  killLine?: string
+}
 
 // CSI (\x1b[...X), OSC (\x1b]...BEL|ST) and single-char ESC sequences.
 // eslint-disable-next-line no-control-regex
@@ -94,8 +98,10 @@ export interface DeliveryIo {
 export function deliverCommand(
   io: DeliveryIo,
   cmd: string,
-  onSettled?: (outcome: DeliveryOutcome) => void
+  onSettled?: (outcome: DeliveryOutcome) => void,
+  options?: DeliverCommandOptions
 ): () => void {
+  const killLine = options?.killLine ?? KILL_LINE
   let done = false
   let attempt = 0
   let echoed = ''
@@ -156,14 +162,14 @@ export function deliverCommand(
         // tail while the pane was in canonical mode, so Enter would submit a command we KNOW is
         // cut in half. Kill the pending line and report instead. See @shared/canonical-line.
         if (!fitsLaunchLine(cmd)) {
-          write(KILL_LINE)
+          write(killLine)
           finish('line-too-long')
           return
         }
         submit() // fail-open: unverified submit beats a never-launched agent
         return
       }
-      if (!write(KILL_LINE)) return // transport gone — the delivery is over, not stuck
+      if (!write(killLine)) return // transport gone — the delivery is over, not stuck
       tryOnce()
     }, VERIFY_TIMEOUT_MS)
     write(cmd, attempt === 1)

--- a/src/renderer/terminal/command-delivery.ts
+++ b/src/renderer/terminal/command-delivery.ts
@@ -15,12 +15,11 @@
 // @shared/canonical-line.
 
 import { fitsLaunchLine } from '@shared/canonical-line'
+import { KILL_LINE, WINDOWS_KILL_LINE } from '@shared/shell-kill-line'
 
 export const VERIFY_TIMEOUT_MS = 2000
 export const DELIVERY_ATTEMPTS = 3
-export const KILL_LINE = '\x15'
-/** Escape — clear the pending input line in Windows shells (PowerShell, cmd.exe). */
-export const WINDOWS_KILL_LINE = '\x1b'
+export { KILL_LINE, WINDOWS_KILL_LINE }
 
 export interface DeliverCommandOptions {
   killLine?: string

--- a/src/renderer/terminal/terminal-kill-line.test.ts
+++ b/src/renderer/terminal/terminal-kill-line.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import { KILL_LINE, WINDOWS_KILL_LINE } from '@shared/shell-kill-line'
+import { terminalKillLine, type TerminalKillLineFacts } from './terminal-kill-line'
+
+const facts = (overrides: Partial<TerminalKillLineFacts> = {}): TerminalKillLineFacts => ({
+  source: 'local',
+  browserRuntime: false,
+  viewerWindows: false,
+  corePlatform: null,
+  remoteSession: false,
+  shell: undefined,
+  ...overrides
+})
+
+describe('terminalKillLine', () => {
+  it('uses the local desktop viewer only where viewer and host are the same machine', () => {
+    expect(terminalKillLine(facts({ viewerWindows: true }))).toBe(WINDOWS_KILL_LINE)
+    expect(terminalKillLine(facts({ viewerWindows: false }))).toBe(KILL_LINE)
+  })
+
+  it('uses the Server Edition host rather than the browser OS', () => {
+    // Windows browser pointed at a Linux server must NOT write Escape into bash
+    expect(
+      terminalKillLine(
+        facts({ source: 'local', browserRuntime: true, viewerWindows: true, corePlatform: 'linux' })
+      )
+    ).toBe(KILL_LINE)
+    // Non-Windows browser pointed at a Windows Server Edition writes Escape
+    expect(
+      terminalKillLine(
+        facts({ source: 'local', browserRuntime: true, viewerWindows: false, corePlatform: 'win32' })
+      )
+    ).toBe(WINDOWS_KILL_LINE)
+  })
+
+  it('uses the relay host rather than the relay guest OS', () => {
+    expect(
+      terminalKillLine(facts({ source: 'relay', viewerWindows: true, corePlatform: 'darwin' }))
+    ).toBe(KILL_LINE)
+    expect(
+      terminalKillLine(facts({ source: 'relay', viewerWindows: false, corePlatform: 'win32' }))
+    ).toBe(WINDOWS_KILL_LINE)
+  })
+
+  it('treats a remote session as POSIX even when desktop core is Windows', () => {
+    expect(
+      terminalKillLine(facts({ viewerWindows: true, corePlatform: 'win32', remoteSession: true }))
+    ).toBe(KILL_LINE)
+  })
+
+  it('fails closed to KILL_LINE (\\x15) when core platform read has not completed on server or relay', () => {
+    expect(
+      terminalKillLine(facts({ source: 'local', browserRuntime: true, viewerWindows: true }))
+    ).toBe(KILL_LINE)
+    expect(terminalKillLine(facts({ source: 'server', viewerWindows: true }))).toBe(KILL_LINE)
+    expect(terminalKillLine(facts({ source: 'relay', viewerWindows: false }))).toBe(KILL_LINE)
+  })
+
+  it('respects shell executable on Windows platform (e.g. git-bash uses \\x15)', () => {
+    expect(
+      terminalKillLine(
+        facts({
+          viewerWindows: true,
+          corePlatform: 'win32',
+          shell: 'C:\\Program Files\\Git\\bin\\bash.exe'
+        })
+      )
+    ).toBe(KILL_LINE)
+    expect(
+      terminalKillLine(
+        facts({
+          viewerWindows: true,
+          corePlatform: 'win32',
+          shell: 'bash'
+        })
+      )
+    ).toBe(KILL_LINE)
+    expect(
+      terminalKillLine(
+        facts({
+          viewerWindows: true,
+          corePlatform: 'win32',
+          shell: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+        })
+      )
+    ).toBe(WINDOWS_KILL_LINE)
+    expect(
+      terminalKillLine(
+        facts({
+          viewerWindows: true,
+          corePlatform: 'win32',
+          shell: 'pwsh.exe'
+        })
+      )
+    ).toBe(WINDOWS_KILL_LINE)
+  })
+})

--- a/src/renderer/terminal/terminal-kill-line.ts
+++ b/src/renderer/terminal/terminal-kill-line.ts
@@ -1,0 +1,44 @@
+import type { SessionSource } from '../session/session'
+import {
+  KILL_LINE,
+  shellKillLineSequence
+} from '@shared/shell-kill-line'
+
+export interface TerminalKillLineFacts {
+  /** Which core owns the active tab's filesystem and process lifecycle. */
+  source: SessionSource
+  /** True for the Server Edition's websocket-backed browser tab (currently source `local`). */
+  browserRuntime: boolean
+  /** The browser/window's OS. It is authoritative only for the local desktop core. */
+  viewerWindows: boolean
+  /** `process.platform` reported by the core; null means it was not observed yet. */
+  corePlatform: string | null
+  /** True if this terminal targets an SSH project or remote session node. */
+  remoteSession: boolean
+  /** Optional shell configured on the node or resolved default. */
+  shell?: string | null
+}
+
+/**
+ * Choose the line-clear sequence for a terminal node (Ctrl-U vs Escape).
+ *
+ * A browser's OS is not evidence about a Server Edition or relay host: a Windows browser
+ * pointed at a Linux Server Edition must not write Escape into bash/readline (where Escape is
+ * the meta-prefix). When the core platform has not been observed yet, fail closed to `\x15`.
+ * Remote sessions (SSH project or standalone SSH) target POSIX environments and use `\x15`.
+ */
+export function terminalKillLine(facts: TerminalKillLineFacts): string {
+  if (facts.remoteSession) return KILL_LINE
+
+  const platform =
+    facts.corePlatform ??
+    (facts.source === 'local' && !facts.browserRuntime
+      ? facts.viewerWindows
+        ? 'win32'
+        : 'posix'
+      : null)
+
+  if (!platform) return KILL_LINE
+
+  return shellKillLineSequence(undefined, facts.shell, platform)
+}

--- a/src/session-host/session.test.ts
+++ b/src/session-host/session.test.ts
@@ -3,8 +3,11 @@ import type { Socket } from 'net'
 import type { IPty } from 'node-pty'
 import {
   HostSession,
+  KILL_LINE,
   SESSION_EMULATOR_OUTPUT_HIGH_WATER_BYTES,
-  SESSION_EMULATOR_OUTPUT_LOW_WATER_BYTES
+  SESSION_EMULATOR_OUTPUT_LOW_WATER_BYTES,
+  WINDOWS_KILL_LINE,
+  shellKillLineSequence
 } from './session'
 import type { TerminalEmulator } from './terminal-emulator'
 import type { SessionHostSpawnOptions } from './protocol'
@@ -611,5 +614,96 @@ describe('HostSession launch echo verification', () => {
 
     // submit() is synchronous inside the data handler, so its absence is observable now.
     expect(proc.written).not.toContain('\r')
+  })
+
+  it('clears line with \\x1b on Windows PowerShell during retry and refusal', async () => {
+    vi.useFakeTimers()
+    try {
+      const proc = deliveryProc()
+      const winSpawn: SessionHostSpawnOptions = {
+        ...SPAWN,
+        shell: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+        launchDialect: 'windows-powershell'
+      }
+      const session = new HostSession('echo-win-retry', winSpawn, 100, {
+        proc: proc.value,
+        term: inertTerm()
+      })
+      const delivered = deliver(session, COMMAND)
+      const failure = expect(delivered).rejects.toThrow(
+        'session-host could not verify launch command delivery'
+      )
+      await vi.advanceTimersByTimeAsync(2_000 * 3)
+      await failure
+      expect(proc.written).toEqual([
+        COMMAND,
+        WINDOWS_KILL_LINE,
+        COMMAND,
+        WINDOWS_KILL_LINE,
+        COMMAND,
+        WINDOWS_KILL_LINE
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears line with \\x15 on POSIX shells during retry and refusal', async () => {
+    vi.useFakeTimers()
+    try {
+      const proc = deliveryProc()
+      const posixSpawn: SessionHostSpawnOptions = {
+        ...SPAWN,
+        shell: '/bin/zsh',
+        launchDialect: 'posix'
+      }
+      const session = new HostSession('echo-posix-retry', posixSpawn, 100, {
+        proc: proc.value,
+        term: inertTerm()
+      })
+      const delivered = deliver(session, COMMAND)
+      const failure = expect(delivered).rejects.toThrow(
+        'session-host could not verify launch command delivery'
+      )
+      await vi.advanceTimersByTimeAsync(2_000 * 3)
+      await failure
+      expect(proc.written).toEqual([
+        COMMAND,
+        KILL_LINE,
+        COMMAND,
+        KILL_LINE,
+        COMMAND,
+        KILL_LINE
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('shellKillLineSequence', () => {
+  it('returns \\x1b for Windows PowerShell, pwsh, and cmd dialects', () => {
+    expect(shellKillLineSequence('windows-powershell')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence('pwsh')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence('cmd')).toBe(WINDOWS_KILL_LINE)
+  })
+
+  it('returns \\x15 for posix dialect', () => {
+    expect(shellKillLineSequence('posix')).toBe(KILL_LINE)
+  })
+
+  it('infers sequence from shell executable name when dialect is omitted', () => {
+    expect(shellKillLineSequence(undefined, 'powershell.exe')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'powershell')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'pwsh.exe')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'cmd.exe')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'bash.exe')).toBe(KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'zsh')).toBe(KILL_LINE)
+  })
+
+  it('falls back based on host platform when dialect and shell executable are unknown', () => {
+    expect(shellKillLineSequence(undefined, undefined, 'win32')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, undefined, 'darwin')).toBe(KILL_LINE)
+    expect(shellKillLineSequence(undefined, undefined, 'linux')).toBe(KILL_LINE)
   })
 })

--- a/src/session-host/session.ts
+++ b/src/session-host/session.ts
@@ -16,36 +16,13 @@ const LAUNCH_READINESS_POLL_MS = 100
 const VERIFY_TIMEOUT_MS = 2_000
 const ECHO_EDGE_CHARS = 24
 const DELIVERY_ATTEMPTS = 3
-export const KILL_LINE = '\x15'
-export const WINDOWS_KILL_LINE = '\x1b'
+import {
+  KILL_LINE,
+  WINDOWS_KILL_LINE,
+  shellKillLineSequence
+} from '../shared/shell-kill-line'
 
-export function shellKillLineSequence(
-  dialect?: SessionHostShellDialect,
-  shellExecutableName?: string,
-  platform: NodeJS.Platform = process.platform
-): string {
-  if (dialect === 'pwsh' || dialect === 'windows-powershell' || dialect === 'cmd') {
-    return WINDOWS_KILL_LINE
-  }
-  if (dialect === 'posix') {
-    return KILL_LINE
-  }
-  const exe = (shellExecutableName ?? '').toLowerCase()
-  if (
-    exe === 'powershell' ||
-    exe === 'powershell.exe' ||
-    exe === 'pwsh' ||
-    exe === 'pwsh.exe' ||
-    exe === 'cmd' ||
-    exe === 'cmd.exe'
-  ) {
-    return WINDOWS_KILL_LINE
-  }
-  if (exe === 'bash' || exe === 'bash.exe' || exe === 'zsh' || exe === 'sh' || exe === 'fish') {
-    return KILL_LINE
-  }
-  return platform === 'win32' ? WINDOWS_KILL_LINE : KILL_LINE
-}
+export { KILL_LINE, WINDOWS_KILL_LINE, shellKillLineSequence }
 
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 // eslint-disable-next-line no-control-regex

--- a/src/session-host/session.ts
+++ b/src/session-host/session.ts
@@ -16,7 +16,37 @@ const LAUNCH_READINESS_POLL_MS = 100
 const VERIFY_TIMEOUT_MS = 2_000
 const ECHO_EDGE_CHARS = 24
 const DELIVERY_ATTEMPTS = 3
-const KILL_LINE = '\x15'
+export const KILL_LINE = '\x15'
+export const WINDOWS_KILL_LINE = '\x1b'
+
+export function shellKillLineSequence(
+  dialect?: SessionHostShellDialect,
+  shellExecutableName?: string,
+  platform: NodeJS.Platform = process.platform
+): string {
+  if (dialect === 'pwsh' || dialect === 'windows-powershell' || dialect === 'cmd') {
+    return WINDOWS_KILL_LINE
+  }
+  if (dialect === 'posix') {
+    return KILL_LINE
+  }
+  const exe = (shellExecutableName ?? '').toLowerCase()
+  if (
+    exe === 'powershell' ||
+    exe === 'powershell.exe' ||
+    exe === 'pwsh' ||
+    exe === 'pwsh.exe' ||
+    exe === 'cmd' ||
+    exe === 'cmd.exe'
+  ) {
+    return WINDOWS_KILL_LINE
+  }
+  if (exe === 'bash' || exe === 'bash.exe' || exe === 'zsh' || exe === 'sh' || exe === 'fish') {
+    return KILL_LINE
+  }
+  return platform === 'win32' ? WINDOWS_KILL_LINE : KILL_LINE
+}
+
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 // eslint-disable-next-line no-control-regex
 const ESC_SEQ = /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[@-_]/g
@@ -167,6 +197,10 @@ export class HostSession {
 
   get suppressingPrivateLaunchOutput(): boolean {
     return this.privateLaunchOutput
+  }
+
+  get killLineSequence(): string {
+    return shellKillLineSequence(this.launchDialect, this.shellExecutableName)
   }
 
   /** True once a successful explicit kill has claimed the name but before node-pty proves process
@@ -576,11 +610,11 @@ export class HostSession {
           if (attempt >= DELIVERY_ATTEMPTS) {
             // Never submit an unverified/mangled command. Clear it so the terminal remains
             // recoverable, cache the fixed failure, and let explicit user action decide next.
-            write(KILL_LINE)
+            write(this.killLineSequence)
             finish(new Error('session-host could not verify launch command delivery'))
             return
           }
-          if (!write(KILL_LINE)) return
+          if (!write(this.killLineSequence)) return
           tryOnce()
         }, VERIFY_TIMEOUT_MS)
         timer.unref?.()

--- a/src/shared/shell-kill-line.test.ts
+++ b/src/shared/shell-kill-line.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  KILL_LINE,
+  WINDOWS_KILL_LINE,
+  shellKillLineSequence
+} from './shell-kill-line'
+
+describe('shellKillLineSequence', () => {
+  it('returns \\x1b for Windows PowerShell, pwsh, and cmd dialects', () => {
+    expect(shellKillLineSequence('windows-powershell')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence('pwsh')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence('cmd')).toBe(WINDOWS_KILL_LINE)
+  })
+
+  it('returns \\x15 for posix dialect even on Windows platform', () => {
+    expect(shellKillLineSequence('posix', undefined, 'win32')).toBe(KILL_LINE)
+    expect(shellKillLineSequence('posix', 'bash.exe', 'win32')).toBe(KILL_LINE)
+  })
+
+  it('infers sequence from bare shell executable name when dialect is omitted', () => {
+    expect(shellKillLineSequence(undefined, 'powershell.exe')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'powershell')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'pwsh.exe')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'pwsh')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'cmd.exe')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'cmd')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'bash.exe')).toBe(KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'bash')).toBe(KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'zsh')).toBe(KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'sh')).toBe(KILL_LINE)
+    expect(shellKillLineSequence(undefined, 'fish')).toBe(KILL_LINE)
+  })
+
+  it('infers sequence from full executable path with forward and backward slashes', () => {
+    expect(shellKillLineSequence(undefined, 'C:\\Program Files\\PowerShell\\7\\pwsh.exe')).toBe(
+      WINDOWS_KILL_LINE
+    )
+    expect(shellKillLineSequence(undefined, 'C:\\Windows\\System32\\cmd.exe')).toBe(
+      WINDOWS_KILL_LINE
+    )
+    expect(shellKillLineSequence(undefined, 'C:\\Program Files\\Git\\bin\\bash.exe')).toBe(
+      KILL_LINE
+    )
+    expect(shellKillLineSequence(undefined, '/usr/local/bin/zsh')).toBe(KILL_LINE)
+    expect(shellKillLineSequence(undefined, '/bin/bash')).toBe(KILL_LINE)
+  })
+
+  it('lets dialect override executable name', () => {
+    expect(shellKillLineSequence('posix', 'powershell.exe', 'win32')).toBe(KILL_LINE)
+    expect(shellKillLineSequence('pwsh', 'bash.exe', 'linux')).toBe(WINDOWS_KILL_LINE)
+  })
+
+  it('falls back based on host platform when dialect and shell executable are unknown', () => {
+    expect(shellKillLineSequence(undefined, undefined, 'win32')).toBe(WINDOWS_KILL_LINE)
+    expect(shellKillLineSequence(undefined, undefined, 'darwin')).toBe(KILL_LINE)
+    expect(shellKillLineSequence(undefined, undefined, 'linux')).toBe(KILL_LINE)
+    expect(shellKillLineSequence(undefined, undefined, null)).toBe(KILL_LINE)
+  })
+})

--- a/src/shared/shell-kill-line.ts
+++ b/src/shared/shell-kill-line.ts
@@ -1,0 +1,63 @@
+/**
+ * LINE-CLEAR SEQUENCES FOR SHELLS VS AGENT TUIS.
+ *
+ * Line clearing before command delivery (command-delivery.ts) or after delivery refusal
+ * targets an interactive SHELL (PowerShell, cmd.exe, bash, zsh).
+ *
+ *  - POSIX shells (bash, zsh, dash) bind `\x15` (Ctrl-U) to kill the pending line in readline/ZLE.
+ *  - Windows shells (PowerShell, cmd.exe) bind `\x1b` (Escape) to clear the line. In PowerShell,
+ *    `\x15` is not bound by default; typing `\x15` leaves junk on the prompt and mangles retried commands.
+ *
+ * CRITICAL LOAD-BEARING SPLIT:
+ * `WINDOWS_KILL_LINE` (`\x1b`) is ONLY for shells. A live AGENT TUI (Claude Code, Codex, etc.) treats
+ * a lone `\x1b` as the INTERRUPT gesture (cancelling turns / thinking), not a line-clear gesture!
+ * Therefore, agent exit phases (`performExitPhase` in `agent-restart.ts`) write into panes owned by
+ * agent TUIs and MUST continue to write `KILL_LINE` (`\x15`), NEVER `WINDOWS_KILL_LINE` (`\x1b`).
+ */
+
+/** Ctrl-U — line-kill sequence in POSIX shells (readline/ZLE) and default agent TUI line clear. */
+export const KILL_LINE = '\x15'
+
+/** Escape — line-clear sequence in Windows native shells (PowerShell, cmd.exe). */
+export const WINDOWS_KILL_LINE = '\x1b'
+
+export type ShellKillLineDialect = 'posix' | 'pwsh' | 'windows-powershell' | 'cmd'
+
+/**
+ * Determine the appropriate line-clear sequence for a shell given its dialect, executable name,
+ * and host platform.
+ *
+ * If a dialect is specified ('pwsh', 'windows-powershell', 'cmd'), it takes precedence.
+ * If dialect is 'posix' (including git-bash / MSYS on Windows), returns `\x15`.
+ * If dialect is omitted, the executable name is checked (e.g. bash.exe vs pwsh.exe), stripping directory paths.
+ * Finally, falls back to the host platform ('win32' -> Escape, others -> Ctrl-U).
+ * Unobserved or unknown platforms fail closed to `KILL_LINE` ('\x15').
+ */
+export function shellKillLineSequence(
+  dialect?: ShellKillLineDialect | string | null,
+  shellExecutableName?: string | null,
+  platform: NodeJS.Platform | string | null = typeof process !== 'undefined' ? process.platform : null
+): string {
+  if (dialect === 'pwsh' || dialect === 'windows-powershell' || dialect === 'cmd') {
+    return WINDOWS_KILL_LINE
+  }
+  if (dialect === 'posix') {
+    return KILL_LINE
+  }
+  const raw = shellExecutableName ?? ''
+  const exe = raw.replace(/^.*[/\\]/, '').toLowerCase()
+  if (
+    exe === 'powershell' ||
+    exe === 'powershell.exe' ||
+    exe === 'pwsh' ||
+    exe === 'pwsh.exe' ||
+    exe === 'cmd' ||
+    exe === 'cmd.exe'
+  ) {
+    return WINDOWS_KILL_LINE
+  }
+  if (exe === 'bash' || exe === 'bash.exe' || exe === 'zsh' || exe === 'sh' || exe === 'fish') {
+    return KILL_LINE
+  }
+  return platform === 'win32' ? WINDOWS_KILL_LINE : KILL_LINE
+}


### PR DESCRIPTION
Closes #710.

## Problem

`KILL_LINE` was hardcoded to `'\x15'` (`Ctrl+U`) in both `src/session-host/session.ts` and `src/renderer/terminal/command-delivery.ts`.

On POSIX shells (`bash`, `zsh`), `\x15` is `unix-line-discard`. On Windows shells (PowerShell with PSReadLine and `cmd.exe`), `\x15` is not bound to line-kill; it is inserted into the prompt buffer as literal text (`^U`).

When delivery verification timed out waiting for echo confirmation on Windows, retries repeatedly typed into the un-cleared buffer. Retries concatenated into corrupted inputs (e.g. `claude^Uclaude^Uclaude` running as `claudeclaudeclaude : The term 'claudeclaudeclaude' is not recognized`).

## Solution

On Windows shells, the native sequence that clears an unsubmitted command line is `\x1b` (`Escape`):
- In PowerShell with PSReadLine (default on Windows), `Escape` is bound to `RevertLine` (discards edits on the current prompt).
- In `cmd.exe`, `Escape` clears the command line.

### Changes

1. **Session Host** (`src/session-host/session.ts`):
   - Exported `WINDOWS_KILL_LINE = '\x1b'` alongside `KILL_LINE = '\x15'`.
   - Added `shellKillLineSequence(dialect?, shellExecutableName?, platform?)` to select `\x1b` for PowerShell, pwsh, cmd, and Windows hosts, while keeping `\x15` for POSIX shells (`bash`, `zsh`, `posix`).
   - Added `killLineSequence` getter to `HostSession` and used it in `deliverVerifiedCommand`.
2. **Renderer Command Delivery** (`src/renderer/terminal/command-delivery.ts`):
   - Exported `WINDOWS_KILL_LINE = '\x1b'`.
   - Added optional `DeliverCommandOptions { killLine?: string }` to `deliverCommand(io, cmd, onSettled?, options?)`.
   - Used `options?.killLine ?? KILL_LINE` in retry and cleanup writes.
3. **Agent Restart / Wake** (`src/renderer/terminal/agent-restart.ts` & `src/renderer/nodes/TerminalNode.tsx`):
   - Added `getTerminalKillLine()` in `TerminalNode.tsx` to pass `WINDOWS_KILL_LINE` for local Windows sessions (`(corePlatformRef.current === 'win32' || (isWindowsPlatform() && session.source === 'local')) && !remoteSession`), keeping `KILL_LINE` for remote SSH or POSIX sessions.
   - Forwarded `killLine` through `performRestartResume` and `performResumePhase`.
4. **Tests**:
   - `src/session-host/session.test.ts`: added unit tests for `shellKillLineSequence` across dialects, executables, and platforms; verified `\x1b` retry output on PowerShell sessions vs `\x15` on POSIX.
   - `src/renderer/terminal/command-delivery.test.ts`: tested custom `killLine` on retry, retry exhaustion, and `line-too-long` refusal.
   - `src/renderer/terminal/agent-restart.test.ts`: verified forwarding `killLine` to `deliverCommand` on verification retry.
   - `src/core/session-host-launch-ledger.test.ts`: updated `FakePty.write` to ignore `\x1b` alongside `\x15` and `\r`.

## Verification

- **Live reproduction on Windows (`powershell.exe` with `node-pty`)**:
  - `\x15`: PowerShell echoed `first_cmd^Usecond_cmd` and failed with `The term 'first_cmdsecond_cmd' is not recognized`.
  - `\x1b`: PowerShell emitted VT erase sequence (`\u001b[9X`), cleanly discarded `first_cmd`, and executed `second_cmd` alone.
- `npm run typecheck`: clean across both `tsconfig.node.json` and `tsconfig.web.json`.
- `npm run host:build`: built session host bundle clean.
- `npm run build`: production bundle built clean.
- `npm test -- src/session-host/ src/renderer/terminal/command-delivery.test.ts src/renderer/terminal/agent-restart.test.ts src/core/session-host-launch-ledger.test.ts`: 16 files, 209 passed.
- Windows CI test suite (`ci.yml:quality-windows`): 28 files, 497 passed.
